### PR TITLE
fix: account for exclusion patterns in conflict detection (#59)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/tests/ExclusionPatterns.test.ts
+++ b/tests/ExclusionPatterns.test.ts
@@ -181,5 +181,80 @@ describe("Exclusion Patterns", () => {
       const exclusionConflicts = conflicts.filter(c => c.targetPattern.startsWith("!"))
       expect(exclusionConflicts).toHaveLength(0)
     })
+
+    it("should suppress conflict when source pattern is excluded by target rule (#59)", () => {
+      const existingRules: CustomRule[] = [
+        {
+          id: "rule-1",
+          name: "Docs",
+          domains: ["docs.*.*", "!docs.google.com"],
+          color: "blue",
+          enabled: true,
+          priority: 1,
+          createdAt: new Date().toISOString()
+        }
+      ]
+
+      const conflicts = detectConflicts(["docs.google.com"], existingRules)
+
+      // docs.google.com is explicitly excluded from the Docs rule, so no conflict
+      expect(conflicts).toHaveLength(0)
+    })
+
+    it("should suppress conflict when target pattern is excluded by source exclusions", () => {
+      const existingRules: CustomRule[] = [
+        {
+          id: "rule-1",
+          name: "Google Docs",
+          domains: ["docs.google.com"],
+          color: "red",
+          enabled: true,
+          priority: 1,
+          createdAt: new Date().toISOString()
+        }
+      ]
+
+      const conflicts = detectConflicts(["*.google.com", "!docs.google.com"], existingRules)
+
+      // docs.google.com is excluded from the source rule, so no conflict
+      expect(conflicts).toHaveLength(0)
+    })
+
+    it("should suppress conflict when subdomain is excluded by wildcard exclusion", () => {
+      const existingRules: CustomRule[] = [
+        {
+          id: "rule-1",
+          name: "Example",
+          domains: ["*.example.com", "!sub.example.com"],
+          color: "green",
+          enabled: true,
+          priority: 1,
+          createdAt: new Date().toISOString()
+        }
+      ]
+
+      const conflicts = detectConflicts(["sub.example.com"], existingRules)
+
+      expect(conflicts).toHaveLength(0)
+    })
+
+    it("should still detect conflicts when no exclusion negates the overlap", () => {
+      const existingRules: CustomRule[] = [
+        {
+          id: "rule-1",
+          name: "Example",
+          domains: ["*.example.com"],
+          color: "blue",
+          enabled: true,
+          priority: 1,
+          createdAt: new Date().toISOString()
+        }
+      ]
+
+      const conflicts = detectConflicts(["sub.example.com"], existingRules)
+
+      // No exclusion pattern, so the conflict should still be detected
+      expect(conflicts.length).toBeGreaterThan(0)
+    })
   })
 })

--- a/utils/RuleConflictDetector.ts
+++ b/utils/RuleConflictDetector.ts
@@ -45,7 +45,25 @@ export function checkPatternOverlap(
 }
 
 /**
+ * Check whether a pattern is negated (excluded) by any exclusion pattern.
+ * A pattern is negated if an exclusion exactly matches it or subsumes it.
+ */
+function isNegatedByExclusions(pattern: string, exclusionPatterns: readonly string[]): boolean {
+  const pat = pattern.toLowerCase().trim()
+
+  return exclusionPatterns.some(exclRaw => {
+    const excl = exclRaw.trim().substring(1).toLowerCase()
+    if (pat === excl) return true
+
+    const overlap = checkPatternOverlap(pat, excl)
+    return overlap === "subsumed_by_wildcard" || overlap === "exact_duplicate"
+  })
+}
+
+/**
  * Detect all conflicts between source patterns and existing rules.
+ * Accounts for exclusion patterns: a conflict is suppressed when the
+ * overlapping pattern is explicitly excluded by either side.
  */
 export function detectConflicts(
   sourcePatterns: readonly string[],
@@ -54,6 +72,8 @@ export function detectConflicts(
 ): PatternConflict[] {
   const conflicts: PatternConflict[] = []
 
+  const sourceExclusions = sourcePatterns.filter(p => p.trim().startsWith("!"))
+
   for (const srcPattern of sourcePatterns) {
     // Skip exclusion patterns — they don't create positive matches
     if (srcPattern.trim().startsWith("!")) continue
@@ -61,12 +81,19 @@ export function detectConflicts(
     for (const rule of existingRules) {
       if (rule.id === excludeRuleId) continue
 
+      const targetExclusions = rule.domains.filter(d => d.trim().startsWith("!"))
+
       for (const tgtPattern of rule.domains) {
         // Skip exclusion patterns in target rules too
         if (tgtPattern.trim().startsWith("!")) continue
 
         const conflictType = checkPatternOverlap(srcPattern, tgtPattern)
         if (conflictType !== null) {
+          // Suppress conflict if the source pattern is excluded by the target rule
+          if (isNegatedByExclusions(srcPattern, targetExclusions)) continue
+          // Suppress conflict if the target pattern is excluded by the source rule
+          if (isNegatedByExclusions(tgtPattern, sourceExclusions)) continue
+
           conflicts.push({
             sourcePattern: srcPattern,
             targetPattern: tgtPattern,


### PR DESCRIPTION
## Summary
- Fixes false-positive "Pattern Conflicts Detected" warnings when a pattern is explicitly excluded by the conflicting rule
- Adds `isNegatedByExclusions()` helper that checks if a pattern is covered by any exclusion pattern (exact match or subsumed by wildcard)
- Updates `detectConflicts()` to suppress conflicts when either side's exclusions negate the overlap

Closes #59

## Test plan
- [x] New test: `docs.google.com` vs rule with `docs.*.*` + `!docs.google.com` → no conflict
- [x] New test: source with `["*.google.com", "!docs.google.com"]` vs rule with `docs.google.com` → no conflict
- [x] New test: `sub.example.com` vs rule with `*.example.com` + `!sub.example.com` → no conflict
- [x] Regression test: conflicts still detected when no exclusion negates the overlap
- [x] All 754 existing tests pass
- [x] Lint and typecheck clean