### PR TITLE
Feat/add option for minimum requirement for tab groups

### DIFF
--- a/docs/MINIMUM_TABS_TEST_PLAN.md
+++ b/docs/MINIMUM_TABS_TEST_PLAN.md
@@ -1,0 +1,205 @@
+# Minimum Tabs Feature Test Plan
+
+## Overview
+
+This test plan covers the minimum tabs threshold feature that allows users to set both global and per-rule minimum tab requirements before the extension creates tab groups.
+
+## Test Environment Setup
+
+- Global minimum tabs setting: 2
+- Test with at least one rule having a custom minimum tabs value
+- Clear all existing tabs/groups before each test for clean state
+
+## Test Cases
+
+### 1. Global Minimum Tabs Setting
+
+#### 1.1 Basic Global Minimum
+
+- **Setup**: Set global minimum to 2
+- **Action**: Open single tab of domain without custom rule (e.g., github.com)
+- **Expected**: No group created, tab remains ungrouped
+- **Verify**: Console shows "Not enough tabs (1 < 2) to create group"
+
+#### 1.2 Meeting Global Minimum
+
+- **Setup**: Global minimum = 2
+- **Action**: Open 2 tabs of same domain without custom rule
+- **Expected**: Group created with both tabs
+- **Verify**: Group title matches domain name
+
+#### 1.3 Changing Global Minimum
+
+- **Setup**: Start with global minimum = 3, have 2 tabs of same domain (ungrouped)
+- **Action**: Change global minimum to 2
+- **Expected**: Existing tabs automatically group together
+- **Verify**: Re-evaluation happens after setting change
+
+### 2. Rule-Specific Minimum Tabs
+
+#### 2.1 Rule Minimum Lower Than Global
+
+- **Setup**: Global = 2, Rule "Extensions" = 1
+- **Action**: Open single tab matching Extensions rule (addons.mozilla.org)
+- **Expected**: Group created immediately with 1 tab
+- **Verify**: Console shows "Using rule-specific minimum: 1"
+
+#### 2.2 Rule Minimum Higher Than Global
+
+- **Setup**: Global = 1, Create rule "Social" with minimum = 3
+- **Action**: Open 2 tabs of facebook.com
+- **Expected**: No group created (needs 3)
+- **Verify**: Console shows rule-specific minimum being used
+
+#### 2.3 Rule Without Minimum Set
+
+- **Setup**: Create new rule without setting minimum tabs field
+- **Action**: Open tabs matching this rule
+- **Expected**: Falls back to global minimum
+- **Verify**: Console shows "Using global minimum"
+
+### 3. UI Behavior
+
+#### 3.1 Creating New Rule
+
+- **Setup**: Create new rule
+- **Action**: Leave minimum tabs field empty
+- **Expected**: Field shows placeholder, help text shows current global setting
+- **Verify**: Rule saved with `minimumTabs: null`
+
+#### 3.2 Editing Existing Rule
+
+- **Setup**: Edit rule with minimumTabs = 1
+- **Action**: Open edit dialog
+- **Expected**: Field shows "1"
+- **Verify**: Value persists after save
+
+#### 3.3 Clearing Rule Minimum
+
+- **Setup**: Edit rule with minimumTabs = 3
+- **Action**: Clear the field and save
+- **Expected**: Rule reverts to using global minimum
+- **Verify**: `minimumTabs: null` in saved data
+
+### 4. Group Threshold Management
+
+#### 4.1 Falling Below Threshold
+
+- **Setup**: Group exists with 3 tabs, minimum = 3
+- **Action**: Close 1 tab
+- **Expected**: Group automatically disbanded, tabs ungrouped
+- **Verify**: Console shows "Group no longer meets minimum threshold"
+
+#### 4.2 Mixed Rules in Same Window
+
+- **Setup**:
+  - Rule A: minimum = 1
+  - Rule B: minimum = 3
+  - Global = 2
+- **Action**: Open 1 tab each of rules A, B, and domain C
+- **Expected**:
+  - Rule A tab: grouped alone
+  - Rule B tab: ungrouped
+  - Domain C tab: ungrouped
+- **Verify**: Each uses correct minimum
+
+### 5. Edge Cases
+
+#### 5.1 Zero Minimum
+
+- **Setup**: Try to set minimum to 0
+- **Action**: Enter 0 in minimum tabs field
+- **Expected**: Treated as "no minimum" (groups with 1 tab)
+- **Verify**: Behaves same as minimum = 1
+
+#### 5.2 Invalid Values
+
+- **Setup**: Try to enter non-numeric or negative values
+- **Action**: Type "abc" or "-1" in field
+- **Expected**: Field validation prevents invalid input
+- **Verify**: HTML5 number input constraints work
+
+#### 5.3 Maximum Value
+
+- **Setup**: Set minimum to 10 (max allowed)
+- **Action**: Open 9 tabs of same domain
+- **Expected**: No group created
+- **Verify**: Opens 10th tab creates group
+
+### 6. Mode Interactions
+
+#### 6.1 Domain vs Subdomain Mode
+
+- **Setup**: Minimum = 2, mode = subdomain
+- **Action**: Open mail.google.com and drive.google.com
+- **Expected**: No group (different subdomains)
+- **Verify**: Each subdomain evaluated separately
+
+#### 6.2 Rules-Only Mode
+
+- **Setup**: Mode = rules-only, domain without rule
+- **Action**: Open tabs of non-rule domain
+- **Expected**: No grouping regardless of tab count
+- **Verify**: Only rule-matched domains group
+
+### 7. Performance & State
+
+#### 7.1 Extension Restart
+
+- **Setup**: Configure minimums, create groups
+- **Action**: Disable/enable extension
+- **Expected**: All settings persist, groups maintain state
+- **Verify**: Check storage contains minimumTabs values
+
+#### 7.2 Browser Restart
+
+- **Setup**: Configure various minimums
+- **Action**: Restart browser completely
+- **Expected**: All minimum settings restored
+- **Verify**: First grouping uses correct minimums
+
+### 8. Import/Export
+
+#### 8.1 Export Rules
+
+- **Setup**: Rules with various minimumTabs values
+- **Action**: Export rules to JSON
+- **Expected**: minimumTabs field included in export
+- **Verify**: JSON contains correct values
+
+#### 8.2 Import Rules
+
+- **Setup**: Import rules with minimumTabs set
+- **Action**: Import JSON file
+- **Expected**: Minimum values properly imported
+- **Verify**: Edit imported rules shows correct values
+
+## Regression Tests
+
+### Critical Paths to Verify
+
+1. Basic auto-grouping still works when minimum = 1
+2. Manual "Group Tabs" button ignores minimums
+3. Ungroup All removes all groups regardless of minimums
+4. Color management unaffected by minimum settings
+5. Pinned tabs still excluded from counts
+
+## Console Log Verification
+
+Key log messages to verify feature is working:
+
+```log
+[TabGroupService] Rule "RuleName" minimumTabs field: X number
+[TabGroupService] Using rule-specific minimum: X for rule "RuleName"
+[TabGroupService] Using global minimum: X for rule "RuleName"
+[TabGroupService] Tab count for "GroupName": X, minimum required: Y
+[TabGroupService] Not enough tabs (X < Y) to create group
+[TabGroupService] Group "Name" no longer meets minimum threshold, ungrouping all tabs
+```
+
+## Notes
+
+- Test both in Chrome and Firefox for cross-browser compatibility
+- Verify performance with many rules having different minimums
+- Check memory usage doesn't increase significantly
+- Ensure no console errors during any operations

