### PR TITLE
FIX: Set the pathname to lowercase before processing rules

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-tab-groups",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-tab-groups",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@playwright/test": "^1.53.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/extension/src/manifest.chrome.json
+++ b/extension/src/manifest.chrome.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Auto Tab Groups",
   "author": "Nitzan Papini",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Automatically groups tabs by domain.",
   "permissions": ["tabs", "storage", "tabGroups"],
   "side_panel": {

--- a/extension/src/manifest.firefox.json
+++ b/extension/src/manifest.firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Auto Tab Groups",
   "author": "Nitzan Papini",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Automatically groups tabs by domain.",
   "permissions": ["tabs", "storage", "tabGroups"],
   "browser_specific_settings": {

--- a/extension/src/services/RulesService.js
+++ b/extension/src/services/RulesService.js
@@ -62,7 +62,7 @@ class RulesService {
       // Parse URL to get components
       const url = new URL(tabUrl)
       const domain = url.hostname.toLowerCase()
-      const path = url.pathname
+      const path = url.pathname.toLowerCase()
 
       // Check if pattern includes a path
       const hasPath = cleanRulePattern.includes("/")


### PR DESCRIPTION
When you save rule patterns, they are automatically lower-cased, this means that when we pass in a path that has an uppercase section, it will never match the rule.

In my case, I was trying to create auto tabbing rules based on github organisations which are case sensitive.

You can reproduce this by:
1. Create a rule against a URL that has an upper case **path** (hosts were already being lowercased).
2. You'll notice that the rule's pattern becomes lowercase
3. When this extension checks your open tabs it does a case specific comparison against your lower case pattern - and as a result, your rule never matches

I've done the quick fix here of just lower-casing the path before we pass it on. Perhaps allowing configuring case sensitivity for each rule would make more sense in the future?