### PR TITLE
Nitzanpap/issue10

### DIFF
--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -74,7 +74,7 @@ browserAPI.runtime.onMessage.addListener((msg, sender, sendResponse) => {
 
       switch (msg.action) {
         case "group":
-          await tabGroupService.groupAllTabs()
+          await tabGroupService.groupAllTabsManually()
           result = { success: true }
           break
 

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -119,6 +119,10 @@ browserAPI.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           result = { enabled: tabGroupState.autoGroupingEnabled }
           break
 
+        case "getGroupNewTabsState":
+          result = { enabled: tabGroupState.groupNewTabs }
+          break
+
         case "getOnlyApplyToNewTabs":
         case "toggleAutoGroup":
           tabGroupState.autoGroupingEnabled = msg.enabled
@@ -128,6 +132,12 @@ browserAPI.runtime.onMessage.addListener((msg, sender, sendResponse) => {
             await tabGroupService.groupAllTabs()
           }
           result = { enabled: tabGroupState.autoGroupingEnabled }
+          break
+
+        case "toggleGroupNewTabs":
+          tabGroupState.groupNewTabs = msg.enabled
+          await storageManager.saveState()
+          result = { enabled: tabGroupState.groupNewTabs }
           break
 
         case "getGroupByMode":

--- a/extension/src/config/Constants.js
+++ b/extension/src/config/Constants.js
@@ -1,0 +1,24 @@
+/**
+ * Constants used throughout the Auto Tab Groups extension
+ */
+
+// Available colors for tab groups in Chrome/Firefox
+export const TAB_GROUP_COLORS = [
+  "grey",
+  "blue",
+  "red",
+  "yellow",
+  "green",
+  "pink",
+  "purple",
+  "cyan",
+  "orange"
+]
+
+/**
+ * Gets a random color from available tab group colors
+ * @returns {string} Random color name
+ */
+export function getRandomTabGroupColor() {
+  return TAB_GROUP_COLORS[Math.floor(Math.random() * TAB_GROUP_COLORS.length)]
+}

--- a/extension/src/config/StorageManager.js
+++ b/extension/src/config/StorageManager.js
@@ -10,6 +10,7 @@ const browserAPI = globalThis.browserAPI || (typeof browser !== "undefined" ? br
 
 export const DEFAULT_STATE = {
   autoGroupingEnabled: true,
+  groupNewTabs: true, // New setting to control whether new tabs should be grouped
   groupByMode: "domain", // "rules", "domain", or "subdomain"
   customRules: {},
   ruleMatchingMode: "exact",

--- a/extension/src/public/popup.html
+++ b/extension/src/public/popup.html
@@ -46,6 +46,13 @@
               <button class="toggle-option" data-value="subdomain">Rules & Sub-domain</button>
             </div>
           </div>
+          <div class="toggle-container">
+            <span>📂 Group new tabs</span>
+            <label class="switch">
+              <input type="checkbox" id="groupNewTabsToggle" />
+              <span class="slider round"></span>
+            </label>
+          </div>
         </div>
 
         <!-- Custom Rules Section -->

--- a/extension/src/public/popup.js
+++ b/extension/src/public/popup.js
@@ -5,6 +5,7 @@ const generateNewColorsButton = document.getElementById("generateNewColors")
 const collapseAllButton = document.getElementById("collapseAllButton")
 const expandAllButton = document.getElementById("expandAllButton")
 const autoGroupToggle = document.getElementById("autoGroupToggle")
+const groupNewTabsToggle = document.getElementById("groupNewTabsToggle")
 const groupByToggleOptions = document.querySelectorAll(".toggle-option")
 
 // Browser API compatibility - use chrome for Chrome, browser for Firefox
@@ -84,6 +85,10 @@ sendMessage({ action: "getAutoGroupState" }).then(response => {
   autoGroupToggle.checked = response.enabled
 })
 
+sendMessage({ action: "getGroupNewTabsState" }).then(response => {
+  groupNewTabsToggle.checked = response.enabled
+})
+
 sendMessage({ action: "getGroupByMode" }).then(response => {
   if (response && response.mode) {
     updateGroupByToggle(response.mode)
@@ -94,6 +99,13 @@ sendMessage({ action: "getGroupByMode" }).then(response => {
 autoGroupToggle.addEventListener("change", event => {
   sendMessage({
     action: "toggleAutoGroup",
+    enabled: event.target.checked
+  })
+})
+
+groupNewTabsToggle.addEventListener("change", event => {
+  sendMessage({
+    action: "toggleGroupNewTabs",
     enabled: event.target.checked
   })
 })

--- a/extension/src/public/sidebar.html
+++ b/extension/src/public/sidebar.html
@@ -46,6 +46,13 @@
               <button class="toggle-option" data-value="subdomain">Sub-domain</button>
             </div>
           </div>
+          <div class="toggle-container">
+            <span>📂 Group new tabs</span>
+            <label class="switch">
+              <input type="checkbox" id="groupNewTabsToggle" />
+              <span class="slider round"></span>
+            </label>
+          </div>
         </div>
 
         <!-- Custom Rules Section -->

--- a/extension/src/state/TabGroupState.js
+++ b/extension/src/state/TabGroupState.js
@@ -9,6 +9,7 @@ class TabGroupState {
   constructor() {
     // Only user settings - no complex state management
     this.autoGroupingEnabled = DEFAULT_STATE.autoGroupingEnabled
+    this.groupNewTabs = DEFAULT_STATE.groupNewTabs
     this.groupByMode = DEFAULT_STATE.groupByMode
     this.customRules = new Map() // Maps ruleId -> rule object
     this.ruleMatchingMode = DEFAULT_STATE.ruleMatchingMode
@@ -20,6 +21,7 @@ class TabGroupState {
    */
   updateFromStorage(data) {
     this.autoGroupingEnabled = data.autoGroupingEnabled
+    this.groupNewTabs = data.groupNewTabs ?? DEFAULT_STATE.groupNewTabs
     this.groupByMode = data.groupByMode || DEFAULT_STATE.groupByMode
     this.ruleMatchingMode = data.ruleMatchingMode || DEFAULT_STATE.ruleMatchingMode
 
@@ -39,6 +41,7 @@ class TabGroupState {
   getStorageData() {
     return {
       autoGroupingEnabled: this.autoGroupingEnabled,
+      groupNewTabs: this.groupNewTabs,
       groupByMode: this.groupByMode,
       ruleMatchingMode: this.ruleMatchingMode,
       customRules: this.getCustomRulesObject()


### PR DESCRIPTION
This pull request introduces a new feature to control whether newly opened tabs should be automatically grouped, along with several enhancements and refactors to improve functionality and maintainability. Key changes include adding a toggle for "Group New Tabs" in the UI, updating the tab grouping logic to respect this setting, and refactoring color selection for tab groups.

### New Feature: "Group New Tabs" Setting
* Added a new `groupNewTabs` setting to the `TabGroupState` and its default value to `DEFAULT_STATE`. This setting determines whether newly opened tabs should be automatically grouped. (`extension/src/config/StorageManager.js` [[1]](diffhunk://#diff-3b6043b6cc466ddc4dfe8b4883b62c59fcde14e125a2976d52ade66d626f0a86R13) `extension/src/state/TabGroupState.js` [[2]](diffhunk://#diff-20491b5b40780f9c5398982b05fe7c494d0a7f242c1e00911dd3c62abc65550fR12) [[3]](diffhunk://#diff-20491b5b40780f9c5398982b05fe7c494d0a7f242c1e00911dd3c62abc65550fR24) [[4]](diffhunk://#diff-20491b5b40780f9c5398982b05fe7c494d0a7f242c1e00911dd3c62abc65550fR44)
* Updated the tab grouping logic in `TabGroupService` to skip grouping for new tab URLs when the `groupNewTabs` setting is disabled. (`extension/src/services/TabGroupService.js` [extension/src/services/TabGroupService.jsR58-R65](diffhunk://#diff-14d09c43b45dcd43b6805370449a6086690fa0d16fc3a7fcc8334317a385f0cdR58-R65))
* Added a new message handler for toggling the `groupNewTabs` setting and retrieving its state. (`extension/src/background.js` [[1]](diffhunk://#diff-63f57208366a525675352a112eb1f04ce2635b4aef3b112e708bbd947b4c9aa2R122-R125) [[2]](diffhunk://#diff-63f57208366a525675352a112eb1f04ce2635b4aef3b112e708bbd947b4c9aa2R137-R142)

### UI Enhancements
* Integrated a toggle switch for "Group New Tabs" in the popup and sidebar settings. (`extension/src/public/popup.html` [[1]](diffhunk://#diff-a2faa8f28da51a2d47ae37c989313c397898e1236046312cbd6909d1887519e9R49-R55) `extension/src/public/sidebar.html` [[2]](diffhunk://#diff-2d65b02e94b65a49b5eebda56bc9fdd3e2f76bfd5a836409f92e1477c251e193R49-R55)
* Updated the popup script to handle the new toggle, including syncing its state with the background script and sending updates when the toggle is changed. (`extension/src/public/popup.js` [[1]](diffhunk://#diff-5c6c10f744b3799030586adffa2d1b99bd707b61863a9c0f9b484901932458c7R8) [[2]](diffhunk://#diff-5c6c10f744b3799030586adffa2d1b99bd707b61863a9c0f9b484901932458c7R88-R91) [[3]](diffhunk://#diff-5c6c10f744b3799030586adffa2d1b99bd707b61863a9c0f9b484901932458c7R106-R112)

### Refactoring and Improvements
* Refactored the tab group color selection logic to use a centralized `getRandomTabGroupColor` function, which was introduced in a new `Constants.js` file. (`extension/src/config/Constants.js` [[1]](diffhunk://#diff-d8d2c7b7d3df76f8f3b014baa0c4031d9e95fd215662729fcb47483b66fae828R1-R24) `extension/src/services/TabGroupService.js` [[2]](diffhunk://#diff-14d09c43b45dcd43b6805370449a6086690fa0d16fc3a7fcc8334317a385f0cdL111-R148) [[3]](diffhunk://#diff-14d09c43b45dcd43b6805370449a6086690fa0d16fc3a7fcc8334317a385f0cdL179-R217) [[4]](diffhunk://#diff-14d09c43b45dcd43b6805370449a6086690fa0d16fc3a7fcc8334317a385f0cdL350-L352) [[5]](diffhunk://#diff-14d09c43b45dcd43b6805370449a6086690fa0d16fc3a7fcc8334317a385f0cdL366-R428)
* Added a new method `groupAllTabsManually` to `TabGroupService` for manually grouping all tabs, bypassing the auto-grouping setting. (`extension/src/services/TabGroupService.js` [extension/src/services/TabGroupService.jsR298-R324](diffhunk://#diff-14d09c43b45dcd43b6805370449a6086690fa0d16fc3a7fcc8334317a385f0cdR298-R324))

These changes collectively enhance the flexibility of the tab grouping extension while improving its maintainability and user experience.