### PR TITLE
Redesign toggle bar for grouping options

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-tab-groups",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-tab-groups",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@playwright/test": "^1.53.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -130,19 +130,19 @@ browserAPI.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           result = { enabled: tabGroupState.autoGroupingEnabled }
           break
 
-        case "getGroupBySubDomain":
-          result = { enabled: tabGroupState.groupBySubDomainEnabled }
+        case "getGroupByMode":
+          result = { mode: tabGroupState.groupByMode }
           break
 
-        case "toggleGroupBySubDomain":
-          tabGroupState.groupBySubDomainEnabled = msg.enabled
+        case "setGroupByMode":
+          tabGroupState.groupByMode = msg.mode
           await storageManager.saveState()
 
           if (tabGroupState.autoGroupingEnabled) {
             await tabGroupService.ungroupAllTabs()
             await tabGroupService.groupTabsWithRules()
           }
-          result = { enabled: tabGroupState.groupBySubDomainEnabled }
+          result = { mode: tabGroupState.groupByMode }
           break
 
         // Custom Rules Management

--- a/extension/src/config/StorageManager.js
+++ b/extension/src/config/StorageManager.js
@@ -10,7 +10,7 @@ const browserAPI = globalThis.browserAPI || (typeof browser !== "undefined" ? br
 
 export const DEFAULT_STATE = {
   autoGroupingEnabled: true,
-  groupBySubDomainEnabled: false,
+  groupByMode: "domain", // "rules", "domain", or "subdomain"
   customRules: {},
   ruleMatchingMode: "exact",
   groupColorMapping: {}

--- a/extension/src/manifest.chrome.json
+++ b/extension/src/manifest.chrome.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Auto Tab Groups",
   "author": "Nitzan Papini",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Automatically groups tabs by domain.",
   "permissions": ["tabs", "storage", "tabGroups"],
   "side_panel": {

--- a/extension/src/manifest.firefox.json
+++ b/extension/src/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Auto Tab Groups",
   "author": "Nitzan Papini",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Automatically groups tabs by domain.",
   "permissions": ["tabs", "storage", "tabGroups"],
   "browser_specific_settings": {

--- a/extension/src/public/popup.css
+++ b/extension/src/public/popup.css
@@ -228,6 +228,7 @@ footer {
   align-items: center;
   width: 100%;
   margin-top: 8px;
+  gap: 10px;
 }
 
 .toggle-container span {
@@ -239,6 +240,7 @@ footer {
 /* New Three-State Toggle Bar Styles */
 .group-by-toggle-bar {
   display: flex;
+  justify-content: space-between;
   background-color: #f3f4f6;
   border-radius: 8px;
   padding: 2px;
@@ -247,7 +249,7 @@ footer {
 }
 
 .toggle-option {
-  padding: 6px 12px;
+  padding: 6px 8px;
   font-size: 12px;
   font-weight: 500;
   color: #6b7280;
@@ -258,8 +260,6 @@ footer {
   transition: all 0.2s ease;
   white-space: nowrap;
   min-width: 0;
-  flex: 1;
-  text-align: center;
 }
 
 .toggle-option:hover {

--- a/extension/src/public/popup.css
+++ b/extension/src/public/popup.css
@@ -236,6 +236,53 @@ footer {
   font-weight: 600;
 }
 
+/* New Three-State Toggle Bar Styles */
+.group-by-toggle-bar {
+  display: flex;
+  background-color: #f3f4f6;
+  border-radius: 8px;
+  padding: 2px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.toggle-option {
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: #6b7280;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+  text-align: center;
+}
+
+.toggle-option:hover {
+  color: #374151;
+  background-color: #e5e7eb;
+}
+
+.toggle-option.active {
+  color: white;
+  background-color: var(--primary-color);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.toggle-option.active:hover {
+  background-color: var(--primary-color-dark);
+}
+
+.toggle-option:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+}
+
+/* Legacy switch styles - keeping for other toggles */
 .switch {
   position: relative;
   display: inline-block;

--- a/extension/src/public/popup.html
+++ b/extension/src/public/popup.html
@@ -38,8 +38,8 @@
             <span>🔍 Group by</span>
             <div class="group-by-toggle-bar">
               <button class="toggle-option" data-value="rules-only">Rules only</button>
-              <button class="toggle-option active" data-value="domain">Domain</button>
-              <button class="toggle-option" data-value="subdomain">Sub-domain</button>
+              <button class="toggle-option active" data-value="domain">Rules & Domain</button>
+              <button class="toggle-option" data-value="subdomain">Rules & Sub-domain</button>
             </div>
           </div>
         </div>

--- a/extension/src/public/popup.html
+++ b/extension/src/public/popup.html
@@ -35,11 +35,12 @@
             </label>
           </div>
           <div class="toggle-container">
-            <span>🔍 Group by domain/sub-domain</span>
-            <label class="switch">
-              <input type="checkbox" id="groupBySubDomain" checked />
-              <span class="slider round"></span>
-            </label>
+            <span>🔍 Group by</span>
+            <div class="group-by-toggle-bar">
+              <button class="toggle-option" data-value="rules">Rules only</button>
+              <button class="toggle-option active" data-value="domain">Domain</button>
+              <button class="toggle-option" data-value="subdomain">Sub-domain</button>
+            </div>
           </div>
         </div>
 

--- a/extension/src/public/popup.html
+++ b/extension/src/public/popup.html
@@ -37,7 +37,7 @@
           <div class="toggle-container">
             <span>🔍 Group by</span>
             <div class="group-by-toggle-bar">
-              <button class="toggle-option" data-value="rules">Rules only</button>
+              <button class="toggle-option" data-value="rules-only">Rules only</button>
               <button class="toggle-option active" data-value="domain">Domain</button>
               <button class="toggle-option" data-value="subdomain">Sub-domain</button>
             </div>

--- a/extension/src/public/popup.js
+++ b/extension/src/public/popup.js
@@ -5,7 +5,7 @@ const generateNewColorsButton = document.getElementById("generateNewColors")
 const collapseAllButton = document.getElementById("collapseAllButton")
 const expandAllButton = document.getElementById("expandAllButton")
 const autoGroupToggle = document.getElementById("autoGroupToggle")
-const groupBySubDomainToggle = document.getElementById("groupBySubDomain")
+const groupByToggleOptions = document.querySelectorAll(".toggle-option")
 
 // Browser API compatibility - use chrome for Chrome, browser for Firefox
 const browserAPI = typeof browser !== "undefined" ? browser : chrome
@@ -84,9 +84,9 @@ sendMessage({ action: "getAutoGroupState" }).then(response => {
   autoGroupToggle.checked = response.enabled
 })
 
-sendMessage({ action: "getGroupBySubDomain" }).then(response => {
-  if (response && response.enabled !== undefined) {
-    groupBySubDomainToggle.checked = response.enabled
+sendMessage({ action: "getGroupByMode" }).then(response => {
+  if (response && response.mode) {
+    updateGroupByToggle(response.mode)
   }
 })
 
@@ -98,15 +98,28 @@ autoGroupToggle.addEventListener("change", event => {
   })
 })
 
-groupBySubDomainToggle.addEventListener("change", () => {
-  console.log("[Popup/Sidebar] groupBySubDomainToggle changed")
-  const enabled = groupBySubDomainToggle.checked
-  console.log("[Popup/Sidebar] Sending toggleGroupBySubDomain message with enabled:", enabled)
-  sendMessage({
-    action: "toggleGroupBySubDomain",
-    enabled: enabled
+// Group by toggle event listeners
+groupByToggleOptions.forEach(option => {
+  option.addEventListener("click", () => {
+    const mode = option.dataset.value
+    console.log("[Popup/Sidebar] Group by mode changed to:", mode)
+    updateGroupByToggle(mode)
+    sendMessage({
+      action: "setGroupByMode",
+      mode: mode
+    })
   })
 })
+
+// Update group by toggle UI
+function updateGroupByToggle(mode) {
+  groupByToggleOptions.forEach(option => {
+    option.classList.remove("active")
+    if (option.dataset.value === mode) {
+      option.classList.add("active")
+    }
+  })
+}
 
 // Custom Rules Elements
 const rulesToggle = document.querySelector(".rules-toggle")

--- a/extension/src/public/sidebar.html
+++ b/extension/src/public/sidebar.html
@@ -35,11 +35,12 @@
             </label>
           </div>
           <div class="toggle-container">
-            <span>🔍 Group by domain/sub-domain</span>
-            <label class="switch">
-              <input type="checkbox" id="groupBySubDomain" checked />
-              <span class="slider round"></span>
-            </label>
+            <span>🔍 Group by</span>
+            <div class="group-by-toggle-bar">
+              <button class="toggle-option" data-value="rules">Rules only</button>
+              <button class="toggle-option active" data-value="domain">Domain</button>
+              <button class="toggle-option" data-value="subdomain">Sub-domain</button>
+            </div>
           </div>
         </div>
 

--- a/extension/src/public/sidebar.html
+++ b/extension/src/public/sidebar.html
@@ -37,7 +37,7 @@
           <div class="toggle-container">
             <span>🔍 Group by</span>
             <div class="group-by-toggle-bar">
-              <button class="toggle-option" data-value="rules">Rules only</button>
+              <button class="toggle-option" data-value="rules-only">Rules only</button>
               <button class="toggle-option active" data-value="domain">Domain</button>
               <button class="toggle-option" data-value="subdomain">Sub-domain</button>
             </div>

--- a/extension/src/state/TabGroupState.js
+++ b/extension/src/state/TabGroupState.js
@@ -9,7 +9,7 @@ class TabGroupState {
   constructor() {
     // Only user settings - no complex state management
     this.autoGroupingEnabled = DEFAULT_STATE.autoGroupingEnabled
-    this.groupBySubDomainEnabled = DEFAULT_STATE.groupBySubDomainEnabled
+    this.groupByMode = DEFAULT_STATE.groupByMode
     this.customRules = new Map() // Maps ruleId -> rule object
     this.ruleMatchingMode = DEFAULT_STATE.ruleMatchingMode
   }
@@ -20,7 +20,7 @@ class TabGroupState {
    */
   updateFromStorage(data) {
     this.autoGroupingEnabled = data.autoGroupingEnabled
-    this.groupBySubDomainEnabled = data.groupBySubDomainEnabled
+    this.groupByMode = data.groupByMode || DEFAULT_STATE.groupByMode
     this.ruleMatchingMode = data.ruleMatchingMode || DEFAULT_STATE.ruleMatchingMode
 
     this.customRules.clear()
@@ -39,7 +39,7 @@ class TabGroupState {
   getStorageData() {
     return {
       autoGroupingEnabled: this.autoGroupingEnabled,
-      groupBySubDomainEnabled: this.groupBySubDomainEnabled,
+      groupByMode: this.groupByMode,
       ruleMatchingMode: this.ruleMatchingMode,
       customRules: this.getCustomRulesObject()
     }

--- a/extension/tests/tabgroup-service.test.js
+++ b/extension/tests/tabgroup-service.test.js
@@ -92,7 +92,7 @@ test("Core services load independently", async ({ page }) => {
         // Mock state and storage
         window.mockState = {
           autoGroupingEnabled: true,
-          groupBySubDomainEnabled: false,
+          groupByMode: "domain",
           getColor: () => 'blue',
           setColor: () => {},
           getGroupDomain: () => 'example.com',
@@ -171,7 +171,7 @@ test("TabGroupService handles pinned tabs correctly", async ({ page }) => {
         // Mock other required modules
         globalThis.tabGroupState = {
           autoGroupingEnabled: true,
-          groupBySubDomainEnabled: false,
+          groupByMode: "domain",
           customRules: new Map()
         }
 


### PR DESCRIPTION
Replace the binary 'Group by domain/sub-domain' toggle with a three-state 'Rules only / Domain / Sub-domain' toggle bar to improve UX.