### PR TITLE
fix: Update to 1.1.7, and skip pinned tabs when auto/manually grouping

### DIFF
--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Auto Tab Groups",
   "author": "Nitzan Papini",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Automatically groups tabs by domain.",
   "permissions": ["tabs", "storage", "tabGroups"],
   "sidebar_action": {

--- a/extension/src/services/TabGroupService.js
+++ b/extension/src/services/TabGroupService.js
@@ -130,6 +130,12 @@ class TabGroupService {
 
       // Group tabs by domain
       for (const tab of tabs) {
+        // Skip pinned tabs
+        if (tab.pinned) {
+          console.log(`[groupTabsByDomain] Skipping pinned tab ${tab.id}`);
+          continue;
+        }
+
         if (!tab.url) continue;
         const domain = extractDomain(
           tab.url,
@@ -220,6 +226,13 @@ class TabGroupService {
     try {
       // 1. Get tab info and extract domain
       const tab = await browser.tabs.get(tabId);
+
+      // Skip pinned tabs
+      if (tab.pinned) {
+        console.log(`[moveTabToGroup] Skipping pinned tab ${tabId}`);
+        return;
+      }
+
       if (!tab.url) return;
 
       const domain = extractDomain(


### PR DESCRIPTION
This pull request includes updates to the `Auto Tab Groups` browser extension to improve functionality and user experience. The most significant changes involve skipping pinned tabs during tab grouping operations and updating the extension version to reflect these enhancements.

### Functional improvements:

* [`extension/src/services/TabGroupService.js`](diffhunk://#diff-14d09c43b45dcd43b6805370449a6086690fa0d16fc3a7fcc8334317a385f0cdR133-R138): Updated the `groupTabsByDomain` method to skip pinned tabs, including a log message for skipped tabs.
* [`extension/src/services/TabGroupService.js`](diffhunk://#diff-14d09c43b45dcd43b6805370449a6086690fa0d16fc3a7fcc8334317a385f0cdR229-R235): Updated the `moveTabToGroup` method to skip pinned tabs, with a log message for skipped tabs as well.

### Version update:

* [`extension/src/manifest.json`](diffhunk://#diff-96a3f3e72a39a717822c7f8db092a756c68fcff056665b458bb0d4b3b6004611L5-R5): Incremented the extension version from `1.1.6` to `1.1.7` to reflect the new functionality.