### PR TITLE
feat: implement tab repositioning next to opener within the same group

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -670,6 +670,9 @@ export default defineBackground(() => {
   browser.tabs.onCreated.addListener(async tab => {
     try {
       console.log(`[tabs.onCreated] Tab ${tab.id} created with URL: ${tab.url}`)
+      if (tab.id) {
+        tabGroupService.markAsNewTab(tab.id)
+      }
       if (tab.url && tab.id) {
         await ensureStateLoaded()
         await tabGroupService.handleTabUpdate(tab.id)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -10,7 +10,8 @@ const mockBrowser = {
     get: vi.fn().mockResolvedValue({}),
     group: vi.fn().mockResolvedValue(1),
     ungroup: vi.fn().mockResolvedValue(undefined),
-    update: vi.fn().mockResolvedValue({})
+    update: vi.fn().mockResolvedValue({}),
+    move: vi.fn().mockResolvedValue({})
   },
   tabGroups: {
     query: vi.fn().mockResolvedValue([]),


### PR DESCRIPTION
This pull request introduces a new feature that improves the user experience by ensuring that newly created tabs are positioned directly after their opener tab within the same group, when possible. It also adds comprehensive tests for this behavior and increments the package version. The main changes are grouped below by theme.

**Feature: Tab Positioning Next to Opener**

* Added logic in `TabGroupServiceSimplified` to track newly created tabs and reposition them directly after their opener tab within the same group, enhancing tab organization. This is achieved using a new `recentlyCreatedTabIds` set, `markAsNewTab`, and `repositionTabNextToOpener` methods. [[1]](diffhunk://#diff-327682d8abbe23122d2e339315544a2bea215c955236a57e1914f2905be28a25R22-R31) [[2]](diffhunk://#diff-327682d8abbe23122d2e339315544a2bea215c955236a57e1914f2905be28a25R830-R852)
* Updated the background script to mark new tabs as "new" when created, enabling the repositioning logic.
* Integrated the repositioning step into the tab grouping workflow, ensuring it occurs both when a tab is newly grouped and when it's already in the correct group. [[1]](diffhunk://#diff-327682d8abbe23122d2e339315544a2bea215c955236a57e1914f2905be28a25R208-R210) [[2]](diffhunk://#diff-327682d8abbe23122d2e339315544a2bea215c955236a57e1914f2905be28a25R222-R224)

**Testing Improvements**

* Added a comprehensive test suite to verify tab positioning behavior, including edge cases such as missing opener, opener in a different group, opener closed, and persistent move failures.
* Updated test setup to mock the `tabs.move` browser API.

**Versioning**

* Bumped the package version to `3.0.3` to reflect the new feature.

## Fixes issue #32 