--- a/extension/README.md
+++ b/extension/README.md
@@ -13,6 +13,7 @@ If you like this extension, please consider rating it 5 stars ⭐ :)
 - ✅ **Cross-browser compatibility** - Single codebase for Chrome and Firefox
 - ✅ **Domain-based tab grouping** - Automatically groups tabs by website domain/subdomain
 - ✅ **Custom rules** - Create named groups that combine multiple domains
+- ✅ **Minimum tabs threshold** - Set how many tabs are needed before creating a group (global and per-rule)
 - ✅ **Export/Import rules** - Backup and restore your custom tab grouping rules
 - ✅ **Smart domain display** - Shows clean domain names (e.g., "github" instead of "github.com")
 - ✅ **Color management** - Persistent group colors across browser sessions
@@ -182,6 +183,45 @@ Custom rules allow you to create named tab groups that combine multiple domains 
 - **Performance**: Rules are cached for fast matching
 - **Validation**: Comprehensive validation for rule names and domains
 - **Limits**: Maximum 20 domains per rule, 50 character rule names
+
+## 🔢 Minimum Tabs Threshold
+
+The minimum tabs threshold feature allows you to control when tab groups are created. Instead of grouping tabs immediately, you can require a minimum number of tabs from the same domain before a group is formed. This helps reduce clutter from single-tab groups.
+
+### How Minimum Tabs Works
+
+1. **Global Setting**: Set a default minimum (e.g., 2 tabs) that applies to all domains
+2. **Per-Rule Override**: Each custom rule can have its own minimum that overrides the global setting
+3. **Automatic Management**: Groups are automatically created when the threshold is met and disbanded when tabs drop below the minimum
+
+### Configuration (Global and Per-Rule)
+
+#### Global Minimum
+
+1. Open the extension popup
+2. Find "Minimum tabs to form group" setting
+3. Set your preferred minimum (1-10 tabs)
+4. All domains without custom rules will use this setting
+
+#### Per-Rule Minimum
+
+1. When creating or editing a custom rule
+2. Set "Minimum tabs to form group" for that specific rule
+3. Leave empty to use the global setting
+4. Example: Set "Extensions" rule to 1 tab, but keep global at 3 tabs
+
+### Example Scenarios (Global and Per-Rule)
+
+- **Global = 3, No custom rules**: Need 3 github.com tabs before they group
+- **Global = 2, "Work" rule = 1**: Work sites group immediately, others need 2 tabs
+- **Global = 1, "Social Media" rule = 5**: Most sites group immediately, but social media sites need 5 tabs to reduce distractions
+
+### Technical Details (Global and Per-Rule)
+
+- **Range**: 1-10 tabs (1 effectively disables the feature)
+- **Auto-ungroup**: When a group falls below its minimum, tabs are automatically ungrouped
+- **Storage**: Settings persist across browser sessions
+- **Import/Export**: Minimum values are included when exporting/importing rules
 
 ## 📖 Documentation
 

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-tab-groups",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-tab-groups",
-      "version": "1.5.2",
+      "version": "1.6.0",
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@playwright/test": "^1.53.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -155,6 +155,21 @@ browserAPI.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           result = { mode: tabGroupState.groupByMode }
           break
 
