### PR TITLE
feat: make "open tab next to current" opt-in with toggle

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -202,6 +202,16 @@ export default defineBackground(() => {
             result = { minimumTabs: tabGroupState.minimumTabsForGroup }
             break
 
+          case "getOpenTabNextToCurrent":
+            result = { enabled: tabGroupState.openTabNextToCurrent }
+            break
+
+          case "toggleOpenTabNextToCurrent":
+            tabGroupState.openTabNextToCurrent = msg.enabled
+            await saveState()
+            result = { enabled: tabGroupState.openTabNextToCurrent }
+            break
+
           // Custom Rules Management
           case "getCustomRules": {
             const rules = await rulesService.getCustomRules()

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -92,6 +92,13 @@
         <div class="help-text collapse-help" id="collapseHelp">
           0 = immediate, or set delay (100-5000ms) before collapsing
         </div>
+        <div class="toggle-container">
+          <span>Open new tabs next to current tab</span>
+          <label class="switch">
+            <input type="checkbox" id="openTabNextToCurrentToggle" />
+            <span class="slider round"></span>
+          </label>
+        </div>
         <div class="settings-info">
           <span class="info-icon">&#128204;</span>
           <span>Pinned tabs are never grouped automatically</span>

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -20,6 +20,11 @@ const collapseDelayContainer = document.getElementById("collapseDelayContainer")
 const collapseDelayInput = document.getElementById("collapseDelayInput") as HTMLInputElement
 const collapseHelp = document.getElementById("collapseHelp") as HTMLDivElement
 
+// Tab Positioning Elements
+const openTabNextToCurrentToggle = document.getElementById(
+  "openTabNextToCurrentToggle"
+) as HTMLInputElement
+
 // Custom Rules Elements
 const rulesToggle = document.querySelector(".rules-toggle") as HTMLButtonElement
 const rulesContent = document.querySelector(".rules-content") as HTMLDivElement
@@ -440,6 +445,11 @@ sendMessage<{ enabled?: boolean; delayMs?: number }>({
   updateCollapseDelayVisibility(enabled)
 })
 
+// Initialize open tab next to current state
+sendMessage<{ enabled?: boolean }>({ action: "getOpenTabNextToCurrent" }).then(response => {
+  openTabNextToCurrentToggle.checked = response?.enabled ?? false
+})
+
 // Toggle event listeners
 autoGroupToggle.addEventListener("change", event => {
   sendMessage({
@@ -497,6 +507,14 @@ collapseDelayInput.addEventListener("change", async () => {
     action: "updateAutoCollapse",
     autoCollapseEnabled: autoCollapseToggle.checked,
     autoCollapseDelayMs: delayMs
+  })
+})
+
+// Open tab next to current event listener
+openTabNextToCurrentToggle.addEventListener("change", event => {
+  sendMessage({
+    action: "toggleOpenTabNextToCurrent",
+    enabled: (event.target as HTMLInputElement).checked
   })
 })
 

--- a/entrypoints/sidebar/index.html
+++ b/entrypoints/sidebar/index.html
@@ -93,6 +93,13 @@
           <div class="help-text collapse-help" id="collapseHelp">
             0 = immediate, or set delay (100-5000ms) before collapsing
           </div>
+          <div class="toggle-container">
+            <span>Open new tabs next to current tab</span>
+            <label class="switch">
+              <input type="checkbox" id="openTabNextToCurrentToggle" />
+              <span class="slider round"></span>
+            </label>
+          </div>
           <div class="settings-info">
             <span class="info-icon">&#128204;</span>
             <span>Pinned tabs are never grouped automatically</span>

--- a/entrypoints/sidebar/main.ts
+++ b/entrypoints/sidebar/main.ts
@@ -21,6 +21,11 @@ const collapseDelayContainer = document.getElementById("collapseDelayContainer")
 const collapseDelayInput = document.getElementById("collapseDelayInput") as HTMLInputElement
 const collapseHelp = document.getElementById("collapseHelp") as HTMLDivElement
 
+// Tab Positioning Elements
+const openTabNextToCurrentToggle = document.getElementById(
+  "openTabNextToCurrentToggle"
+) as HTMLInputElement
+
 // Custom Rules Elements
 const rulesToggle = document.querySelector(".rules-toggle") as HTMLButtonElement
 const rulesContent = document.querySelector(".rules-content") as HTMLDivElement
@@ -484,6 +489,11 @@ sendMessage<{ enabled?: boolean; delayMs?: number }>({
   updateCollapseDelayVisibility(enabled)
 })
 
+// Initialize open tab next to current state
+sendMessage<{ enabled?: boolean }>({ action: "getOpenTabNextToCurrent" }).then(response => {
+  openTabNextToCurrentToggle.checked = response?.enabled ?? false
+})
+
 // Toggle event listeners
 autoGroupToggle.addEventListener("change", event => {
   sendMessage({
@@ -541,6 +551,14 @@ collapseDelayInput.addEventListener("change", async () => {
     action: "updateAutoCollapse",
     autoCollapseEnabled: autoCollapseToggle.checked,
     autoCollapseDelayMs: delayMs
+  })
+})
+
+// Open tab next to current event listener
+openTabNextToCurrentToggle.addEventListener("change", event => {
+  sendMessage({
+    action: "toggleOpenTabNextToCurrent",
+    enabled: (event.target as HTMLInputElement).checked
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/services/TabGroupService.ts
+++ b/services/TabGroupService.ts
@@ -222,7 +222,7 @@ class TabGroupServiceSimplified {
     if (existingGroup) {
       if (tab.groupId === existingGroup.id) {
         console.log(`[TabGroupService] Tab ${tabId} already in correct group`)
-        if (this.consumeNewTabFlag(tabId)) {
+        if (this.consumeNewTabFlag(tabId) && tabGroupState.openTabNextToCurrent) {
           await this.repositionTabNextToOpener(tabId, tab, existingGroup.id)
         }
         return true
@@ -237,7 +237,9 @@ class TabGroupServiceSimplified {
       )
 
       this.consumeNewTabFlag(tabId)
-      await this.repositionTabNextToOpener(tabId, tab, existingGroup.id)
+      if (tabGroupState.openTabNextToCurrent) {
+        await this.repositionTabNextToOpener(tabId, tab, existingGroup.id)
+      }
 
       // Update color if from custom rule
       if (customRule?.color && existingGroup.color !== customRule.color) {

--- a/services/TabGroupState.ts
+++ b/services/TabGroupState.ts
@@ -21,6 +21,7 @@ class TabGroupState {
   minimumTabsForGroup: number
   autoCollapseEnabled: boolean
   autoCollapseDelayMs: number
+  openTabNextToCurrent: boolean
 
   constructor() {
     this.autoGroupingEnabled = DEFAULT_STATE.autoGroupingEnabled
@@ -31,6 +32,7 @@ class TabGroupState {
     this.minimumTabsForGroup = DEFAULT_STATE.minimumTabsForGroup
     this.autoCollapseEnabled = DEFAULT_STATE.autoCollapseEnabled
     this.autoCollapseDelayMs = DEFAULT_STATE.autoCollapseDelayMs
+    this.openTabNextToCurrent = DEFAULT_STATE.openTabNextToCurrent
   }
 
   /**
@@ -44,6 +46,7 @@ class TabGroupState {
     this.minimumTabsForGroup = data.minimumTabsForGroup ?? this.minimumTabsForGroup
     this.autoCollapseEnabled = data.autoCollapseEnabled ?? this.autoCollapseEnabled
     this.autoCollapseDelayMs = data.autoCollapseDelayMs ?? this.autoCollapseDelayMs
+    this.openTabNextToCurrent = data.openTabNextToCurrent ?? this.openTabNextToCurrent
 
     this.customRules.clear()
 
@@ -68,6 +71,7 @@ class TabGroupState {
       minimumTabsForGroup: this.minimumTabsForGroup,
       autoCollapseEnabled: this.autoCollapseEnabled,
       autoCollapseDelayMs: this.autoCollapseDelayMs,
+      openTabNextToCurrent: this.openTabNextToCurrent,
       // AI settings managed by AiService, pass defaults for storage schema
       aiEnabled: DEFAULT_STATE.aiEnabled,
       aiProvider: DEFAULT_STATE.aiProvider,

--- a/tests/TabGroupService.test.ts
+++ b/tests/TabGroupService.test.ts
@@ -845,7 +845,11 @@ describe("TabGroupService", () => {
   describe("tab positioning next to opener", () => {
     beforeEach(() => {
       vi.clearAllMocks()
-      tabGroupState.updateFromStorage({ ...DEFAULT_STATE, autoGroupingEnabled: true })
+      tabGroupState.updateFromStorage({
+        ...DEFAULT_STATE,
+        autoGroupingEnabled: true,
+        openTabNextToCurrent: true
+      })
     })
 
     it("should position tab next to opener when opener is in the same group", async () => {
@@ -1063,6 +1067,42 @@ describe("TabGroupService", () => {
 
       expect(mockBrowser.tabs.group).not.toHaveBeenCalled()
       expect(mockBrowser.tabs.move).toHaveBeenCalledWith(2, { index: 4 })
+    })
+
+    it("should NOT reposition when openTabNextToCurrent is disabled", async () => {
+      tabGroupState.openTabNextToCurrent = false
+      tabGroupService.markAsNewTab(2)
+      mockBrowser.tabs.get.mockImplementation(async (tabId: number) => {
+        if (tabId === 2) {
+          return {
+            id: 2,
+            url: "https://youtube.com/watch?v=new",
+            pinned: false,
+            windowId: 1,
+            groupId: -1,
+            openerTabId: 1
+          }
+        }
+        if (tabId === 1) {
+          return {
+            id: 1,
+            url: "https://youtube.com/watch?v=old",
+            pinned: false,
+            windowId: 1,
+            groupId: 100,
+            index: 3
+          }
+        }
+        return {}
+      })
+      mockBrowser.tabGroups.query.mockResolvedValue([{ id: 100, title: "Youtube", windowId: 1 }])
+      mockBrowser.tabs.group.mockResolvedValue(100)
+      mockBrowser.tabs.query.mockResolvedValue([])
+
+      await tabGroupService.handleTabUpdate(2)
+
+      expect(mockBrowser.tabs.group).toHaveBeenCalled()
+      expect(mockBrowser.tabs.move).not.toHaveBeenCalled()
     })
 
     it("should NOT reposition on manual move (tab not marked as new)", async () => {

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -27,6 +27,8 @@ export type MessageAction =
   | "setGroupByMode"
   | "getMinimumTabsForGroup"
   | "setMinimumTabsForGroup"
+  | "getOpenTabNextToCurrent"
+  | "toggleOpenTabNextToCurrent"
   | "getCustomRules"
   | "addCustomRule"
   | "updateCustomRule"
@@ -62,6 +64,7 @@ export interface SimpleMessage extends BaseMessage {
     | "getOnlyApplyToNewTabs"
     | "getGroupByMode"
     | "getMinimumTabsForGroup"
+    | "getOpenTabNextToCurrent"
     | "getCustomRules"
     | "getRulesStats"
     | "exportRules"
@@ -107,6 +110,14 @@ export interface SetMinimumTabsMessage extends BaseMessage {
 }
 
 /**
+ * Toggle open tab next to current message
+ */
+export interface ToggleOpenTabNextToCurrentMessage extends BaseMessage {
+  action: "toggleOpenTabNextToCurrent"
+  enabled: boolean
+}
+
+/**
  * Add custom rule message
  */
 export interface AddCustomRuleMessage extends BaseMessage {
@@ -149,6 +160,7 @@ export type Message =
   | ToggleGroupNewTabsMessage
   | SetGroupByModeMessage
   | SetMinimumTabsMessage
+  | ToggleOpenTabNextToCurrentMessage
   | AddCustomRuleMessage
   | UpdateCustomRuleMessage
   | DeleteCustomRuleMessage

--- a/types/storage.ts
+++ b/types/storage.ts
@@ -53,6 +53,8 @@ export interface StorageSchema {
   aiProvider: AiProvider
   /** Selected AI model ID */
   aiModelId: string
+  /** Whether to open new tabs next to the current tab (opt-in, default off) */
+  openTabNextToCurrent: boolean
 }
 
 /**
@@ -70,7 +72,8 @@ export const DEFAULT_STATE: StorageSchema = {
   autoCollapseDelayMs: 0,
   aiEnabled: false,
   aiProvider: "webllm",
-  aiModelId: "Qwen2.5-3B-Instruct-q4f16_1-MLC"
+  aiModelId: "Qwen2.5-3B-Instruct-q4f16_1-MLC",
+  openTabNextToCurrent: false
 }
 
 /**

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -67,6 +67,10 @@ export const aiModelId = storage.defineItem<string>("local:aiModelId", {
   fallback: DEFAULT_STATE.aiModelId
 })
 
+export const openTabNextToCurrent = storage.defineItem<boolean>("local:openTabNextToCurrent", {
+  fallback: DEFAULT_STATE.openTabNextToCurrent
+})
+
 /**
  * Cached AI suggestions (survives popup reopens, not a user setting)
  */
@@ -91,7 +95,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     autoCollapseDelayMsValue,
     aiEnabledValue,
     aiProviderValue,
-    aiModelIdValue
+    aiModelIdValue,
+    openTabNextToCurrentValue
   ] = await Promise.all([
     autoGroupingEnabled.getValue(),
     groupNewTabs.getValue(),
@@ -104,7 +109,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     autoCollapseDelayMs.getValue(),
     aiEnabled.getValue(),
     aiProvider.getValue(),
-    aiModelId.getValue()
+    aiModelId.getValue(),
+    openTabNextToCurrent.getValue()
   ])
 
   return {
@@ -119,7 +125,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     autoCollapseDelayMs: autoCollapseDelayMsValue,
     aiEnabled: aiEnabledValue,
     aiProvider: aiProviderValue,
-    aiModelId: aiModelIdValue
+    aiModelId: aiModelIdValue,
+    openTabNextToCurrent: openTabNextToCurrentValue
   }
 }
 
@@ -164,6 +171,9 @@ export async function saveAllStorage(data: Partial<StorageSchema>): Promise<void
   }
   if (data.aiModelId !== undefined) {
     promises.push(aiModelId.setValue(data.aiModelId))
+  }
+  if (data.openTabNextToCurrent !== undefined) {
+    promises.push(openTabNextToCurrent.setValue(data.openTabNextToCurrent))
   }
   await Promise.all(promises)
 }


### PR DESCRIPTION
The tab positioning feature that moves new tabs next to their opener was previously always-on. This makes it opt-in (disabled by default) with a toggle in both the popup and sidebar UIs, restoring native browser tab creation behavior as the default.

- Add openTabNextToCurrent to storage schema (default: false)
- Add toggle UI to popup and sidebar
- Gate repositioning logic in TabGroupService behind the setting
- Add message types for get/toggle operations
- Add tests for disabled state
- Bump version to 3.0.6