### PR TITLE
feat: capitalize domain names in group titles and update related tests

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -335,6 +335,13 @@ export default defineBackground(() => {
     try {
       console.log(`[tabs.onRemoved] Tab ${tabId} removed`)
       await ensureStateLoaded()
+
+      // Check if any groups now fall below the minimum tabs threshold
+      if (tabGroupState.autoGroupingEnabled) {
+        // Small delay to allow browser to fully update tab counts (needed for Firefox)
+        await new Promise(resolve => setTimeout(resolve, 100))
+        await tabGroupService.checkAllGroupsThreshold()
+      }
     } catch (error) {
       console.error(`[tabs.onRemoved] Error handling tab ${tabId} removal:`, error)
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/tests/ColorPersistence.test.ts
+++ b/tests/ColorPersistence.test.ts
@@ -105,7 +105,7 @@ describe("Color Persistence", () => {
     })
 
     it("should use saved color when creating group with same title", async () => {
-      colorMappingState = { example: "cyan" }
+      colorMappingState = { Example: "cyan" }
       mockBrowser.tabs.get.mockResolvedValue({
         id: 1,
         url: "https://example.com",
@@ -126,7 +126,7 @@ describe("Color Persistence", () => {
       expect(mockBrowser.tabGroups.update).toHaveBeenCalledWith(
         100,
         expect.objectContaining({
-          title: "example",
+          title: "Example",
           color: "cyan"
         })
       )
@@ -154,13 +154,13 @@ describe("Color Persistence", () => {
       expect(mockBrowser.tabGroups.update).toHaveBeenCalledWith(
         100,
         expect.objectContaining({
-          title: "newdomain",
+          title: "Newdomain",
           color: expect.any(String)
         })
       )
 
       // Verify updateGroupColor was called to save the color
-      expect(updateGroupColor).toHaveBeenCalledWith("newdomain", expect.any(String))
+      expect(updateGroupColor).toHaveBeenCalledWith("Newdomain", expect.any(String))
     })
 
     it("should not overwrite custom rule colors with saved colors", async () => {

--- a/tests/DomainUtils.test.ts
+++ b/tests/DomainUtils.test.ts
@@ -78,28 +78,28 @@ describe("DomainUtils", () => {
   })
 
   describe("getDomainDisplayName", () => {
-    it("should return display name for simple domain", () => {
-      expect(getDomainDisplayName("example.com")).toBe("example")
+    it("should return capitalized display name for simple domain", () => {
+      expect(getDomainDisplayName("example.com")).toBe("Example")
     })
 
     it('should return "System" for system domain', () => {
       expect(getDomainDisplayName("system")).toBe("System")
     })
 
-    it("should remove www prefix", () => {
-      expect(getDomainDisplayName("www.example.com")).toBe("example")
+    it("should remove www prefix and capitalize", () => {
+      expect(getDomainDisplayName("www.example.com")).toBe("Example")
     })
 
-    it("should handle country code SLDs (co.uk)", () => {
-      expect(getDomainDisplayName("bbc.co.uk")).toBe("bbc")
+    it("should handle country code SLDs (co.uk) and capitalize", () => {
+      expect(getDomainDisplayName("bbc.co.uk")).toBe("Bbc")
     })
 
-    it("should handle country code SLDs (com.au)", () => {
-      expect(getDomainDisplayName("abc.com.au")).toBe("abc")
+    it("should handle country code SLDs (com.au) and capitalize", () => {
+      expect(getDomainDisplayName("abc.com.au")).toBe("Abc")
     })
 
-    it("should handle subdomains with ccSLDs", () => {
-      expect(getDomainDisplayName("news.bbc.co.uk")).toBe("news.bbc")
+    it("should handle subdomains with ccSLDs and capitalize", () => {
+      expect(getDomainDisplayName("news.bbc.co.uk")).toBe("News.bbc")
     })
 
     it("should capitalize single word domains", () => {

--- a/tests/TabGroupService.test.ts
+++ b/tests/TabGroupService.test.ts
@@ -476,7 +476,7 @@ describe("TabGroupService", () => {
           { id: 3, url: "https://example.com", pinned: false }
         ])
 
-        const count = await tabGroupService.countTabsForGroup("example", 1, null)
+        const count = await tabGroupService.countTabsForGroup("Example", 1, null)
 
         // Should be 2 (excludes pinned tab)
         expect(count).toBe(2)
@@ -488,7 +488,7 @@ describe("TabGroupService", () => {
           { id: 2, url: "https://example.com", pinned: true }
         ])
 
-        const count = await tabGroupService.countTabsForGroup("example", 1, null)
+        const count = await tabGroupService.countTabsForGroup("Example", 1, null)
 
         expect(count).toBe(0)
       })

--- a/tests/e2e/auto-collapse.e2e.ts
+++ b/tests/e2e/auto-collapse.e2e.ts
@@ -104,9 +104,9 @@ test.describe("Auto-Collapse Feature", () => {
     const tab3 = await createTab(context, TEST_URLS.domain3)
 
     // Wait for groups to be created
-    await waitForGroup(popupPage, "example")
-    await waitForGroup(popupPage, "httpbin")
-    await waitForGroup(popupPage, "typicode")
+    await waitForGroup(popupPage, "Example")
+    await waitForGroup(popupPage, "Httpbin")
+    await waitForGroup(popupPage, "Typicode")
 
     // Expand all groups first
     await expandAllGroups(popupPage)
@@ -163,8 +163,8 @@ test.describe("Auto-Collapse Feature", () => {
     const tab2 = await createTab(context, TEST_URLS.domain2)
 
     // Wait for groups
-    await waitForGroup(popupPage, "example")
-    await waitForGroup(popupPage, "httpbin")
+    await waitForGroup(popupPage, "Example")
+    await waitForGroup(popupPage, "Httpbin")
 
     // Expand all groups
     await expandAllGroups(popupPage)
@@ -200,8 +200,8 @@ test.describe("Auto-Collapse Feature", () => {
     const tab2 = await createTab(context, TEST_URLS.domain2)
 
     // Wait for groups
-    await waitForGroup(popupPage, "example")
-    await waitForGroup(popupPage, "httpbin")
+    await waitForGroup(popupPage, "Example")
+    await waitForGroup(popupPage, "Httpbin")
 
     // Expand all
     await expandAllGroups(popupPage)
@@ -239,8 +239,8 @@ test.describe("Auto-Collapse Feature", () => {
     const tab2 = await createTab(context, TEST_URLS.domain2)
 
     // Wait for groups
-    await waitForGroup(popupPage, "example")
-    await waitForGroup(popupPage, "httpbin")
+    await waitForGroup(popupPage, "Example")
+    await waitForGroup(popupPage, "Httpbin")
 
     // Collapse all groups first
     await popupPage.evaluate(async () => {

--- a/tests/e2e/auto-grouping.e2e.ts
+++ b/tests/e2e/auto-grouping.e2e.ts
@@ -70,8 +70,8 @@ test.afterEach(async () => {
 })
 
 test.describe("Auto-Grouping Toggle", () => {
-  // Note: The extension strips TLDs from domain names for group titles
-  // e.g., "example.com" -> "example", "httpbin.org" -> "httpbin"
+  // Note: The extension strips TLDs and capitalizes domain names for group titles
+  // e.g., "example.com" -> "Example", "httpbin.org" -> "Httpbin"
 
   test("groups tabs automatically when auto-group is enabled", async () => {
     // Enable auto-grouping first
@@ -86,11 +86,11 @@ test.describe("Auto-Grouping Toggle", () => {
     const tab2 = await createTab(context, TEST_URLS.domain1Page2)
 
     // Wait for automatic grouping (TLD stripped)
-    await waitForTabInGroup(popupPage, "example.com", "example")
+    await waitForTabInGroup(popupPage, "example.com", "Example")
 
     // Verify group was created
     const groups = await getTabGroups(popupPage)
-    expect(groups.some(g => g.title === "example")).toBe(true)
+    expect(groups.some(g => g.title === "Example")).toBe(true)
 
     // Cleanup
     await tab1.close()
@@ -141,20 +141,20 @@ test.describe("Auto-Grouping Toggle", () => {
     // Verify no groups with our test domains initially
     await popupPage.waitForTimeout(500)
     let groups = await getTabGroups(popupPage)
-    expect(groups.some(g => g.title === "example")).toBe(false)
-    expect(groups.some(g => g.title === "httpbin")).toBe(false)
+    expect(groups.some(g => g.title === "Example")).toBe(false)
+    expect(groups.some(g => g.title === "Httpbin")).toBe(false)
 
     // Click the Group button to manually group tabs
     await groupAllTabs(popupPage)
 
     // Wait for groups to be created (TLDs stripped)
-    await waitForGroup(popupPage, "example")
-    await waitForGroup(popupPage, "httpbin")
+    await waitForGroup(popupPage, "Example")
+    await waitForGroup(popupPage, "Httpbin")
 
     // Verify our expected groups were created (may have additional system groups)
     groups = await getTabGroups(popupPage)
-    expect(groups.some(g => g.title === "example")).toBe(true)
-    expect(groups.some(g => g.title === "httpbin")).toBe(true)
+    expect(groups.some(g => g.title === "Example")).toBe(true)
+    expect(groups.some(g => g.title === "Httpbin")).toBe(true)
 
     // Cleanup
     await tab1.close()
@@ -169,13 +169,13 @@ test.describe("Auto-Grouping Toggle", () => {
     const tab2 = await createTab(context, TEST_URLS.domain2)
 
     // Wait for groups to be created (TLDs stripped)
-    await waitForGroup(popupPage, "example")
-    await waitForGroup(popupPage, "httpbin")
+    await waitForGroup(popupPage, "Example")
+    await waitForGroup(popupPage, "Httpbin")
 
     // Verify our expected groups exist
     let groups = await getTabGroups(popupPage)
-    expect(groups.some(g => g.title === "example")).toBe(true)
-    expect(groups.some(g => g.title === "httpbin")).toBe(true)
+    expect(groups.some(g => g.title === "Example")).toBe(true)
+    expect(groups.some(g => g.title === "Httpbin")).toBe(true)
 
     // Disable auto-group first to prevent re-grouping
     await disableAutoGroup(popupPage)

--- a/tests/e2e/custom-rules.e2e.ts
+++ b/tests/e2e/custom-rules.e2e.ts
@@ -117,9 +117,9 @@ test.describe("Custom Rules", () => {
     expect(matchingTabs.length).toBe(2)
     expect(matchingTabs.every(t => t.groupId === ruleGroup?.id)).toBe(true)
 
-    // Verify no separate domain groups were created
-    const exampleGroup = groups.find(g => g.title === "example")
-    const httpbinGroup = groups.find(g => g.title === "httpbin")
+    // Verify no separate domain groups were created (domain groups would be capitalized)
+    const exampleGroup = groups.find(g => g.title === "Example")
+    const httpbinGroup = groups.find(g => g.title === "Httpbin")
     expect(exampleGroup).toBeUndefined()
     expect(httpbinGroup).toBeUndefined()
 
@@ -173,12 +173,12 @@ test.describe("Custom Rules", () => {
     // Create a tab to example.com
     const tab = await createTab(context, TEST_URLS.domain1)
 
-    // Should be grouped by domain (TLD stripped), not rule (since rule is disabled)
-    await waitForGroup(popupPage, "example")
+    // Should be grouped by domain (TLD stripped, capitalized), not rule (since rule is disabled)
+    await waitForGroup(popupPage, "Example")
 
     // Verify the group is named by domain, not the disabled rule
     const groups = await getTabGroups(popupPage)
-    const domainGroup = groups.find(g => g.title === "example")
+    const domainGroup = groups.find(g => g.title === "Example")
     const ruleGroup = groups.find(g => g.title === "Disabled Rule")
 
     expect(domainGroup).toBeDefined()
@@ -215,12 +215,12 @@ test.describe("Custom Rules", () => {
     // Wait for the regrouping to happen
     await popupPage.waitForTimeout(1000)
 
-    // Since auto-group is on and rule is deleted, tabs should regroup by domain (TLD stripped)
-    await waitForGroup(popupPage, "example")
+    // Since auto-group is on and rule is deleted, tabs should regroup by domain (TLD stripped, capitalized)
+    await waitForGroup(popupPage, "Example")
 
     // Verify the tab is now grouped by domain
     groups = await getTabGroups(popupPage)
-    const domainGroup = groups.find(g => g.title === "example")
+    const domainGroup = groups.find(g => g.title === "Example")
     const ruleGroup = groups.find(g => g.title === "Temp Rule")
 
     expect(domainGroup).toBeDefined()

--- a/tests/e2e/group-operations.e2e.ts
+++ b/tests/e2e/group-operations.e2e.ts
@@ -67,8 +67,8 @@ test.afterEach(async () => {
 })
 
 test.describe("Group Operations - Collapse/Expand", () => {
-  // Note: The extension strips TLDs from domain names for group titles
-  // e.g., "example.com" -> "example", "httpbin.org" -> "httpbin"
+  // Note: The extension strips TLDs and capitalizes first letter for group titles
+  // e.g., "example.com" -> "Example", "httpbin.org" -> "Httpbin"
 
   test("collapse all groups", async () => {
     await enableAutoGroup(popupPage)
@@ -78,16 +78,16 @@ test.describe("Group Operations - Collapse/Expand", () => {
     const tab2 = await createTab(context, TEST_URLS.domain2)
     const tab3 = await createTab(context, TEST_URLS.domain3)
 
-    // Wait for groups to be created (TLDs stripped)
-    await waitForGroup(popupPage, "example")
-    await waitForGroup(popupPage, "httpbin")
-    await waitForGroup(popupPage, "typicode")
+    // Wait for groups to be created (TLDs stripped, capitalized)
+    await waitForGroup(popupPage, "Example")
+    await waitForGroup(popupPage, "Httpbin")
+    await waitForGroup(popupPage, "Typicode")
 
     // Verify expected groups exist
     let groups = await getTabGroups(popupPage)
-    expect(groups.some(g => g.title === "example")).toBe(true)
-    expect(groups.some(g => g.title === "httpbin")).toBe(true)
-    expect(groups.some(g => g.title === "typicode")).toBe(true)
+    expect(groups.some(g => g.title === "Example")).toBe(true)
+    expect(groups.some(g => g.title === "Httpbin")).toBe(true)
+    expect(groups.some(g => g.title === "Typicode")).toBe(true)
     expect(groups.length).toBeGreaterThanOrEqual(3)
 
     // Expand all first to have a known state
@@ -121,9 +121,9 @@ test.describe("Group Operations - Collapse/Expand", () => {
     const tab1 = await createTab(context, TEST_URLS.domain1)
     const tab2 = await createTab(context, TEST_URLS.domain2)
 
-    // Wait for groups (TLDs stripped)
-    await waitForGroup(popupPage, "example")
-    await waitForGroup(popupPage, "httpbin")
+    // Wait for groups (TLDs stripped, capitalized)
+    await waitForGroup(popupPage, "Example")
+    await waitForGroup(popupPage, "Httpbin")
 
     // Collapse all first
     await collapseAllGroups(popupPage)
@@ -154,9 +154,9 @@ test.describe("Group Operations - Collapse/Expand", () => {
     const tab1 = await createTab(context, TEST_URLS.domain1)
     const tab2 = await createTab(context, TEST_URLS.domain2)
 
-    // Wait for groups (TLDs stripped)
-    await waitForGroup(popupPage, "example")
-    await waitForGroup(popupPage, "httpbin")
+    // Wait for groups (TLDs stripped, capitalized)
+    await waitForGroup(popupPage, "Example")
+    await waitForGroup(popupPage, "Httpbin")
 
     // Expand all to start from known state
     await expandAllGroups(popupPage)

--- a/tests/e2e/tab-grouping.e2e.ts
+++ b/tests/e2e/tab-grouping.e2e.ts
@@ -72,8 +72,8 @@ test.afterEach(async () => {
 })
 
 test.describe("Tab Grouping by Domain", () => {
-  // Note: The extension strips TLDs from domain names for group titles
-  // e.g., "example.com" -> "example", "httpbin.org" -> "httpbin"
+  // Note: The extension strips TLDs and capitalizes domain names for group titles
+  // e.g., "example.com" -> "Example", "httpbin.org" -> "Httpbin"
 
   test("groups tabs from same domain into one group", async () => {
     // Enable auto-grouping
@@ -84,12 +84,12 @@ test.describe("Tab Grouping by Domain", () => {
     const tab2 = await createTab(context, TEST_URLS.domain1Page2)
     const tab3 = await createTab(context, TEST_URLS.domain1Page3)
 
-    // Wait for all tabs to be grouped under "example" (TLD stripped)
-    await waitForTabInGroup(popupPage, "example.com", "example")
+    // Wait for all tabs to be grouped under "Example" (TLD stripped, capitalized)
+    await waitForTabInGroup(popupPage, "example.com", "Example")
 
     // Verify there's only one group
     const groups = await getTabGroups(popupPage)
-    const exampleGroup = groups.find(g => g.title === "example")
+    const exampleGroup = groups.find(g => g.title === "Example")
     expect(exampleGroup).toBeDefined()
 
     // Verify all tabs are in the same group
@@ -113,14 +113,14 @@ test.describe("Tab Grouping by Domain", () => {
     const tab1 = await createTab(context, TEST_URLS.domain1)
     const tab2 = await createTab(context, TEST_URLS.domain2)
 
-    // Wait for groups to be created (TLDs stripped)
-    await waitForGroup(popupPage, "example")
-    await waitForGroup(popupPage, "httpbin")
+    // Wait for groups to be created (TLDs stripped, capitalized)
+    await waitForGroup(popupPage, "Example")
+    await waitForGroup(popupPage, "Httpbin")
 
     // Verify expected groups exist (may have additional system groups)
     const groups = await getTabGroups(popupPage)
-    expect(groups.some(g => g.title === "example")).toBe(true)
-    expect(groups.some(g => g.title === "httpbin")).toBe(true)
+    expect(groups.some(g => g.title === "Example")).toBe(true)
+    expect(groups.some(g => g.title === "Httpbin")).toBe(true)
 
     // Verify tabs are in separate groups
     const tabs = await getTabs(popupPage)
@@ -144,12 +144,12 @@ test.describe("Tab Grouping by Domain", () => {
     // Create a tab to a ccSLD domain
     const tab = await createTab(context, TEST_URLS.ccSLD)
 
-    // Wait for the group - should be "bbc" (ccSLD .co.uk stripped correctly)
-    await waitForGroup(popupPage, "bbc")
+    // Wait for the group - should be "Bbc" (ccSLD .co.uk stripped correctly, capitalized)
+    await waitForGroup(popupPage, "Bbc")
 
     // Verify the group title
     const groups = await getTabGroups(popupPage)
-    const bbcGroup = groups.find(g => g.title === "bbc")
+    const bbcGroup = groups.find(g => g.title === "Bbc")
     expect(bbcGroup).toBeDefined()
 
     // Verify no "co" or "co.uk" group was created
@@ -165,7 +165,7 @@ test.describe("Tab Grouping by Domain", () => {
 
     // Create a tab and wait for it to be grouped
     const tab = await createTab(context, TEST_URLS.domain1)
-    await waitForTabInGroup(popupPage, "example.com", "example")
+    await waitForTabInGroup(popupPage, "example.com", "Example")
 
     // Pin the tab
     await pinTab(popupPage, "example.com")
@@ -202,14 +202,14 @@ test.describe("Tab Grouping by Domain", () => {
     const tab2 = await createTab(context, TEST_URLS.subDomain2) // docs.github.com
 
     // Wait for groups to be created - in subdomain mode, full subdomain is used
-    // Group titles strip TLD: "api.github.com" -> "api.github", "docs.github.com" -> "docs.github"
-    await waitForGroup(popupPage, "api.github")
-    await waitForGroup(popupPage, "docs.github")
+    // Group titles strip TLD and capitalize: "api.github.com" -> "Api.github", "docs.github.com" -> "Docs.github"
+    await waitForGroup(popupPage, "Api.github")
+    await waitForGroup(popupPage, "Docs.github")
 
     // Verify there are 2 separate groups
     const groups = await getTabGroups(popupPage)
-    const apiGroup = groups.find(g => g.title === "api.github")
-    const docsGroup = groups.find(g => g.title === "docs.github")
+    const apiGroup = groups.find(g => g.title === "Api.github")
+    const docsGroup = groups.find(g => g.title === "Docs.github")
 
     expect(apiGroup).toBeDefined()
     expect(docsGroup).toBeDefined()

--- a/utils/DomainUtils.ts
+++ b/utils/DomainUtils.ts
@@ -172,8 +172,13 @@ export function getDomainDisplayName(domain: string): string {
 
     const displayName = displayParts.join(".")
 
+    // Capitalize first letter of display name
+    if (displayName) {
+      return displayName.charAt(0).toUpperCase() + displayName.slice(1)
+    }
+
     // If we end up with an empty string, return the original domain
-    return displayName || domain
+    return domain
   } catch {
     return domain // Fallback to original domain if error occurs
   }


### PR DESCRIPTION
This pull request primarily updates the logic and tests to ensure that tab group titles derived from domain names are capitalized (e.g., "example.com" now becomes "Example" instead of "example"). It also improves the handling of group thresholds after tab removal and updates related documentation and tests for consistency.

**Domain Group Title Capitalization:**

* All references to domain-derived group titles are updated to capitalize the first letter (e.g., "example" → "Example") throughout the codebase and tests, ensuring consistency in group naming. [[1]](diffhunk://#diff-434f001bf2ab0c2b2c7aead342eff69be091679a55b2a1cacbb9ca567959b295L108-R108) [[2]](diffhunk://#diff-434f001bf2ab0c2b2c7aead342eff69be091679a55b2a1cacbb9ca567959b295L129-R129) [[3]](diffhunk://#diff-434f001bf2ab0c2b2c7aead342eff69be091679a55b2a1cacbb9ca567959b295L157-R163) [[4]](diffhunk://#diff-1e66e8d152f7800295b2f4c29b3a9fdb1be6cfffd8196086bdb748417615c745L81-R102) [[5]](diffhunk://#diff-4f0c2ad77d2ae8e870d09132c4ae206e7ac8ffcadfd2e002142face179b2d524L479-R479) [[6]](diffhunk://#diff-4f0c2ad77d2ae8e870d09132c4ae206e7ac8ffcadfd2e002142face179b2d524L491-R491) [[7]](diffhunk://#diff-0752d6861123b97c7cd2a1c9e55bde4e5f3970a79a87eb49da35b897ec54013fL107-R109) [[8]](diffhunk://#diff-0752d6861123b97c7cd2a1c9e55bde4e5f3970a79a87eb49da35b897ec54013fL166-R167) [[9]](diffhunk://#diff-0752d6861123b97c7cd2a1c9e55bde4e5f3970a79a87eb49da35b897ec54013fL203-R204) [[10]](diffhunk://#diff-0752d6861123b97c7cd2a1c9e55bde4e5f3970a79a87eb49da35b897ec54013fL242-R243) [[11]](diffhunk://#diff-51b32bf310ab31cb3304fff07d4a767da32b28d5c74b3fda5739eed552fe88d1L73-R74) [[12]](diffhunk://#diff-51b32bf310ab31cb3304fff07d4a767da32b28d5c74b3fda5739eed552fe88d1L89-R93) [[13]](diffhunk://#diff-51b32bf310ab31cb3304fff07d4a767da32b28d5c74b3fda5739eed552fe88d1L144-R157) [[14]](diffhunk://#diff-51b32bf310ab31cb3304fff07d4a767da32b28d5c74b3fda5739eed552fe88d1L172-R178) [[15]](diffhunk://#diff-64d3163e4998d01c3ee47a235073f404594949ff9aaa68b8be8be2dda5292cb4L120-R122) [[16]](diffhunk://#diff-64d3163e4998d01c3ee47a235073f404594949ff9aaa68b8be8be2dda5292cb4L176-R181) [[17]](diffhunk://#diff-64d3163e4998d01c3ee47a235073f404594949ff9aaa68b8be8be2dda5292cb4L218-R223) [[18]](diffhunk://#diff-0927abca3fb07ea6c74716d2cf68ed301bc190dcd4b50fe35f3e0aa3c906fb03L70-R71) [[19]](diffhunk://#diff-0927abca3fb07ea6c74716d2cf68ed301bc190dcd4b50fe35f3e0aa3c906fb03L81-R90) [[20]](diffhunk://#diff-0927abca3fb07ea6c74716d2cf68ed301bc190dcd4b50fe35f3e0aa3c906fb03L124-R126) [[21]](diffhunk://#diff-0927abca3fb07ea6c74716d2cf68ed301bc190dcd4b50fe35f3e0aa3c906fb03L157-R159) [[22]](diffhunk://#diff-838c25c6aa63893c83e20237e6cb5cc4900a518e6ea8373bd11f53449c6ea7fdL109-R110) [[23]](diffhunk://#diff-838c25c6aa63893c83e20237e6cb5cc4900a518e6ea8373bd11f53449c6ea7fdL163-R169) [[24]](diffhunk://#diff-838c25c6aa63893c83e20237e6cb5cc4900a518e6ea8373bd11f53449c6ea7fdL195-R196)

**Behavioral Improvements:**

* After a tab is removed, the extension now checks if any groups fall below the minimum tabs threshold (with a short delay for browser consistency), ensuring groups are updated or removed as needed.

**Documentation and Versioning:**

* Updated comments in code and tests to clarify that group titles are now capitalized after stripping TLDs. [[1]](diffhunk://#diff-51b32bf310ab31cb3304fff07d4a767da32b28d5c74b3fda5739eed552fe88d1L73-R74) [[2]](diffhunk://#diff-0927abca3fb07ea6c74716d2cf68ed301bc190dcd4b50fe35f3e0aa3c906fb03L70-R71) [[3]](diffhunk://#diff-838c25c6aa63893c83e20237e6cb5cc4900a518e6ea8373bd11f53449c6ea7fdL109-R110)
* Bumped the extension version from 2.1.7 to 2.1.8 in `package.json`.