+        case "getMinimumTabsForGroup":
+          result = { minimumTabs: tabGroupState.minimumTabsForGroup || 1 }
+          break
+
+        case "setMinimumTabsForGroup":
+          tabGroupState.minimumTabsForGroup = msg.minimumTabs || 1
+          await storageManager.saveState()
+
+          // Re-evaluate all existing groups
+          if (tabGroupState.autoGroupingEnabled) {
+            await tabGroupService.groupAllTabs()
+          }
+          result = { minimumTabs: tabGroupState.minimumTabsForGroup }
+          break
+
         // Custom Rules Management
         case "getCustomRules": {
           const rules = await rulesService.getCustomRules()

--- a/extension/src/config/StorageManager.js
+++ b/extension/src/config/StorageManager.js
@@ -14,7 +14,8 @@ export const DEFAULT_STATE = {
   groupByMode: "domain", // "rules", "domain", or "subdomain"
   customRules: {},
   ruleMatchingMode: "exact",
-  groupColorMapping: {}
+  groupColorMapping: {},
+  minimumTabsForGroup: 1 // Minimum number of tabs required to form a group
 }
 
 class StorageManager {

--- a/extension/src/manifest.chrome.json
+++ b/extension/src/manifest.chrome.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Auto Tab Groups",
   "author": "Nitzan Papini",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Automatically groups tabs by domain.",
   "permissions": ["tabs", "storage", "tabGroups"],
   "side_panel": {

--- a/extension/src/manifest.firefox.json
+++ b/extension/src/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Auto Tab Groups",
   "author": "Nitzan Papini",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Automatically groups tabs by domain.",
   "permissions": ["tabs", "storage", "tabGroups"],
   "browser_specific_settings": {

--- a/extension/src/public/popup.css
+++ b/extension/src/public/popup.css
@@ -375,6 +375,49 @@ input:checked + .slider:before {
   border-radius: 50%;
 }
 
+/* Number input styles */
+.number-input-container {
+  display: flex;
+  align-items: center;
+}
+
+.number-input {
+  width: 60px;
+  height: 32px;
+  padding: 4px 8px;
+  border: 2px solid #e5e7eb;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  text-align: center;
+  background-color: #ffffff;
+  color: #111827;
+  transition: border-color 0.2s;
+  -moz-user-select: text;
+  user-select: text;
+}
+
+.number-input:focus {
+  outline: none;
+  border-color: var(--primary-color);
+}
+
+.number-input:hover {
+  border-color: #d1d5db;
+}
+
+/* Chrome, Safari, Edge, Opera */
+.number-input::-webkit-outer-spin-button,
+.number-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+.number-input[type="number"] {
+  -moz-appearance: textfield;
+}
+
 .settings-container {
   display: flex;
   flex-direction: column;

--- a/extension/src/public/popup.html
+++ b/extension/src/public/popup.html
@@ -53,6 +53,19 @@
               <span class="slider round"></span>
             </label>
           </div>
+          <div class="toggle-container">
+            <span>🔢 Minimum tabs to form a group</span>
+            <div class="number-input-container">
+              <input
+                type="number"
+                id="minimumTabsInput"
+                min="1"
+                max="10"
+                value="1"
+                class="number-input"
+              />
+            </div>
+          </div>
         </div>
 
         <!-- Custom Rules Section -->

--- a/extension/src/public/popup.js
+++ b/extension/src/public/popup.js
@@ -7,6 +7,7 @@ const expandAllButton = document.getElementById("expandAllButton")
 const autoGroupToggle = document.getElementById("autoGroupToggle")
 const groupNewTabsToggle = document.getElementById("groupNewTabsToggle")
 const groupByToggleOptions = document.querySelectorAll(".toggle-option")
+const minimumTabsInput = document.getElementById("minimumTabsInput")
 
 // Browser API compatibility - use chrome for Chrome, browser for Firefox
 const browserAPI = typeof browser !== "undefined" ? browser : chrome
@@ -95,6 +96,10 @@ sendMessage({ action: "getGroupByMode" }).then(response => {
   }
 })
 
+sendMessage({ action: "getMinimumTabsForGroup" }).then(response => {
+  minimumTabsInput.value = response.minimumTabs || 1
+})
+
 // Listen for toggle changes.
 autoGroupToggle.addEventListener("change", event => {
   sendMessage({
@@ -120,6 +125,19 @@ groupByToggleOptions.forEach(option => {
       action: "setGroupByMode",
       mode: mode
     })
+  })
+})
+
+// Minimum tabs input event listener
+minimumTabsInput.addEventListener("change", event => {
+  const value = parseInt(event.target.value) || 1
+  // Ensure value is within bounds
+  const clampedValue = Math.max(1, Math.min(10, value))
+  event.target.value = clampedValue
+
+  sendMessage({
+    action: "setMinimumTabsForGroup",
+    minimumTabs: clampedValue
   })
 })
 

--- a/extension/src/public/rules-modal.css
+++ b/extension/src/public/rules-modal.css
@@ -69,6 +69,32 @@ body {
   font-family: inherit;
 }
 
+/* Number input styles for minimumTabs */
+.number-input-container {
+  display: flex;
+  align-items: center;
+}
+
+.number-input-small {
+  width: 120px !important;
+  text-align: center;
+  -moz-user-select: text !important;
+  user-select: text !important;
+}
+
+/* Chrome, Safari, Edge, Opera */
+.number-input-small::-webkit-outer-spin-button,
+.number-input-small::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+.number-input-small[type="number"] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
 .color-selector {
   display: flex;
   gap: 8px;

--- a/extension/src/public/rules-modal.html
+++ b/extension/src/public/rules-modal.html
@@ -74,6 +74,23 @@
         </div>
 
         <div class="form-group">
+          <label class="form-label" for="minimumTabsInput">Minimum tabs to form group</label>
+          <div class="number-input-container">
+            <input
+              type="number"
+              id="minimumTabsInput"
+              min="1"
+              max="10"
+              placeholder="Ex: 3"
+              class="form-input number-input-small"
+            />
+          </div>
+          <div class="help-text" id="minimumTabsHelp">
+            Leave empty to use global setting (currently: 1 tab)
+          </div>
+        </div>
+
+        <div class="form-group">
           <div class="checkbox-container">
             <input type="checkbox" id="ruleEnabled" checked />
             <label for="ruleEnabled" class="form-label" style="margin: 0">Enable this rule</label>

--- a/extension/src/public/rules-modal.js
+++ b/extension/src/public/rules-modal.js
@@ -33,6 +33,7 @@ class RulesModal {
     this.initializeEventListeners()
     this.populateColorSelector()
     this.loadCurrentTabs()
+    this.loadGlobalMinimumTabs()
     this.loadRuleData()
   }
 
@@ -43,6 +44,8 @@ class RulesModal {
     this.domainsInput = document.getElementById("ruleDomains")
     this.enabledCheckbox = document.getElementById("ruleEnabled")
     this.colorSelector = document.getElementById("colorSelector")
+    this.minimumTabsInput = document.getElementById("minimumTabsInput")
+    this.minimumTabsHelp = document.getElementById("minimumTabsHelp")
     this.saveButton = document.getElementById("saveButton")
     this.cancelButton = document.getElementById("cancelButton")
     this.nameError = document.getElementById("nameError")
@@ -132,6 +135,20 @@ class RulesModal {
     }
   }
 
+  async loadGlobalMinimumTabs() {
+    try {
+      const response = await this.sendMessage({
+        action: "getMinimumTabsForGroup"
+      })
+
+      const globalMinimum = response.minimumTabs || 1
+      this.minimumTabsHelp.textContent = `Leave empty to use global setting (currently: ${globalMinimum} tab${globalMinimum === 1 ? "" : "s"})`
+    } catch (error) {
+      console.error("Error loading global minimum tabs:", error)
+      // Keep default text if loading fails
+    }
+  }
+
   async loadExistingRule() {
     try {
       const response = await this.sendMessage({
@@ -155,6 +172,9 @@ class RulesModal {
     this.domainsInput.value = (rule.domains || []).join("\n")
     this.enabledCheckbox.checked = rule.enabled !== false
     this.selectedColor = rule.color || "blue"
+    // Handle minimumTabs properly - don't use || operator since 0 is falsy
+    this.minimumTabsInput.value =
+      rule.minimumTabs !== null && rule.minimumTabs !== undefined ? rule.minimumTabs : ""
     this.populateColorSelector()
   }
 
@@ -206,13 +226,15 @@ class RulesModal {
 
   collectFormData() {
     const domains = parseDomainsText(this.domainsInput.value)
+    const minimumTabsValue = this.minimumTabsInput.value.trim()
 
     return {
       name: this.nameInput.value.trim(),
       domains: domains,
       color: this.selectedColor,
       enabled: this.enabledCheckbox.checked,
-      priority: 1 // Default priority
+      priority: 1, // Default priority
+      minimumTabs: minimumTabsValue ? parseInt(minimumTabsValue) : null
     }
   }
 

--- a/extension/src/public/sidebar.html
+++ b/extension/src/public/sidebar.html
@@ -53,6 +53,19 @@
               <span class="slider round"></span>
             </label>
           </div>
+          <div class="toggle-container">
+            <span>🔢 Minimum tabs to form a group</span>
+            <div class="number-input-container">
+              <input
+                type="number"
+                id="minimumTabsInput"
+                min="1"
+                max="10"
+                value="1"
+                class="number-input"
+              />
+            </div>
+          </div>
         </div>
 
         <!-- Custom Rules Section -->

--- a/extension/src/services/RulesService.js
+++ b/extension/src/services/RulesService.js
@@ -257,6 +257,7 @@ class RulesService {
       color: ruleData.color || "blue",
       enabled: ruleData.enabled !== false,
       priority: ruleData.priority || 1,
+      minimumTabs: ruleData.minimumTabs ? parseInt(ruleData.minimumTabs) : null, // null means use global setting
       createdAt: new Date().toISOString()
     }
 
@@ -293,7 +294,13 @@ class RulesService {
       domains: ruleData.domains.map(d => d.toLowerCase().trim()).filter(d => d),
       color: ruleData.color || customRules[ruleId].color,
       enabled: ruleData.enabled !== false,
-      priority: ruleData.priority || customRules[ruleId].priority
+      priority: ruleData.priority || customRules[ruleId].priority,
+      minimumTabs:
+        ruleData.minimumTabs !== undefined
+          ? ruleData.minimumTabs
+            ? parseInt(ruleData.minimumTabs)
+            : null
+          : customRules[ruleId].minimumTabs
     }
 
     // Update rule in state
@@ -363,6 +370,16 @@ class RulesService {
         if (!validation.isValid) {
           errors.push(`Invalid pattern "${pattern}": ${validation.error}`)
         }
+      }
+    }
+
+    // Validate minimumTabs (optional field)
+    if (ruleData.minimumTabs !== null && ruleData.minimumTabs !== undefined) {
+      const minTabs = parseInt(ruleData.minimumTabs)
+      if (isNaN(minTabs) || minTabs < 1 || minTabs > 10) {
+        errors.push(
+          "Minimum tabs must be a number between 1 and 10, or empty to use global setting"
+        )
       }
     }
 

--- a/extension/src/services/TabGroupService.js
+++ b/extension/src/services/TabGroupService.js
@@ -137,6 +137,47 @@ class TabGroupServiceSimplified {
   }
 
   /**
+   * Counts tabs that would belong to the same group
+   * @param {string} expectedTitle - The group title to check
+   * @param {number} windowId - The window ID
+   * @param {Object|null} customRule - The custom rule if applicable
+   * @returns {Promise<number>} Count of tabs that match this group
+   */
+  async countTabsForGroup(expectedTitle, windowId, customRule) {
+    try {
+      const tabs = await browserAPI.tabs.query({ windowId })
+      let count = 0
+
+      for (const tab of tabs) {
+        // Skip pinned tabs
+        if (tab.pinned) continue
+
+        // For rules-based grouping
+        if (customRule) {
+          const matchingRule = await rulesService.findMatchingRule(tab.url)
+          if (matchingRule && matchingRule.name === customRule.name) {
+            count++
+          }
+        } else {
+          // For domain-based grouping
+          const includeSubDomain = tabGroupState.groupByMode === "subdomain"
+          const domain = extractDomain(tab.url, includeSubDomain)
+          const displayName = getDomainDisplayName(domain)
+
+          if (displayName === expectedTitle) {
+            count++
+          }
+        }
+      }
+
+      return count
+    } catch (error) {
+      console.error(`[TabGroupService] Error counting tabs for group:`, error)
+      return 0
+    }
+  }
+
+  /**
    * Moves a tab to the target group, creating the group if it doesn't exist
    * @param {number} tabId - The tab ID to move
    * @param {Object} tab - The tab object
@@ -180,7 +221,29 @@ class TabGroupServiceSimplified {
       return true
     }
 
-    // No group exists - create new one by grouping the tab first
+    // No group exists - check if we meet the minimum threshold before creating
+    const tabCount = await this.countTabsForGroup(expectedTitle, tab.windowId, customRule)
+    const minimumTabs = tabGroupState.minimumTabsForGroup || 1
+
+    console.log(
+      `[TabGroupService] Tab count for "${expectedTitle}": ${tabCount}, minimum required: ${minimumTabs}`
+    )
+
+    if (tabCount < minimumTabs) {
+      console.log(
+        `[TabGroupService] Not enough tabs (${tabCount} < ${minimumTabs}) to create group "${expectedTitle}", keeping tab ungrouped`
+      )
+
+      // If tab is currently in a group, ungroup it since it doesn't meet threshold
+      if (tab.groupId && tab.groupId !== -1) {
+        await browserAPI.tabs.ungroup([tabId])
+        console.log(`[TabGroupService] Ungrouped tab ${tabId} as it doesn't meet minimum threshold`)
+      }
+
+      return false
+    }
+
+    // Threshold is met - use standard grouping logic but group all matching tabs at once
     console.log(`[TabGroupService] Creating new group "${expectedTitle}" for tab ${tabId}`)
 
     const groupId = await browserAPI.tabs.group({
@@ -236,7 +299,69 @@ class TabGroupServiceSimplified {
     }
 
     console.log(`[TabGroupService] Created group ${groupId} with title "${expectedTitle}"`)
+
+    // After creating the group, check if any other ungrouped tabs should join it
+    await this.groupMatchingUngroupedTabs(expectedTitle, tab.windowId, customRule)
+
     return true
+  }
+
+  /**
+   * Groups any ungrouped tabs that match the given group criteria
+   * @param {string} expectedTitle - The group title to match
+   * @param {number} windowId - The window ID
+   * @param {Object|null} customRule - The custom rule if applicable
+   * @returns {Promise<void>}
+   */
+  async groupMatchingUngroupedTabs(expectedTitle, windowId, customRule) {
+    try {
+      // Find the existing group by title (fresh from browser)
+      const existingGroup = await this.findGroupByTitle(expectedTitle, windowId)
+      if (!existingGroup) {
+        console.log(`[TabGroupService] No group found with title "${expectedTitle}" to add tabs to`)
+        return
+      }
+
+      // Get all tabs in this window (fresh from browser)
+      const allTabs = await browserAPI.tabs.query({ windowId })
+      const tabsToGroup = []
+
+      for (const otherTab of allTabs) {
+        // Skip if pinned, already in a group, or doesn't match
+        if (otherTab.pinned || (otherTab.groupId && otherTab.groupId !== -1)) {
+          continue
+        }
+
+        // Check if this tab matches the same group using existing logic
+        let shouldGroup = false
+        if (customRule) {
+          const matchingRule = await rulesService.findMatchingRule(otherTab.url)
+          shouldGroup = matchingRule && matchingRule.name === customRule.name
+        } else {
+          const includeSubDomain = tabGroupState.groupByMode === "subdomain"
+          const domain = extractDomain(otherTab.url, includeSubDomain)
+          const displayName = getDomainDisplayName(domain)
+          shouldGroup = displayName === expectedTitle
+        }
+
+        if (shouldGroup) {
+          tabsToGroup.push(otherTab.id)
+        }
+      }
+
+      // Group any matching ungrouped tabs
+      if (tabsToGroup.length > 0) {
+        await browserAPI.tabs.group({
+          tabIds: tabsToGroup,
+          groupId: existingGroup.id
+        })
+        console.log(
+          `[TabGroupService] Added ${tabsToGroup.length} ungrouped tabs to group "${expectedTitle}"`
+        )
+      }
+    } catch (error) {
+      console.error(`[TabGroupService] Error grouping matching ungrouped tabs:`, error)
+    }
   }
 
   /**
@@ -345,12 +470,66 @@ class TabGroupServiceSimplified {
   }
 
   /**
+   * Checks if a group should be ungrouped based on minimum threshold
+   * Uses browser-fetched state to handle Chrome's memory optimizations
+   * @param {number} groupId - The group ID to check
+   * @returns {Promise<boolean>} True if group was ungrouped
+   */
+  async checkGroupThreshold(groupId) {
+    try {
+      const minimumTabs = tabGroupState.minimumTabsForGroup || 1
+
+      // If minimum is 1, no need to check
+      if (minimumTabs <= 1) return false
+
+      // Get fresh group details from browser (following established pattern to avoid stale state)
+      const groups = await browserAPI.tabGroups.query({ groupId })
+      if (groups.length === 0) return false
+
+      const group = groups[0]
+
+      // Get fresh tab count from browser
+      const tabs = await browserAPI.tabs.query({ groupId })
+      const tabCount = tabs.filter(tab => !tab.pinned).length
+
+      console.log(
+        `[TabGroupService] Group "${group.title}" has ${tabCount} tabs, minimum required: ${minimumTabs}`
+      )
+
+      if (tabCount < minimumTabs) {
+        console.log(
+          `[TabGroupService] Group "${group.title}" no longer meets minimum threshold, ungrouping all tabs`
+        )
+
+        // Ungroup all tabs - let browser handle the rest
+        const tabIds = tabs.map(tab => tab.id)
+        if (tabIds.length > 0) {
+          await browserAPI.tabs.ungroup(tabIds)
+          console.log(
+            `[TabGroupService] Ungrouped ${tabIds.length} tabs from group "${group.title}"`
+          )
+        }
+
+        return true
+      }
+
+      return false
+    } catch (error) {
+      console.error(`[TabGroupService] Error checking group threshold:`, error)
+      return false
+    }
+  }
+
+  /**
    * Removes an empty group (no-op in simplified version, browser handles this)
    * @param {number} groupId - The group ID to check and remove if empty
    * @returns {Promise<boolean>} True if successful
    */
   async removeEmptyGroup(groupId) {
-    // In the simplified version, we let the browser handle empty group cleanup
+    // Check if group should be ungrouped based on threshold
+    await this.checkGroupThreshold(groupId)
+
+    // Let the browser handle empty group cleanup
     console.log(`[TabGroupService] Group ${groupId} cleanup handled by browser`)
     return true
   }

--- a/extension/src/state/TabGroupState.js
+++ b/extension/src/state/TabGroupState.js
@@ -13,6 +13,7 @@ class TabGroupState {
     this.groupByMode = DEFAULT_STATE.groupByMode
     this.customRules = new Map() // Maps ruleId -> rule object
     this.ruleMatchingMode = DEFAULT_STATE.ruleMatchingMode
+    this.minimumTabsForGroup = DEFAULT_STATE.minimumTabsForGroup
   }
 
   /**
@@ -24,6 +25,7 @@ class TabGroupState {
     this.groupNewTabs = data.groupNewTabs ?? DEFAULT_STATE.groupNewTabs
     this.groupByMode = data.groupByMode || DEFAULT_STATE.groupByMode
     this.ruleMatchingMode = data.ruleMatchingMode || DEFAULT_STATE.ruleMatchingMode
+    this.minimumTabsForGroup = data.minimumTabsForGroup ?? DEFAULT_STATE.minimumTabsForGroup
 
     this.customRules.clear()
 
@@ -44,7 +46,8 @@ class TabGroupState {
       groupNewTabs: this.groupNewTabs,
       groupByMode: this.groupByMode,
       ruleMatchingMode: this.ruleMatchingMode,
-      customRules: this.getCustomRulesObject()
+      customRules: this.getCustomRulesObject(),
+      minimumTabsForGroup: this.minimumTabsForGroup
     }
   }
 


### PR DESCRIPTION
This pull request introduces the "Minimum Tabs Threshold" feature, allowing users to set global and per-rule minimum tab requirements before creating tab groups. It also includes updates to the UI, documentation, and extension version to support this functionality. Below is a summary of the most important changes:

### Feature Implementation
* Added support for global and per-rule minimum tabs thresholds in the `background.js` file, including new actions (`getMinimumTabsForGroup` and `setMinimumTabsForGroup`) to manage the minimum tabs setting. These changes ensure that tab groups are created or disbanded based on the configured thresholds. [[1]](diffhunk://#diff-63f57208366a525675352a112eb1f04ce2635b4aef3b112e708bbd947b4c9aa2R158-R172) [[2]](diffhunk://#diff-3b6043b6cc466ddc4dfe8b4883b62c59fcde14e125a2976d52ade66d626f0a86L17-R18)

### UI Updates
* Updated the popup UI (`popup.html`, `popup.css`, `popup.js`) to include a number input for configuring the global minimum tabs threshold. Added validation and event listeners for user input. [[1]](diffhunk://#diff-5e6583b1945d04f7fa3866eeb2288e95c02b5d3fe447b825c9044549a5893871R378-R420) [[2]](diffhunk://#diff-a2faa8f28da51a2d47ae37c989313c397898e1236046312cbd6909d1887519e9R56-R68) [[3]](diffhunk://#diff-5c6c10f744b3799030586adffa2d1b99bd707b61863a9c0f9b484901932458c7R10) [[4]](diffhunk://#diff-5c6c10f744b3799030586adffa2d1b99bd707b61863a9c0f9b484901932458c7R99-R102) [[5]](diffhunk://#diff-5c6c10f744b3799030586adffa2d1b99bd707b61863a9c0f9b484901932458c7R131-R143)
* Enhanced the rules modal (`rules-modal.html`, `rules-modal.css`, `rules-modal.js`) to allow users to set or override minimum tabs for individual rules. Includes dynamic help text reflecting the current global setting. [[1]](diffhunk://#diff-1c074ff09d3a623cce511c339239bcc2ab09e23b9e60e4c41ae8a6b35a91b276R72-R97) [[2]](diffhunk://#diff-065c1c06de688fbceccae3dae83311d75ae07f467afc1d32a9a413d7ec170833R76-R92) [[3]](diffhunk://#diff-a28bb0f10401ce92fb1b3d5387f1249dd3671562331997f35c76ceba77c62aa2R36) [[4]](diffhunk://#diff-a28bb0f10401ce92fb1b3d5387f1249dd3671562331997f35c76ceba77c62aa2R47-R48) [[5]](diffhunk://#diff-a28bb0f10401ce92fb1b3d5387f1249dd3671562331997f35c76ceba77c62aa2R138-R151) [[6]](diffhunk://#diff-a28bb0f10401ce92fb1b3d5387f1249dd3671562331997f35c76ceba77c62aa2R175-R177) [[7]](diffhunk://#diff-a28bb0f10401ce92fb1b3d5387f1249dd3671562331997f35c76ceba77c62aa2R229-R237)

### Documentation Updates
* Added a detailed test plan for the "Minimum Tabs Threshold" feature in `docs/MINIMUM_TABS_TEST_PLAN.md`, covering various scenarios, edge cases, and regression tests.
* Updated the `README.md` to document the new feature, including an explanation of its functionality, configuration options, and example scenarios. [[1]](diffhunk://#diff-7a10f33fd65f6692603aa7fe85eb9cdb287ed5db10964d2d2cbe651960d7aa63R16) [[2]](diffhunk://#diff-7a10f33fd65f6692603aa7fe85eb9cdb287ed5db10964d2d2cbe651960d7aa63R187-R225)

### Versioning
* Bumped the extension version from `1.5.2` to `1.6.0` in `package.json`, `package-lock.json`, and browser manifest files to reflect the addition of the new feature. [[1]](diffhunk://#diff-ef03613fbffade6992d95fb06d4e0ff84e7e18a09ebcd05e77954fcd6803d142L3-R9) [[2]](diffhunk://#diff-724c34d3e8d728c5e46ea6059b9826c749f8c99c208bb18edbdf1fc6eb52bd63L5-R5) [[3]](diffhunk://#diff-24b32acde46e4c486bac0a333a161b851e531d12a28055b38c64dad79af8f432L5-R5)

### Styling Enhancements
* Added CSS styles for the number input fields in both the popup and rules modal to ensure consistent appearance across browsers. [[1]](diffhunk://#diff-5e6583b1945d04f7fa3866eeb2288e95c02b5d3fe447b825c9044549a5893871R378-R420) [[2]](diffhunk://#diff-1c074ff09d3a623cce511c339239bcc2ab09e23b9e60e4c41ae8a6b35a91b276R72-R97)

These changes collectively enhance the functionality and usability of the extension, providing users with greater control over tab grouping behavior.