### PR TITLE
fix: update tab grouping logic for system URLs and enhance related tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/public/fonts/inter.css
+++ b/public/fonts/inter.css
@@ -1,15 +1,15 @@
 @font-face {
-  font-family: 'Inter';
+  font-family: "Inter";
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/fonts/Inter-Regular.woff2') format('woff2');
+  src: url("/fonts/Inter-Regular.woff2") format("woff2");
 }
 
 @font-face {
-  font-family: 'Inter';
+  font-family: "Inter";
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: url('/fonts/Inter-SemiBold.woff2') format('woff2');
+  src: url("/fonts/Inter-SemiBold.woff2") format("woff2");
 }

--- a/services/TabGroupService.ts
+++ b/services/TabGroupService.ts
@@ -54,12 +54,15 @@ class TabGroupServiceSimplified {
       const tab = await browser.tabs.get(tabId)
       console.log(`[TabGroupService] Tab URL: ${tab.url}`)
 
-      // Check if this is a new tab URL and user has disabled grouping new tabs
-      if (!forceGrouping && !tabGroupState.groupNewTabs && tab.url && this.isNewTabUrl(tab.url)) {
-        console.log(
-          `[TabGroupService] Tab ${tabId} has a new tab URL and grouping new tabs is disabled`
-        )
-        return false
+      // Check if this is a system URL and user has disabled grouping system tabs
+      if (!forceGrouping && !tabGroupState.groupNewTabs) {
+        const domain = extractDomain(tab.url || "", false)
+        if (domain === "system") {
+          console.log(
+            `[TabGroupService] Tab ${tabId} has a system URL and grouping system tabs is disabled`
+          )
+          return false
+        }
       }
 
       // Skip pinned tabs
@@ -146,9 +149,10 @@ class TabGroupServiceSimplified {
             count++
           }
         } else {
-          // Handle empty/undefined URLs and new tab URLs as System tabs
+          // Handle empty/undefined URLs and system URLs as System tabs
           if (expectedTitle === "System") {
-            if (!tab.url || tab.url === "" || this.isNewTabUrl(tab.url)) {
+            const tabDomain = extractDomain(tab.url || "", false)
+            if (!tab.url || tab.url === "" || tabDomain === "system") {
               count++
               continue
             }
@@ -404,9 +408,10 @@ class TabGroupServiceSimplified {
             continue
           }
 
-          // For new tab URLs, respect the groupNewTabs setting
-          if (this.isNewTabUrl(tab.url) && !tabGroupState.groupNewTabs) {
-            console.log(`[TabGroupService] Skipping new tab ${tab.id} - groupNewTabs disabled`)
+          // For system URLs, respect the groupNewTabs setting
+          const domain = extractDomain(tab.url, false)
+          if (domain === "system" && !tabGroupState.groupNewTabs) {
+            console.log(`[TabGroupService] Skipping system tab ${tab.id} - groupNewTabs disabled`)
             continue
           }
 


### PR DESCRIPTION
This pull request refines how the extension identifies and handles "system" tabs (such as `chrome://` and `about:` URLs) when grouping tabs, especially in relation to the `groupNewTabs` user setting. It updates the logic for system tab detection, ensures consistent handling across both automatic and manual grouping, and adds comprehensive tests for these scenarios.

**System Tab Handling Improvements:**

* Updated logic in `TabGroupService.ts` to consistently treat system URLs (e.g., `chrome://settings/`, `about:config`) as "system" tabs, and to respect the `groupNewTabs` setting when deciding whether to group them. This replaces the previous logic that only checked for new tab URLs. [[1]](diffhunk://#diff-327682d8abbe23122d2e339315544a2bea215c955236a57e1914f2905be28a25L57-R66) [[2]](diffhunk://#diff-327682d8abbe23122d2e339315544a2bea215c955236a57e1914f2905be28a25L149-R155) [[3]](diffhunk://#diff-327682d8abbe23122d2e339315544a2bea215c955236a57e1914f2905be28a25L407-R414)

**Testing Enhancements:**

* Added new test cases in `TabGroupService.test.ts` to verify that system tabs are correctly skipped or grouped based on the `groupNewTabs` setting, both for automatic and manual grouping. [[1]](diffhunk://#diff-4f0c2ad77d2ae8e870d09132c4ae206e7ac8ffcadfd2e002142face179b2d524R74-R183) [[2]](diffhunk://#diff-4f0c2ad77d2ae8e870d09132c4ae206e7ac8ffcadfd2e002142face179b2d524R480-R527)
* Added tests to ensure that the counting of tabs for the "System" group correctly includes system URLs and empty/undefined URLs.

**Other Changes:**

* Minor formatting updates in `public/fonts/inter.css` for consistency (switching to double quotes).
* Bumped the extension version to `2.1.10` in `package.json`.