### PR TITLE
Feat/add blacklist

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -267,6 +267,10 @@ export default defineBackground(() => {
               result = { success: true, ruleId }
 
               if (tabGroupState.autoGroupingEnabled) {
+                if (msg.ruleData?.isBlacklist) {
+                  // Blacklist rules need to ungroup currently grouped tabs that match
+                  await tabGroupService.ungroupAllTabs()
+                }
                 await tabGroupService.groupTabsWithRules()
               }
 

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -237,6 +237,34 @@
           </div>
         </div>
       </div>
+
+      <!-- Blacklist Section -->
+      <div class="blacklist-section">
+        <button class="blacklist-toggle">
+          <span class="noselect">Blacklist</span>
+          <span class="blacklist-count" id="blacklistCount">(0)</span>
+          <span class="up-arrow">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                d="m16.707 13.293-4-4a1 1 0 0 0-1.414 0l-4 4A1 1 0 0 0 8 15h8a1 1 0 0 0 .707-1.707z"
+                style="fill: #e03131"
+                data-name="Up"
+              />
+            </svg>
+          </span>
+        </button>
+        <div class="blacklist-content">
+          <div class="blacklist-list" id="blacklistList">
+            <!-- Blacklist rules will be dynamically added here -->
+          </div>
+          <div class="blacklist-actions">
+            <button id="addBlacklistButton" class="button blacklist-button">Add to Blacklist</button>
+          </div>
+          <div class="help-text blacklist-help">
+            Blacklisted domains will never be grouped
+          </div>
+        </div>
+      </div>
     </main>
     <footer class="footer-container">
       <div class="separator"></div>

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -43,6 +43,13 @@ const addRuleButton = document.getElementById("addRuleButton") as HTMLButtonElem
 const exportRulesButton = document.getElementById("exportRulesButton") as HTMLButtonElement
 const importRulesButton = document.getElementById("importRulesButton") as HTMLButtonElement
 
+// Blacklist Elements
+const blacklistToggle = document.querySelector(".blacklist-toggle") as HTMLButtonElement
+const blacklistContent = document.querySelector(".blacklist-content") as HTMLDivElement
+const blacklistCount = document.getElementById("blacklistCount") as HTMLSpanElement
+const blacklistList = document.getElementById("blacklistList") as HTMLDivElement
+const addBlacklistButton = document.getElementById("addBlacklistButton") as HTMLButtonElement
+
 // AI Elements
 const aiToggle = document.querySelector(".ai-toggle") as HTMLButtonElement
 const aiContent = document.querySelector(".ai-content") as HTMLDivElement
@@ -66,6 +73,7 @@ let aiSectionExpanded = false
 let aiStatusPollingInterval: ReturnType<typeof setInterval> | null = null
 let sortingSectionExpanded = false
 let customRulesExpanded = false
+let blacklistExpanded = false
 let currentRules: Record<string, CustomRule> = {}
 
 // Color mapping for display
@@ -187,60 +195,129 @@ async function loadCustomRules(): Promise<void> {
   }
 }
 
-// Update the rules display
+// Update the rules display (excludes blacklist rules)
 function updateRulesDisplay(): void {
-  const rulesArray = Object.values(currentRules)
-  const enabledRules = rulesArray.filter(rule => rule.enabled)
+  const allRules = Object.values(currentRules)
+  const groupingRules = allRules.filter(rule => !rule.isBlacklist)
+  const enabledGroupingRules = groupingRules.filter(rule => rule.enabled)
 
-  rulesCount.textContent = `(${enabledRules.length})`
+  rulesCount.textContent = `(${enabledGroupingRules.length})`
 
   if (exportRulesButton) {
-    exportRulesButton.disabled = rulesArray.length === 0
+    exportRulesButton.disabled = allRules.length === 0
     exportRulesButton.title =
-      rulesArray.length === 0 ? "No rules to export" : "Export all rules to JSON file"
+      allRules.length === 0 ? "No rules to export" : "Export all rules to JSON file"
   }
 
-  rulesList.innerHTML = ""
+  while (rulesList.firstChild) rulesList.removeChild(rulesList.firstChild)
 
-  if (rulesArray.length === 0) {
+  if (groupingRules.length === 0) {
     const emptyDiv = document.createElement("div")
     emptyDiv.className = "empty-rules"
     emptyDiv.textContent =
       "No custom rules yet. Create your first rule to group tabs by your preferences!"
     rulesList.appendChild(emptyDiv)
+  } else {
+    groupingRules.sort((a, b) => {
+      if (a.priority !== b.priority) {
+        return a.priority - b.priority
+      }
+      return a.name.localeCompare(b.name)
+    })
+
+    groupingRules.forEach(rule => {
+      const ruleElement = createRuleElement(rule)
+      rulesList.appendChild(ruleElement)
+    })
+  }
+
+  // Also update blacklist display since they share the same data source
+  updateBlacklistDisplay()
+}
+
+// Update the blacklist display
+function updateBlacklistDisplay(): void {
+  const blacklistRules = Object.values(currentRules).filter(rule => rule.isBlacklist === true)
+  const enabledBlacklist = blacklistRules.filter(rule => rule.enabled)
+
+  blacklistCount.textContent = `(${enabledBlacklist.length})`
+
+  while (blacklistList.firstChild) blacklistList.removeChild(blacklistList.firstChild)
+
+  if (blacklistRules.length === 0) {
+    const emptyDiv = document.createElement("div")
+    emptyDiv.className = "empty-rules"
+    emptyDiv.textContent = "No blacklisted domains yet."
+    blacklistList.appendChild(emptyDiv)
     return
   }
 
-  rulesArray.sort((a, b) => {
-    if (a.priority !== b.priority) {
-      return a.priority - b.priority
-    }
-    return a.name.localeCompare(b.name)
-  })
+  blacklistRules.sort((a, b) => a.name.localeCompare(b.name))
 
-  rulesArray.forEach(rule => {
-    const ruleElement = createRuleElement(rule)
-    rulesList.appendChild(ruleElement)
+  blacklistRules.forEach(rule => {
+    const ruleElement = createBlacklistElement(rule)
+    blacklistList.appendChild(ruleElement)
   })
 }
 
-// Create a rule element
-function createRuleElement(rule: CustomRule): HTMLDivElement {
-  const isBlacklist = rule.isBlacklist === true
+// Create a blacklist rule element
+function createBlacklistElement(rule: CustomRule): HTMLDivElement {
   const ruleItem = document.createElement("div")
-  ruleItem.className = `rule-item${!rule.enabled ? " disabled" : ""}${isBlacklist ? " blacklist" : ""}`
+  ruleItem.className = `rule-item${!rule.enabled ? " disabled" : ""} blacklist`
 
   const domainsDisplay = formatDomainsDisplay(rule.domains)
 
   const colorIndicator = document.createElement("div")
+  colorIndicator.className = "rule-color-indicator blacklist-indicator"
+
+  const ruleInfo = document.createElement("div")
+  ruleInfo.className = "rule-info"
+
+  const ruleDomains = document.createElement("div")
+  ruleDomains.className = "rule-domains blacklist-domains"
+  ruleDomains.textContent = domainsDisplay
+
+  ruleInfo.appendChild(ruleDomains)
+
+  const ruleActions = document.createElement("div")
+  ruleActions.className = "rule-actions"
+
+  const editBtn = document.createElement("button")
+  editBtn.className = "rule-action-btn edit"
+  editBtn.title = "Edit blacklist rule"
+  editBtn.setAttribute("data-rule-id", rule.id)
+  editBtn.textContent = "Edit"
+
+  const deleteBtn = document.createElement("button")
+  deleteBtn.className = "rule-action-btn delete"
+  deleteBtn.title = "Delete blacklist rule"
+  deleteBtn.setAttribute("data-rule-id", rule.id)
+  deleteBtn.textContent = "Delete"
+
+  ruleActions.appendChild(editBtn)
+  ruleActions.appendChild(deleteBtn)
+
+  ruleItem.appendChild(colorIndicator)
+  ruleItem.appendChild(ruleInfo)
+  ruleItem.appendChild(ruleActions)
+
+  editBtn.addEventListener("click", () => editBlacklistRule(rule.id))
+  deleteBtn.addEventListener("click", () => deleteRule(rule.id, rule.name))
+
+  return ruleItem
+}
+
+// Create a rule element
+function createRuleElement(rule: CustomRule): HTMLDivElement {
+  const ruleItem = document.createElement("div")
+  ruleItem.className = `rule-item${!rule.enabled ? " disabled" : ""}`
+
+  const colorHex = RULE_COLORS[rule.color] || RULE_COLORS.blue
+  const domainsDisplay = formatDomainsDisplay(rule.domains)
+
+  const colorIndicator = document.createElement("div")
   colorIndicator.className = "rule-color-indicator"
-  if (isBlacklist) {
-    colorIndicator.classList.add("blacklist-indicator")
-    colorIndicator.title = "Blacklist rule"
-  } else {
-    const colorHex = RULE_COLORS[rule.color] || RULE_COLORS.blue
-    colorIndicator.style.backgroundColor = colorHex
-  }
+  colorIndicator.style.backgroundColor = colorHex
 
   const ruleInfo = document.createElement("div")
   ruleInfo.className = "rule-info"
@@ -248,13 +325,6 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   const ruleName = document.createElement("div")
   ruleName.className = "rule-name"
   ruleName.textContent = rule.name
-
-  if (isBlacklist) {
-    const badge = document.createElement("span")
-    badge.className = "blacklist-badge"
-    badge.textContent = "Blacklist"
-    ruleName.appendChild(badge)
-  }
 
   const ruleDomains = document.createElement("div")
   ruleDomains.className = "rule-domains"
@@ -266,16 +336,11 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   const ruleActions = document.createElement("div")
   ruleActions.className = "rule-actions"
 
-  // Hide "Add Tab" button for blacklist rules (they don't create groups)
-  if (!isBlacklist) {
-    const addTabBtn = document.createElement("button")
-    addTabBtn.className = "rule-action-btn add-tab"
-    addTabBtn.title = "Add Tab to Existing Rule"
-    addTabBtn.setAttribute("data-rule-id", rule.id)
-    addTabBtn.textContent = "+"
-    ruleActions.appendChild(addTabBtn)
-    addTabBtn.addEventListener("click", () => addCurrentTabToRule(rule.id, addTabBtn))
-  }
+  const addTabBtn = document.createElement("button")
+  addTabBtn.className = "rule-action-btn add-tab"
+  addTabBtn.title = "Add Tab to Existing Rule"
+  addTabBtn.setAttribute("data-rule-id", rule.id)
+  addTabBtn.textContent = "+"
 
   const editBtn = document.createElement("button")
   editBtn.className = "rule-action-btn edit"
@@ -289,6 +354,7 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   deleteBtn.setAttribute("data-rule-id", rule.id)
   deleteBtn.textContent = "Delete"
 
+  ruleActions.appendChild(addTabBtn)
   ruleActions.appendChild(editBtn)
   ruleActions.appendChild(deleteBtn)
 
@@ -296,6 +362,7 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   ruleItem.appendChild(ruleInfo)
   ruleItem.appendChild(ruleActions)
 
+  addTabBtn.addEventListener("click", () => addCurrentTabToRule(rule.id, addTabBtn))
   editBtn.addEventListener("click", () => editRule(rule.id))
   deleteBtn.addEventListener("click", () => deleteRule(rule.id, rule.name))
 
@@ -421,6 +488,41 @@ async function editRule(ruleId: string): Promise<void> {
     await browser.tabs.create({ url, active: true })
   } catch (error) {
     console.error("Error opening edit rule modal:", error)
+  }
+}
+
+// Open add blacklist rule modal
+async function addBlacklistRule(): Promise<void> {
+  try {
+    const url = browser.runtime.getURL("/rules-modal.html?blacklist=true")
+    await browser.tabs.create({ url, active: true })
+  } catch (error) {
+    console.error("Error opening blacklist modal:", error)
+  }
+}
+
+// Open edit blacklist rule modal
+async function editBlacklistRule(ruleId: string): Promise<void> {
+  try {
+    const url = browser.runtime.getURL(
+      `/rules-modal.html?edit=true&ruleId=${ruleId}&blacklist=true`
+    )
+    await browser.tabs.create({ url, active: true })
+  } catch (error) {
+    console.error("Error opening edit blacklist modal:", error)
+  }
+}
+
+// Toggle blacklist section
+function toggleBlacklistSection(): void {
+  blacklistExpanded = !blacklistExpanded
+  blacklistToggle.classList.toggle("expanded", blacklistExpanded)
+  blacklistContent.classList.toggle("expanded", blacklistExpanded)
+
+  if (blacklistExpanded) {
+    if (Object.keys(currentRules).length === 0) {
+      loadCustomRules()
+    }
   }
 }
 
@@ -1063,6 +1165,10 @@ rulesToggle?.addEventListener("click", toggleRulesSection)
 addRuleButton?.addEventListener("click", addRule)
 exportRulesButton?.addEventListener("click", exportRules)
 importRulesButton?.addEventListener("click", importRules)
+
+// Blacklist event listeners
+blacklistToggle?.addEventListener("click", toggleBlacklistSection)
+addBlacklistButton?.addEventListener("click", addBlacklistRule)
 
 // Initialize AI badge on popup open
 sendMessage<{

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -226,15 +226,21 @@ function updateRulesDisplay(): void {
 
 // Create a rule element
 function createRuleElement(rule: CustomRule): HTMLDivElement {
+  const isBlacklist = rule.isBlacklist === true
   const ruleItem = document.createElement("div")
-  ruleItem.className = `rule-item ${!rule.enabled ? "disabled" : ""}`
+  ruleItem.className = `rule-item${!rule.enabled ? " disabled" : ""}${isBlacklist ? " blacklist" : ""}`
 
-  const colorHex = RULE_COLORS[rule.color] || RULE_COLORS.blue
   const domainsDisplay = formatDomainsDisplay(rule.domains)
 
   const colorIndicator = document.createElement("div")
   colorIndicator.className = "rule-color-indicator"
-  colorIndicator.style.backgroundColor = colorHex
+  if (isBlacklist) {
+    colorIndicator.classList.add("blacklist-indicator")
+    colorIndicator.title = "Blacklist rule"
+  } else {
+    const colorHex = RULE_COLORS[rule.color] || RULE_COLORS.blue
+    colorIndicator.style.backgroundColor = colorHex
+  }
 
   const ruleInfo = document.createElement("div")
   ruleInfo.className = "rule-info"
@@ -242,6 +248,13 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   const ruleName = document.createElement("div")
   ruleName.className = "rule-name"
   ruleName.textContent = rule.name
+
+  if (isBlacklist) {
+    const badge = document.createElement("span")
+    badge.className = "blacklist-badge"
+    badge.textContent = "Blacklist"
+    ruleName.appendChild(badge)
+  }
 
   const ruleDomains = document.createElement("div")
   ruleDomains.className = "rule-domains"
@@ -253,11 +266,16 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   const ruleActions = document.createElement("div")
   ruleActions.className = "rule-actions"
 
-  const addTabBtn = document.createElement("button")
-  addTabBtn.className = "rule-action-btn add-tab"
-  addTabBtn.title = "Add Tab to Existing Rule"
-  addTabBtn.setAttribute("data-rule-id", rule.id)
-  addTabBtn.textContent = "+"
+  // Hide "Add Tab" button for blacklist rules (they don't create groups)
+  if (!isBlacklist) {
+    const addTabBtn = document.createElement("button")
+    addTabBtn.className = "rule-action-btn add-tab"
+    addTabBtn.title = "Add Tab to Existing Rule"
+    addTabBtn.setAttribute("data-rule-id", rule.id)
+    addTabBtn.textContent = "+"
+    ruleActions.appendChild(addTabBtn)
+    addTabBtn.addEventListener("click", () => addCurrentTabToRule(rule.id, addTabBtn))
+  }
 
   const editBtn = document.createElement("button")
   editBtn.className = "rule-action-btn edit"
@@ -271,7 +289,6 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   deleteBtn.setAttribute("data-rule-id", rule.id)
   deleteBtn.textContent = "Delete"
 
-  ruleActions.appendChild(addTabBtn)
   ruleActions.appendChild(editBtn)
   ruleActions.appendChild(deleteBtn)
 
@@ -279,7 +296,6 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   ruleItem.appendChild(ruleInfo)
   ruleItem.appendChild(ruleActions)
 
-  addTabBtn.addEventListener("click", () => addCurrentTabToRule(rule.id, addTabBtn))
   editBtn.addEventListener("click", () => editRule(rule.id))
   deleteBtn.addEventListener("click", () => deleteRule(rule.id, rule.name))
 

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -540,18 +540,6 @@ input:checked + .slider:before {
   background: repeating-linear-gradient(-45deg, #e03131, #e03131 2px, #fff5f5 2px, #fff5f5 4px);
 }
 
-.blacklist-badge {
-  display: inline-block;
-  font-size: 10px;
-  font-weight: 600;
-  color: #e03131;
-  background: #ffe3e3;
-  padding: 1px 5px;
-  border-radius: 3px;
-  margin-left: 6px;
-  vertical-align: middle;
-}
-
 .rule-actions {
   display: flex;
   gap: 4px;
@@ -1319,4 +1307,113 @@ input:checked + .slider:before {
   color: #555;
   border-color: #ccc;
   background: #f5f5f5;
+}
+
+/* Blacklist Section */
+.blacklist-section {
+  margin-top: 12px;
+}
+
+.blacklist-toggle {
+  width: 100%;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  background: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  padding: 12px 16px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 14px;
+  font-weight: 500;
+  color: #495057;
+}
+
+.blacklist-toggle:hover {
+  background: #e9ecef;
+  border-color: #dee2e6;
+}
+
+.blacklist-toggle.expanded {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: none;
+  background: #e9ecef;
+}
+
+.blacklist-toggle .noselect {
+  flex: 1;
+  text-align: left;
+}
+
+.blacklist-count {
+  color: #6c757d;
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.blacklist-toggle .up-arrow {
+  transition: transform 0.2s ease;
+}
+
+.blacklist-toggle.expanded .up-arrow {
+  transform: rotate(180deg);
+}
+
+.blacklist-content {
+  display: none;
+  background: white;
+  border: 1px solid #e9ecef;
+  border-top: none;
+  border-radius: 0 0 8px 8px;
+  padding: 16px;
+}
+
+.blacklist-content.expanded {
+  display: block;
+}
+
+.blacklist-list {
+  max-height: 200px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.blacklist-actions {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
+}
+
+.blacklist-button {
+  background: #e9ecef;
+  color: #495057;
+  border: 1px solid #ced4da;
+  padding: 8px 16px;
+  font-size: 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.blacklist-button:hover {
+  background: #dee2e6;
+  border-color: #adb5bd;
+}
+
+.blacklist-domains {
+  font-size: 13px;
+  color: #495057;
+}
+
+.blacklist-help {
+  padding-top: 4px;
+  font-size: 11px;
+  color: #6c757d;
+  text-align: center;
 }

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -528,6 +528,30 @@ input:checked + .slider:before {
   flex-shrink: 0;
 }
 
+.rule-item.blacklist {
+  background: #fff5f5;
+}
+
+.rule-item.blacklist:hover {
+  background: #ffe3e3;
+}
+
+.rule-color-indicator.blacklist-indicator {
+  background: repeating-linear-gradient(-45deg, #e03131, #e03131 2px, #fff5f5 2px, #fff5f5 4px);
+}
+
+.blacklist-badge {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  color: #e03131;
+  background: #ffe3e3;
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
 .rule-actions {
   display: flex;
   gap: 4px;

--- a/entrypoints/rules-modal.unlisted/index.html
+++ b/entrypoints/rules-modal.unlisted/index.html
@@ -56,7 +56,7 @@ example.com/admin/*
           <div class="help-text pattern-help">Supports: domains, wildcards (*.example.com), paths (example.com/api/*), IP addresses</div>
           <div id="patternFeedback" class="pattern-feedback"></div>
         </div>
-        <div class="form-group">
+        <div class="form-group" id="colorGroup">
           <label>Group Color</label>
           <div id="colorPicker" class="color-picker">
             <button type="button" class="color-btn active" data-color="blue" title="Blue"></button>
@@ -70,6 +70,13 @@ example.com/admin/*
             <button type="button" class="color-btn" data-color="grey" title="Grey"></button>
           </div>
           <input type="hidden" id="ruleColor" value="blue" />
+        </div>
+        <div class="form-group checkbox-group">
+          <label>
+            <input type="checkbox" id="ruleBlacklist" />
+            Blacklist (prevent grouping)
+          </label>
+          <div class="help-text">Matching tabs will never be grouped and will be removed from existing groups</div>
         </div>
         <div class="form-group checkbox-group">
           <label>

--- a/entrypoints/rules-modal.unlisted/index.html
+++ b/entrypoints/rules-modal.unlisted/index.html
@@ -73,13 +73,6 @@ example.com/admin/*
         </div>
         <div class="form-group checkbox-group">
           <label>
-            <input type="checkbox" id="ruleBlacklist" />
-            Blacklist (prevent grouping)
-          </label>
-          <div class="help-text">Matching tabs will never be grouped and will be removed from existing groups</div>
-        </div>
-        <div class="form-group checkbox-group">
-          <label>
             <input type="checkbox" id="ruleEnabled" checked />
             Enabled
           </label>

--- a/entrypoints/rules-modal.unlisted/main.ts
+++ b/entrypoints/rules-modal.unlisted/main.ts
@@ -21,7 +21,9 @@ const ruleNameInput = document.getElementById("ruleName") as HTMLInputElement
 const rulePatternsInput = document.getElementById("rulePatterns") as HTMLTextAreaElement
 const ruleColorInput = document.getElementById("ruleColor") as HTMLInputElement
 const colorPicker = document.getElementById("colorPicker") as HTMLDivElement
+const ruleBlacklistCheckbox = document.getElementById("ruleBlacklist") as HTMLInputElement
 const ruleEnabledCheckbox = document.getElementById("ruleEnabled") as HTMLInputElement
+const colorGroup = document.getElementById("colorGroup") as HTMLDivElement
 const saveButton = document.getElementById("saveButton") as HTMLButtonElement
 const cancelButton = document.getElementById("cancelButton") as HTMLButtonElement
 const patternFeedback = document.getElementById("patternFeedback") as HTMLDivElement
@@ -110,6 +112,8 @@ async function loadExistingRule(): Promise<void> {
       rulePatternsInput.value = rule.domains.join("\n")
       setColorPickerValue(rule.color || "blue")
       ruleEnabledCheckbox.checked = rule.enabled !== false
+      ruleBlacklistCheckbox.checked = rule.isBlacklist === true
+      updateBlacklistUI()
     }
   } catch (error) {
     console.error("Error loading rule:", error)
@@ -137,7 +141,9 @@ function buildRuleData(): RuleData | null {
     return null
   }
 
-  return { name, domains: patterns, color, enabled, priority: 1 }
+  const isBlacklist = ruleBlacklistCheckbox.checked
+
+  return { name, domains: patterns, color, enabled, priority: 1, isBlacklist }
 }
 
 // Persist rule to background
@@ -270,6 +276,15 @@ function cancel(): void {
 }
 
 // Color picker helpers
+// Toggle color picker visibility based on blacklist state
+function updateBlacklistUI(): void {
+  if (ruleBlacklistCheckbox.checked) {
+    colorGroup.style.display = "none"
+  } else {
+    colorGroup.style.display = ""
+  }
+}
+
 function setColorPickerValue(color: string): void {
   ruleColorInput.value = color
 
@@ -433,5 +448,6 @@ if (isAiAssist) {
 ruleForm.addEventListener("submit", saveRule)
 cancelButton.addEventListener("click", cancel)
 rulePatternsInput.addEventListener("input", validatePatterns)
+ruleBlacklistCheckbox.addEventListener("change", updateBlacklistUI)
 aiGenerateBtn.addEventListener("click", generateRuleFromDescription)
 aiDescription.addEventListener("focus", checkAiAvailability)

--- a/entrypoints/rules-modal.unlisted/main.ts
+++ b/entrypoints/rules-modal.unlisted/main.ts
@@ -21,9 +21,11 @@ const ruleNameInput = document.getElementById("ruleName") as HTMLInputElement
 const rulePatternsInput = document.getElementById("rulePatterns") as HTMLTextAreaElement
 const ruleColorInput = document.getElementById("ruleColor") as HTMLInputElement
 const colorPicker = document.getElementById("colorPicker") as HTMLDivElement
-const ruleBlacklistCheckbox = document.getElementById("ruleBlacklist") as HTMLInputElement
 const ruleEnabledCheckbox = document.getElementById("ruleEnabled") as HTMLInputElement
 const colorGroup = document.getElementById("colorGroup") as HTMLDivElement
+
+// Blacklist mode — determined by URL param, not a checkbox
+const isBlacklistMode = urlParams.get("blacklist") === "true"
 const saveButton = document.getElementById("saveButton") as HTMLButtonElement
 const cancelButton = document.getElementById("cancelButton") as HTMLButtonElement
 const patternFeedback = document.getElementById("patternFeedback") as HTMLDivElement
@@ -112,8 +114,6 @@ async function loadExistingRule(): Promise<void> {
       rulePatternsInput.value = rule.domains.join("\n")
       setColorPickerValue(rule.color || "blue")
       ruleEnabledCheckbox.checked = rule.enabled !== false
-      ruleBlacklistCheckbox.checked = rule.isBlacklist === true
-      updateBlacklistUI()
     }
   } catch (error) {
     console.error("Error loading rule:", error)
@@ -123,7 +123,6 @@ async function loadExistingRule(): Promise<void> {
 
 // Build RuleData from form inputs
 function buildRuleData(): RuleData | null {
-  const name = ruleNameInput.value.trim()
   const patterns = rulePatternsInput.value
     .split("\n")
     .map(p => p.trim())
@@ -131,19 +130,18 @@ function buildRuleData(): RuleData | null {
   const color = ruleColorInput.value as TabGroupColor
   const enabled = ruleEnabledCheckbox.checked
 
-  if (!name) {
-    alert("Please enter a rule name")
-    return null
-  }
-
   if (patterns.length === 0) {
     alert("Please enter at least one URL pattern")
     return null
   }
 
-  const isBlacklist = ruleBlacklistCheckbox.checked
+  const name = isBlacklistMode ? "" : ruleNameInput.value.trim()
+  if (!isBlacklistMode && !name) {
+    alert("Please enter a rule name")
+    return null
+  }
 
-  return { name, domains: patterns, color, enabled, priority: 1, isBlacklist }
+  return { name, domains: patterns, color, enabled, priority: 1, isBlacklist: isBlacklistMode }
 }
 
 // Persist rule to background
@@ -276,13 +274,17 @@ function cancel(): void {
 }
 
 // Color picker helpers
-// Toggle color picker visibility based on blacklist state
-function updateBlacklistUI(): void {
-  if (ruleBlacklistCheckbox.checked) {
-    colorGroup.style.display = "none"
-  } else {
-    colorGroup.style.display = ""
-  }
+// Apply blacklist mode UI adjustments
+function applyBlacklistMode(): void {
+  if (!isBlacklistMode) return
+  modalTitle.textContent = isEditMode ? "Edit Blacklist Rule" : "Add to Blacklist"
+  saveButton.textContent = isEditMode ? "Update Rule" : "Save Blacklist Rule"
+  colorGroup.style.display = "none"
+  ruleNameInput.required = false
+  const ruleNameGroup = ruleNameInput.closest(".form-group")
+  if (ruleNameGroup) (ruleNameGroup as HTMLElement).style.display = "none"
+  const aiAssistSection = document.getElementById("aiAssistSection")
+  if (aiAssistSection) aiAssistSection.style.display = "none"
 }
 
 function setColorPickerValue(color: string): void {
@@ -448,6 +450,8 @@ if (isAiAssist) {
 ruleForm.addEventListener("submit", saveRule)
 cancelButton.addEventListener("click", cancel)
 rulePatternsInput.addEventListener("input", validatePatterns)
-ruleBlacklistCheckbox.addEventListener("change", updateBlacklistUI)
 aiGenerateBtn.addEventListener("click", generateRuleFromDescription)
 aiDescription.addEventListener("focus", checkAiAvailability)
+
+// Apply blacklist mode UI if opened via blacklist param
+applyBlacklistMode()

--- a/entrypoints/sidebar/index.html
+++ b/entrypoints/sidebar/index.html
@@ -238,6 +238,34 @@
             </div>
           </div>
         </div>
+
+        <!-- Blacklist Section -->
+        <div class="blacklist-section">
+          <button class="blacklist-toggle">
+            <span class="noselect">Blacklist</span>
+            <span class="blacklist-count" id="blacklistCount">(0)</span>
+            <span class="up-arrow">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+                <path
+                  d="m16.707 13.293-4-4a1 1 0 0 0-1.414 0l-4 4A1 1 0 0 0 8 15h8a1 1 0 0 0 .707-1.707z"
+                  style="fill: #e03131"
+                  data-name="Up"
+                />
+              </svg>
+            </span>
+          </button>
+          <div class="blacklist-content">
+            <div class="blacklist-list" id="blacklistList">
+              <!-- Blacklist rules will be dynamically added here -->
+            </div>
+            <div class="blacklist-actions">
+              <button id="addBlacklistButton" class="button blacklist-button">Add to Blacklist</button>
+            </div>
+            <div class="help-text blacklist-help">
+              Blacklisted domains will never be grouped
+            </div>
+          </div>
+        </div>
       </main>
       <footer class="footer-container">
         <div class="separator"></div>

--- a/entrypoints/sidebar/main.ts
+++ b/entrypoints/sidebar/main.ts
@@ -228,15 +228,21 @@ function updateRulesDisplay(): void {
 
 // Create a rule element
 function createRuleElement(rule: CustomRule): HTMLDivElement {
+  const isBlacklist = rule.isBlacklist === true
   const ruleItem = document.createElement("div")
-  ruleItem.className = `rule-item ${!rule.enabled ? "disabled" : ""}`
+  ruleItem.className = `rule-item${!rule.enabled ? " disabled" : ""}${isBlacklist ? " blacklist" : ""}`
 
-  const colorHex = RULE_COLORS[rule.color] || RULE_COLORS.blue
   const domainsDisplay = formatDomainsDisplay(rule.domains)
 
   const colorIndicator = document.createElement("div")
   colorIndicator.className = "rule-color-indicator"
-  colorIndicator.style.backgroundColor = colorHex
+  if (isBlacklist) {
+    colorIndicator.classList.add("blacklist-indicator")
+    colorIndicator.title = "Blacklist rule"
+  } else {
+    const colorHex = RULE_COLORS[rule.color] || RULE_COLORS.blue
+    colorIndicator.style.backgroundColor = colorHex
+  }
 
   const ruleInfo = document.createElement("div")
   ruleInfo.className = "rule-info"
@@ -244,6 +250,13 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   const ruleName = document.createElement("div")
   ruleName.className = "rule-name"
   ruleName.textContent = rule.name
+
+  if (isBlacklist) {
+    const badge = document.createElement("span")
+    badge.className = "blacklist-badge"
+    badge.textContent = "Blacklist"
+    ruleName.appendChild(badge)
+  }
 
   const ruleDomains = document.createElement("div")
   ruleDomains.className = "rule-domains"
@@ -255,11 +268,16 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   const ruleActions = document.createElement("div")
   ruleActions.className = "rule-actions"
 
-  const addTabBtn = document.createElement("button")
-  addTabBtn.className = "rule-action-btn add-tab"
-  addTabBtn.title = "Add Tab to Existing Rule"
-  addTabBtn.setAttribute("data-rule-id", rule.id)
-  addTabBtn.textContent = "+"
+  // Hide "Add Tab" button for blacklist rules (they don't create groups)
+  if (!isBlacklist) {
+    const addTabBtn = document.createElement("button")
+    addTabBtn.className = "rule-action-btn add-tab"
+    addTabBtn.title = "Add Tab to Existing Rule"
+    addTabBtn.setAttribute("data-rule-id", rule.id)
+    addTabBtn.textContent = "+"
+    ruleActions.appendChild(addTabBtn)
+    addTabBtn.addEventListener("click", () => addCurrentTabToRule(rule.id, addTabBtn))
+  }
 
   const editBtn = document.createElement("button")
   editBtn.className = "rule-action-btn edit"
@@ -273,7 +291,6 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   deleteBtn.setAttribute("data-rule-id", rule.id)
   deleteBtn.textContent = "Delete"
 
-  ruleActions.appendChild(addTabBtn)
   ruleActions.appendChild(editBtn)
   ruleActions.appendChild(deleteBtn)
 
@@ -281,7 +298,6 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   ruleItem.appendChild(ruleInfo)
   ruleItem.appendChild(ruleActions)
 
-  addTabBtn.addEventListener("click", () => addCurrentTabToRule(rule.id, addTabBtn))
   editBtn.addEventListener("click", () => editRule(rule.id))
   deleteBtn.addEventListener("click", () => deleteRule(rule.id, rule.name))
 

--- a/entrypoints/sidebar/main.ts
+++ b/entrypoints/sidebar/main.ts
@@ -45,6 +45,13 @@ const exportRulesButton = document.getElementById("exportRulesButton") as HTMLBu
 const importRulesButton = document.getElementById("importRulesButton") as HTMLButtonElement
 const importFileInput = document.getElementById("importFileInput") as HTMLInputElement
 
+// Blacklist Elements
+const blacklistToggle = document.querySelector(".blacklist-toggle") as HTMLButtonElement
+const blacklistContent = document.querySelector(".blacklist-content") as HTMLDivElement
+const blacklistCount = document.getElementById("blacklistCount") as HTMLSpanElement
+const blacklistList = document.getElementById("blacklistList") as HTMLDivElement
+const addBlacklistButton = document.getElementById("addBlacklistButton") as HTMLButtonElement
+
 // AI Elements
 const aiToggle = document.querySelector(".ai-toggle") as HTMLButtonElement
 const aiContent = document.querySelector(".ai-content") as HTMLDivElement
@@ -68,6 +75,7 @@ let aiSectionExpanded = false
 let aiStatusPollingInterval: ReturnType<typeof setInterval> | null = null
 let sortingSectionExpanded = false
 let customRulesExpanded = false
+let blacklistExpanded = false
 let currentRules: Record<string, CustomRule> = {}
 
 // Color mapping for display
@@ -189,60 +197,129 @@ async function loadCustomRules(): Promise<void> {
   }
 }
 
-// Update the rules display
+// Update the rules display (excludes blacklist rules)
 function updateRulesDisplay(): void {
-  const rulesArray = Object.values(currentRules)
-  const enabledRules = rulesArray.filter(rule => rule.enabled)
+  const allRules = Object.values(currentRules)
+  const groupingRules = allRules.filter(rule => !rule.isBlacklist)
+  const enabledGroupingRules = groupingRules.filter(rule => rule.enabled)
 
-  rulesCount.textContent = `(${enabledRules.length})`
+  rulesCount.textContent = `(${enabledGroupingRules.length})`
 
   if (exportRulesButton) {
-    exportRulesButton.disabled = rulesArray.length === 0
+    exportRulesButton.disabled = allRules.length === 0
     exportRulesButton.title =
-      rulesArray.length === 0 ? "No rules to export" : "Export all rules to JSON file"
+      allRules.length === 0 ? "No rules to export" : "Export all rules to JSON file"
   }
 
-  rulesList.innerHTML = ""
+  while (rulesList.firstChild) rulesList.removeChild(rulesList.firstChild)
 
-  if (rulesArray.length === 0) {
+  if (groupingRules.length === 0) {
     const emptyDiv = document.createElement("div")
     emptyDiv.className = "empty-rules"
     emptyDiv.textContent =
       "No custom rules yet. Create your first rule to group tabs by your preferences!"
     rulesList.appendChild(emptyDiv)
+  } else {
+    groupingRules.sort((a, b) => {
+      if (a.priority !== b.priority) {
+        return a.priority - b.priority
+      }
+      return a.name.localeCompare(b.name)
+    })
+
+    groupingRules.forEach(rule => {
+      const ruleElement = createRuleElement(rule)
+      rulesList.appendChild(ruleElement)
+    })
+  }
+
+  // Also update blacklist display since they share the same data source
+  updateBlacklistDisplay()
+}
+
+// Update the blacklist display
+function updateBlacklistDisplay(): void {
+  const blacklistRules = Object.values(currentRules).filter(rule => rule.isBlacklist === true)
+  const enabledBlacklist = blacklistRules.filter(rule => rule.enabled)
+
+  blacklistCount.textContent = `(${enabledBlacklist.length})`
+
+  while (blacklistList.firstChild) blacklistList.removeChild(blacklistList.firstChild)
+
+  if (blacklistRules.length === 0) {
+    const emptyDiv = document.createElement("div")
+    emptyDiv.className = "empty-rules"
+    emptyDiv.textContent = "No blacklisted domains yet."
+    blacklistList.appendChild(emptyDiv)
     return
   }
 
-  rulesArray.sort((a, b) => {
-    if (a.priority !== b.priority) {
-      return a.priority - b.priority
-    }
-    return a.name.localeCompare(b.name)
-  })
+  blacklistRules.sort((a, b) => a.name.localeCompare(b.name))
 
-  rulesArray.forEach(rule => {
-    const ruleElement = createRuleElement(rule)
-    rulesList.appendChild(ruleElement)
+  blacklistRules.forEach(rule => {
+    const ruleElement = createBlacklistElement(rule)
+    blacklistList.appendChild(ruleElement)
   })
 }
 
-// Create a rule element
-function createRuleElement(rule: CustomRule): HTMLDivElement {
-  const isBlacklist = rule.isBlacklist === true
+// Create a blacklist rule element
+function createBlacklistElement(rule: CustomRule): HTMLDivElement {
   const ruleItem = document.createElement("div")
-  ruleItem.className = `rule-item${!rule.enabled ? " disabled" : ""}${isBlacklist ? " blacklist" : ""}`
+  ruleItem.className = `rule-item${!rule.enabled ? " disabled" : ""} blacklist`
 
   const domainsDisplay = formatDomainsDisplay(rule.domains)
 
   const colorIndicator = document.createElement("div")
+  colorIndicator.className = "rule-color-indicator blacklist-indicator"
+
+  const ruleInfo = document.createElement("div")
+  ruleInfo.className = "rule-info"
+
+  const ruleDomains = document.createElement("div")
+  ruleDomains.className = "rule-domains blacklist-domains"
+  ruleDomains.textContent = domainsDisplay
+
+  ruleInfo.appendChild(ruleDomains)
+
+  const ruleActions = document.createElement("div")
+  ruleActions.className = "rule-actions"
+
+  const editBtn = document.createElement("button")
+  editBtn.className = "rule-action-btn edit"
+  editBtn.title = "Edit blacklist rule"
+  editBtn.setAttribute("data-rule-id", rule.id)
+  editBtn.textContent = "Edit"
+
+  const deleteBtn = document.createElement("button")
+  deleteBtn.className = "rule-action-btn delete"
+  deleteBtn.title = "Delete blacklist rule"
+  deleteBtn.setAttribute("data-rule-id", rule.id)
+  deleteBtn.textContent = "Delete"
+
+  ruleActions.appendChild(editBtn)
+  ruleActions.appendChild(deleteBtn)
+
+  ruleItem.appendChild(colorIndicator)
+  ruleItem.appendChild(ruleInfo)
+  ruleItem.appendChild(ruleActions)
+
+  editBtn.addEventListener("click", () => editBlacklistRule(rule.id))
+  deleteBtn.addEventListener("click", () => deleteRule(rule.id, rule.name))
+
+  return ruleItem
+}
+
+// Create a rule element
+function createRuleElement(rule: CustomRule): HTMLDivElement {
+  const ruleItem = document.createElement("div")
+  ruleItem.className = `rule-item${!rule.enabled ? " disabled" : ""}`
+
+  const colorHex = RULE_COLORS[rule.color] || RULE_COLORS.blue
+  const domainsDisplay = formatDomainsDisplay(rule.domains)
+
+  const colorIndicator = document.createElement("div")
   colorIndicator.className = "rule-color-indicator"
-  if (isBlacklist) {
-    colorIndicator.classList.add("blacklist-indicator")
-    colorIndicator.title = "Blacklist rule"
-  } else {
-    const colorHex = RULE_COLORS[rule.color] || RULE_COLORS.blue
-    colorIndicator.style.backgroundColor = colorHex
-  }
+  colorIndicator.style.backgroundColor = colorHex
 
   const ruleInfo = document.createElement("div")
   ruleInfo.className = "rule-info"
@@ -250,13 +327,6 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   const ruleName = document.createElement("div")
   ruleName.className = "rule-name"
   ruleName.textContent = rule.name
-
-  if (isBlacklist) {
-    const badge = document.createElement("span")
-    badge.className = "blacklist-badge"
-    badge.textContent = "Blacklist"
-    ruleName.appendChild(badge)
-  }
 
   const ruleDomains = document.createElement("div")
   ruleDomains.className = "rule-domains"
@@ -268,16 +338,11 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   const ruleActions = document.createElement("div")
   ruleActions.className = "rule-actions"
 
-  // Hide "Add Tab" button for blacklist rules (they don't create groups)
-  if (!isBlacklist) {
-    const addTabBtn = document.createElement("button")
-    addTabBtn.className = "rule-action-btn add-tab"
-    addTabBtn.title = "Add Tab to Existing Rule"
-    addTabBtn.setAttribute("data-rule-id", rule.id)
-    addTabBtn.textContent = "+"
-    ruleActions.appendChild(addTabBtn)
-    addTabBtn.addEventListener("click", () => addCurrentTabToRule(rule.id, addTabBtn))
-  }
+  const addTabBtn = document.createElement("button")
+  addTabBtn.className = "rule-action-btn add-tab"
+  addTabBtn.title = "Add Tab to Existing Rule"
+  addTabBtn.setAttribute("data-rule-id", rule.id)
+  addTabBtn.textContent = "+"
 
   const editBtn = document.createElement("button")
   editBtn.className = "rule-action-btn edit"
@@ -291,6 +356,7 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   deleteBtn.setAttribute("data-rule-id", rule.id)
   deleteBtn.textContent = "Delete"
 
+  ruleActions.appendChild(addTabBtn)
   ruleActions.appendChild(editBtn)
   ruleActions.appendChild(deleteBtn)
 
@@ -298,6 +364,7 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
   ruleItem.appendChild(ruleInfo)
   ruleItem.appendChild(ruleActions)
 
+  addTabBtn.addEventListener("click", () => addCurrentTabToRule(rule.id, addTabBtn))
   editBtn.addEventListener("click", () => editRule(rule.id))
   deleteBtn.addEventListener("click", () => deleteRule(rule.id, rule.name))
 
@@ -427,6 +494,41 @@ async function editRule(ruleId: string): Promise<void> {
 }
 
 // Delete rule
+// Open add blacklist rule modal
+async function addBlacklistRule(): Promise<void> {
+  try {
+    const url = browser.runtime.getURL("/rules-modal.html?blacklist=true")
+    await browser.tabs.create({ url, active: true })
+  } catch (error) {
+    console.error("Error opening blacklist modal:", error)
+  }
+}
+
+// Open edit blacklist rule modal
+async function editBlacklistRule(ruleId: string): Promise<void> {
+  try {
+    const url = browser.runtime.getURL(
+      `/rules-modal.html?edit=true&ruleId=${ruleId}&blacklist=true`
+    )
+    await browser.tabs.create({ url, active: true })
+  } catch (error) {
+    console.error("Error opening edit blacklist modal:", error)
+  }
+}
+
+// Toggle blacklist section
+function toggleBlacklistSection(): void {
+  blacklistExpanded = !blacklistExpanded
+  blacklistToggle.classList.toggle("expanded", blacklistExpanded)
+  blacklistContent.classList.toggle("expanded", blacklistExpanded)
+
+  if (blacklistExpanded) {
+    if (Object.keys(currentRules).length === 0) {
+      loadCustomRules()
+    }
+  }
+}
+
 async function deleteRule(ruleId: string, ruleName: string): Promise<void> {
   if (!confirm(`Are you sure you want to delete the rule "${ruleName}"?`)) {
     return
@@ -1104,6 +1206,10 @@ addRuleButton?.addEventListener("click", addRule)
 exportRulesButton?.addEventListener("click", exportRules)
 importRulesButton?.addEventListener("click", importRules)
 importFileInput?.addEventListener("change", handleFileImport)
+
+// Blacklist event listeners
+blacklistToggle?.addEventListener("click", toggleBlacklistSection)
+addBlacklistButton?.addEventListener("click", addBlacklistRule)
 
 // Initialize AI badge on sidebar open
 sendMessage<{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/services/ContextMenuService.ts
+++ b/services/ContextMenuService.ts
@@ -126,7 +126,9 @@ class ContextMenuService {
     this.currentRuleMenuIds = []
 
     const rules = tabGroupState.getCustomRulesObject()
-    const enabledRules = Object.values(rules).filter((rule: CustomRule) => rule.enabled)
+    const enabledRules = Object.values(rules).filter(
+      (rule: CustomRule) => rule.enabled && !rule.isBlacklist
+    )
 
     if (enabledRules.length === 0) {
       // Show a disabled placeholder

--- a/services/ContextMenuService.ts
+++ b/services/ContextMenuService.ts
@@ -259,6 +259,17 @@ class ContextMenuService {
     if (!domain || domain === "system") return
 
     try {
+      // Check if domain is already blacklisted
+      const rules = tabGroupState.getCustomRulesObject()
+      const alreadyBlacklisted = Object.values(rules).some(
+        rule => rule.isBlacklist && rule.domains.some(d => d.toLowerCase() === domain.toLowerCase())
+      )
+
+      if (alreadyBlacklisted) {
+        console.log(`[ContextMenuService] "${domain}" is already blacklisted`)
+        return
+      }
+
       await rulesService.addRule({
         name: "",
         domains: [domain],

--- a/services/ContextMenuService.ts
+++ b/services/ContextMenuService.ts
@@ -46,6 +46,7 @@ const isFirefox = (): boolean => {
 class ContextMenuService {
   private readonly MENU_ID_CREATE_RULE = "create-rule-from-group"
   private readonly MENU_ID_ADD_TO_RULE_PARENT = "add-tab-to-rule"
+  private readonly MENU_ID_ADD_TO_BLACKLIST = "add-to-blacklist"
   private readonly MENU_ID_NO_RULES = "add-to-rule-none"
   private initialized = false
   /** Track current sub-menu rule IDs for cleanup */
@@ -78,6 +79,13 @@ class ContextMenuService {
       await browser.contextMenus.create({
         id: this.MENU_ID_ADD_TO_RULE_PARENT,
         title: "Add Tab to Existing Rule",
+        contexts
+      })
+
+      // Create "Add to Blacklist" menu item
+      await browser.contextMenus.create({
+        id: this.MENU_ID_ADD_TO_BLACKLIST,
+        title: "Add to Blacklist",
         contexts
       })
 
@@ -175,6 +183,11 @@ class ContextMenuService {
       return
     }
 
+    if (menuId === this.MENU_ID_ADD_TO_BLACKLIST) {
+      await this.handleAddToBlacklist(tab)
+      return
+    }
+
     if (menuId.startsWith(ADD_TO_RULE_PREFIX)) {
       const ruleId = menuId.slice(ADD_TO_RULE_PREFIX.length)
       await this.handleAddTabToRule(ruleId, tab)
@@ -233,6 +246,33 @@ class ContextMenuService {
       // Re-group all tabs so the new domain takes effect immediately
       await tabGroupService.ungroupAllTabs()
       await tabGroupService.groupAllTabsManually()
+    }
+  }
+
+  /**
+   * Handles adding the current tab's domain to the blacklist
+   */
+  private async handleAddToBlacklist(tab?: Browser.tabs.Tab): Promise<void> {
+    if (!tab?.url) return
+
+    const domain = extractDomain(tab.url)
+    if (!domain || domain === "system") return
+
+    try {
+      await rulesService.addRule({
+        name: "",
+        domains: [domain],
+        isBlacklist: true,
+        enabled: true
+      })
+
+      // Ungroup and re-group so the blacklist takes effect
+      await tabGroupService.ungroupAllTabs()
+      await tabGroupService.groupAllTabsManually()
+
+      console.log(`[ContextMenuService] Added "${domain}" to blacklist`)
+    } catch (error) {
+      console.error("[ContextMenuService] Error adding to blacklist:", error)
     }
   }
 

--- a/services/RulesService.ts
+++ b/services/RulesService.ts
@@ -52,16 +52,36 @@ class RulesService {
     if (!url) return null
 
     const customRules = tabGroupState.getCustomRulesObject()
-    const ruleCount = Object.keys(customRules).length
+    const groupingRules = Object.values(customRules).filter(r => !r.isBlacklist)
 
-    console.log(`[RulesService] Found ${ruleCount} custom rules to check`)
+    console.log(`[RulesService] Found ${groupingRules.length} grouping rules to check`)
 
     // First pass: exact matches only (no auto-subdomain)
-    const exactMatch = this.findMatchInRules(url, Object.values(customRules), false)
+    const exactMatch = this.findMatchInRules(url, groupingRules, false)
     if (exactMatch) return exactMatch
 
     // Second pass: auto-subdomain matches (domain.com matches *.domain.com)
-    return this.findMatchInRules(url, Object.values(customRules), true)
+    return this.findMatchInRules(url, groupingRules, true)
+  }
+
+  /**
+   * Finds a matching blacklist rule for a given URL.
+   * Blacklist rules prevent tabs from being grouped entirely.
+   */
+  async findBlacklistMatch(url: string): Promise<MatchedRule | null> {
+    if (!url) return null
+
+    const customRules = tabGroupState.getCustomRulesObject()
+    const blacklistRules = Object.values(customRules).filter(r => r.isBlacklist === true)
+
+    if (blacklistRules.length === 0) return null
+
+    // First pass: exact matches only
+    const exactMatch = this.findMatchInRules(url, blacklistRules, false)
+    if (exactMatch) return exactMatch
+
+    // Second pass: auto-subdomain matches
+    return this.findMatchInRules(url, blacklistRules, true)
   }
 
   /**
@@ -181,13 +201,16 @@ class RulesService {
       enabled: ruleData.enabled !== false,
       priority: ruleData.priority || 1,
       minimumTabs: ruleData.minimumTabs,
+      isBlacklist: ruleData.isBlacklist ?? false,
       createdAt: new Date().toISOString()
     }
 
     tabGroupState.addCustomRule(ruleId, rule)
     await this.saveState()
 
-    console.log(`[RulesService] Added new rule: ${rule.name} (${ruleId})`)
+    console.log(
+      `[RulesService] Added new rule: ${rule.name} (${ruleId})${rule.isBlacklist ? " [blacklist]" : ""}`
+    )
     return ruleId
   }
 
@@ -215,7 +238,8 @@ class RulesService {
         : existingRule.color) as TabGroupColor,
       enabled: ruleData.enabled !== false,
       priority: ruleData.priority || existingRule.priority,
-      minimumTabs: ruleData.minimumTabs ?? existingRule.minimumTabs
+      minimumTabs: ruleData.minimumTabs ?? existingRule.minimumTabs,
+      isBlacklist: ruleData.isBlacklist ?? existingRule.isBlacklist ?? false
     }
 
     tabGroupState.updateCustomRule(ruleId, updatedRule)
@@ -372,6 +396,7 @@ class RulesService {
               : "blue") as TabGroupColor,
             enabled: ruleData.enabled !== false,
             priority: ruleData.priority || 1,
+            isBlacklist: ruleData.isBlacklist ?? false,
             createdAt: ruleData.createdAt || new Date().toISOString()
           }
         } else {

--- a/services/RulesService.ts
+++ b/services/RulesService.ts
@@ -271,13 +271,15 @@ class RulesService {
   validateRule(ruleData: RuleData): RuleValidation {
     const errors: string[] = []
 
-    // Validate name
-    if (!ruleData.name || typeof ruleData.name !== "string") {
-      errors.push("Rule name is required")
-    } else if (ruleData.name.trim().length < 1) {
-      errors.push("Rule name cannot be empty")
-    } else if (ruleData.name.trim().length > 50) {
-      errors.push("Rule name cannot exceed 50 characters")
+    // Validate name (not required for blacklist rules)
+    if (!ruleData.isBlacklist) {
+      if (!ruleData.name || typeof ruleData.name !== "string") {
+        errors.push("Rule name is required")
+      } else if (ruleData.name.trim().length < 1) {
+        errors.push("Rule name cannot be empty")
+      } else if (ruleData.name.trim().length > 50) {
+        errors.push("Rule name cannot exceed 50 characters")
+      }
     }
 
     // Validate patterns

--- a/services/TabGroupService.ts
+++ b/services/TabGroupService.ts
@@ -105,6 +105,18 @@ class TabGroupServiceSimplified {
         return false
       }
 
+      // Check blacklist rules — if matched, ungroup the tab and skip all grouping
+      const blacklistMatch = await rulesService.findBlacklistMatch(tab.url || "")
+      if (blacklistMatch) {
+        console.log(
+          `[TabGroupService] Tab ${tabId} matches blacklist rule "${blacklistMatch.name}", skipping grouping`
+        )
+        if (tab.groupId && tab.groupId !== -1) {
+          await withTabEditRetry(() => browser.tabs.ungroup([tabId]))
+        }
+        return false
+      }
+
       // Handle rules-only mode
       if (tabGroupState.groupByMode === "rules-only") {
         const customRule = await rulesService.findMatchingRule(tab.url || "")
@@ -171,6 +183,10 @@ class TabGroupServiceSimplified {
 
       for (const tab of tabs) {
         if (tab.pinned) continue
+
+        // Skip blacklisted tabs from count
+        const blacklisted = await rulesService.findBlacklistMatch(tab.url || "")
+        if (blacklisted) continue
 
         if (customRule) {
           const matchingRule = await rulesService.findMatchingRule(tab.url || "")
@@ -341,6 +357,10 @@ class TabGroupServiceSimplified {
         if (otherTab.pinned || (otherTab.groupId && otherTab.groupId !== -1)) {
           continue
         }
+
+        // Skip blacklisted tabs
+        const blacklisted = await rulesService.findBlacklistMatch(otherTab.url || "")
+        if (blacklisted) continue
 
         let shouldGroup = false
         if (customRule) {

--- a/tests/BlacklistRules.test.ts
+++ b/tests/BlacklistRules.test.ts
@@ -1,0 +1,306 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { tabGroupState } from "../services/TabGroupState"
+import type { CustomRule } from "../types"
+import { DEFAULT_STATE } from "../types/storage"
+
+// Mock storage utilities before importing RulesService
+vi.mock("../utils/storage", () => ({
+  saveAllStorage: vi.fn().mockResolvedValue(undefined),
+  getGroupColor: vi.fn().mockResolvedValue(null),
+  updateGroupColor: vi.fn().mockResolvedValue(undefined),
+  groupColorMapping: {
+    getValue: vi.fn().mockResolvedValue({})
+  }
+}))
+
+import { rulesService } from "../services/RulesService"
+
+/**
+ * Tests for blacklist rules.
+ * Blacklist rules prevent matching tabs from being grouped entirely,
+ * taking priority over normal grouping rules.
+ */
+describe("Blacklist Rules", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    tabGroupState.updateFromStorage(DEFAULT_STATE)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function createRule(overrides: Partial<CustomRule> & { id: string }): CustomRule {
+    return {
+      name: "Test Rule",
+      domains: ["example.com"],
+      color: "blue",
+      enabled: true,
+      priority: 1,
+      isBlacklist: false,
+      createdAt: new Date().toISOString(),
+      ...overrides
+    }
+  }
+
+  function setupRules(rules: Record<string, CustomRule>): void {
+    tabGroupState.updateFromStorage({
+      ...DEFAULT_STATE,
+      autoGroupingEnabled: true,
+      customRules: rules
+    })
+  }
+
+  describe("RulesService.findBlacklistMatch", () => {
+    it("should return a match when URL matches a blacklist rule", async () => {
+      setupRules({
+        "rule-bl": createRule({
+          id: "rule-bl",
+          name: "Blocked Sites",
+          domains: ["blocked.com"],
+          isBlacklist: true
+        })
+      })
+
+      const result = await rulesService.findBlacklistMatch("https://blocked.com/page")
+      expect(result).not.toBeNull()
+      expect(result?.name).toBe("Blocked Sites")
+    })
+
+    it("should return null when URL does not match any blacklist rule", async () => {
+      setupRules({
+        "rule-bl": createRule({
+          id: "rule-bl",
+          name: "Blocked Sites",
+          domains: ["blocked.com"],
+          isBlacklist: true
+        })
+      })
+
+      const result = await rulesService.findBlacklistMatch("https://allowed.com/page")
+      expect(result).toBeNull()
+    })
+
+    it("should return null when there are no blacklist rules", async () => {
+      setupRules({
+        "rule-normal": createRule({
+          id: "rule-normal",
+          name: "Normal Rule",
+          domains: ["example.com"],
+          isBlacklist: false
+        })
+      })
+
+      const result = await rulesService.findBlacklistMatch("https://example.com/page")
+      expect(result).toBeNull()
+    })
+
+    it("should ignore disabled blacklist rules", async () => {
+      setupRules({
+        "rule-bl": createRule({
+          id: "rule-bl",
+          name: "Blocked Sites",
+          domains: ["blocked.com"],
+          isBlacklist: true,
+          enabled: false
+        })
+      })
+
+      const result = await rulesService.findBlacklistMatch("https://blocked.com/page")
+      expect(result).toBeNull()
+    })
+
+    it("should match wildcard patterns in blacklist rules", async () => {
+      setupRules({
+        "rule-bl": createRule({
+          id: "rule-bl",
+          name: "Blocked Wildcards",
+          domains: ["*.blocked.com"],
+          isBlacklist: true
+        })
+      })
+
+      const result = await rulesService.findBlacklistMatch("https://sub.blocked.com/page")
+      expect(result).not.toBeNull()
+    })
+
+    it("should support exclusion patterns within blacklist rules", async () => {
+      setupRules({
+        "rule-bl": createRule({
+          id: "rule-bl",
+          name: "Blocked with Exception",
+          domains: ["*.example.com", "!safe.example.com"],
+          isBlacklist: true
+        })
+      })
+
+      expect(await rulesService.findBlacklistMatch("https://bad.example.com/page")).not.toBeNull()
+      expect(await rulesService.findBlacklistMatch("https://safe.example.com/page")).toBeNull()
+    })
+
+    it("should return null for empty URL", async () => {
+      setupRules({
+        "rule-bl": createRule({
+          id: "rule-bl",
+          domains: ["blocked.com"],
+          isBlacklist: true
+        })
+      })
+
+      const result = await rulesService.findBlacklistMatch("")
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("RulesService.findMatchingRule excludes blacklist rules", () => {
+    it("should not return blacklist rules from findMatchingRule", async () => {
+      setupRules({
+        "rule-bl": createRule({
+          id: "rule-bl",
+          name: "Blocked",
+          domains: ["example.com"],
+          isBlacklist: true
+        })
+      })
+
+      const result = await rulesService.findMatchingRule("https://example.com/page")
+      expect(result).toBeNull()
+    })
+
+    it("should return normal rules while skipping blacklist rules", async () => {
+      setupRules({
+        "rule-bl": createRule({
+          id: "rule-bl",
+          name: "Blocked",
+          domains: ["blocked.com"],
+          isBlacklist: true
+        }),
+        "rule-normal": createRule({
+          id: "rule-normal",
+          name: "Normal Group",
+          domains: ["example.com"],
+          isBlacklist: false
+        })
+      })
+
+      const result = await rulesService.findMatchingRule("https://example.com/page")
+      expect(result).not.toBeNull()
+      expect(result?.name).toBe("Normal Group")
+
+      const blockedResult = await rulesService.findMatchingRule("https://blocked.com/page")
+      expect(blockedResult).toBeNull()
+    })
+  })
+
+  describe("RulesService.addRule with isBlacklist", () => {
+    it("should persist isBlacklist flag when adding a rule", async () => {
+      vi.spyOn(tabGroupState, "addCustomRule")
+
+      await rulesService.addRule({
+        name: "Blocked",
+        domains: ["blocked.com"],
+        isBlacklist: true
+      })
+
+      expect(tabGroupState.addCustomRule).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ isBlacklist: true })
+      )
+    })
+
+    it("should default isBlacklist to false when not specified", async () => {
+      vi.spyOn(tabGroupState, "addCustomRule")
+
+      await rulesService.addRule({
+        name: "Normal",
+        domains: ["example.com"]
+      })
+
+      expect(tabGroupState.addCustomRule).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ isBlacklist: false })
+      )
+    })
+  })
+
+  describe("RulesService.updateRule with isBlacklist", () => {
+    it("should update isBlacklist flag", async () => {
+      setupRules({
+        "rule-1": createRule({
+          id: "rule-1",
+          name: "Was Normal",
+          domains: ["example.com"],
+          isBlacklist: false
+        })
+      })
+
+      vi.spyOn(tabGroupState, "updateCustomRule")
+
+      await rulesService.updateRule("rule-1", {
+        name: "Now Blocked",
+        domains: ["example.com"],
+        isBlacklist: true
+      })
+
+      expect(tabGroupState.updateCustomRule).toHaveBeenCalledWith(
+        "rule-1",
+        expect.objectContaining({ isBlacklist: true })
+      )
+    })
+
+    it("should preserve existing isBlacklist when not specified in update", async () => {
+      setupRules({
+        "rule-1": createRule({
+          id: "rule-1",
+          name: "Blacklisted",
+          domains: ["example.com"],
+          isBlacklist: true
+        })
+      })
+
+      vi.spyOn(tabGroupState, "updateCustomRule")
+
+      await rulesService.updateRule("rule-1", {
+        name: "Still Blacklisted",
+        domains: ["example.com"]
+      })
+
+      expect(tabGroupState.updateCustomRule).toHaveBeenCalledWith(
+        "rule-1",
+        expect.objectContaining({ isBlacklist: true })
+      )
+    })
+  })
+
+  describe("Blacklist priority over normal rules", () => {
+    it("blacklist match should be found even when a normal rule also matches the same domain", async () => {
+      setupRules({
+        "rule-normal": createRule({
+          id: "rule-normal",
+          name: "Group It",
+          domains: ["example.com"],
+          isBlacklist: false
+        }),
+        "rule-bl": createRule({
+          id: "rule-bl",
+          name: "Block It",
+          domains: ["example.com"],
+          isBlacklist: true
+        })
+      })
+
+      // Normal matching excludes blacklist rules
+      const normalMatch = await rulesService.findMatchingRule("https://example.com/page")
+      expect(normalMatch).not.toBeNull()
+      expect(normalMatch?.name).toBe("Group It")
+
+      // Blacklist matching finds the blacklist rule
+      const blacklistMatch = await rulesService.findBlacklistMatch("https://example.com/page")
+      expect(blacklistMatch).not.toBeNull()
+      expect(blacklistMatch?.name).toBe("Block It")
+
+      // In the actual grouping pipeline, blacklist is checked first (in TabGroupService),
+      // so the tab would never reach findMatchingRule
+    })
+  })
+})

--- a/types/rules.ts
+++ b/types/rules.ts
@@ -46,6 +46,8 @@ export interface CustomRule {
   priority: number
   /** Minimum tabs required to form this group (optional, overrides global) */
   minimumTabs?: number
+  /** Whether this rule is a blacklist (prevents grouping instead of creating groups) */
+  isBlacklist?: boolean
   /** ISO date string when rule was created */
   createdAt: string
 }
@@ -60,6 +62,7 @@ export interface RuleData {
   enabled?: boolean
   priority?: number
   minimumTabs?: number
+  isBlacklist?: boolean
   id?: string
   createdAt?: string
 }


### PR DESCRIPTION
This pull request introduces a comprehensive "Blacklist" feature to the tab grouping extension, allowing users to specify domains that should never be grouped. The changes span the popup and sidebar UIs, as well as the rule creation modal and background logic. The implementation includes new UI sections, event handling, rule persistence, and specialized behavior for blacklist rules.

The most important changes are:

**Blacklist UI and Functionality:**
* Added a dedicated "Blacklist" section to both the popup and sidebar UIs, including a toggleable panel, count display, and a list of blacklisted domains with add/edit/delete capabilities. (`entrypoints/popup/index.html` [[1]](diffhunk://#diff-2c7eeba9066dfb900facdac231869fe59a2ad91fea520aaf6dcc6ea2a7b48fbfR240-R267) `entrypoints/sidebar/index.html` [[2]](diffhunk://#diff-14753d51b4dff1d6e3d394d4d03c97abf76e48ef317ae2fb5a6bc2d78bc7f1f1R241-R268) `entrypoints/popup/main.ts` [[3]](diffhunk://#diff-0568bcb31e58b72c3e01c26ffdd940d90906754f56cc5183fd5bad38b9a755d1R46-R52) [[4]](diffhunk://#diff-0568bcb31e58b72c3e01c26ffdd940d90906754f56cc5183fd5bad38b9a755d1L190-R309) [[5]](diffhunk://#diff-0568bcb31e58b72c3e01c26ffdd940d90906754f56cc5183fd5bad38b9a755d1R494-R528) [[6]](diffhunk://#diff-0568bcb31e58b72c3e01c26ffdd940d90906754f56cc5183fd5bad38b9a755d1R1169-R1172) `entrypoints/sidebar/main.ts` [[7]](diffhunk://#diff-381d6214f5a38830fac82bb3d8988807f9358fb4e6f7eb3379fbf96ad95c79ddR48-R54) [[8]](diffhunk://#diff-381d6214f5a38830fac82bb3d8988807f9358fb4e6f7eb3379fbf96ad95c79ddR78)
* Implemented blacklist-specific styling for rule display and section elements to visually distinguish blacklisted domains from grouping rules. (`entrypoints/popup/style.css` [[1]](diffhunk://#diff-bd15d0be90c6529149e4e6b5796cc05681875d23ba363ba64971433f5e98304eR531-R542) [[2]](diffhunk://#diff-bd15d0be90c6529149e4e6b5796cc05681875d23ba363ba64971433f5e98304eR1311-R1419)

**Blacklist Rule Creation and Editing:**
* Updated the rule creation modal to support "blacklist mode," hiding irrelevant fields (like color and rule name), adjusting UI labels, and ensuring blacklist rules are saved with the appropriate attributes. (`entrypoints/rules-modal.unlisted/index.html` [[1]](diffhunk://#diff-0729db1ce3919620e491eb1fe2529fad6da1734ba67c1440176d065bd40c4898L59-R59) `entrypoints/rules-modal.unlisted/main.ts` [[2]](diffhunk://#diff-2ee71c3f6ed91d7c1d343cd98b6aed30ded3ff31056d3b0357c8e6939e8ea523R25-R28) [[3]](diffhunk://#diff-2ee71c3f6ed91d7c1d343cd98b6aed30ded3ff31056d3b0357c8e6939e8ea523L122-R144) [[4]](diffhunk://#diff-2ee71c3f6ed91d7c1d343cd98b6aed30ded3ff31056d3b0357c8e6939e8ea523R277-R289) [[5]](diffhunk://#diff-2ee71c3f6ed91d7c1d343cd98b6aed30ded3ff31056d3b0357c8e6939e8ea523R455-R457)

**Rule Handling and Background Logic:**
* Ensured that when a blacklist rule is added or edited, any currently grouped tabs matching the blacklist are ungrouped immediately, and grouping logic is re-applied. (`entrypoints/background.ts` [entrypoints/background.tsR270-R273](diffhunk://#diff-8d11bb5e767a7727c1d6e56e994158a624642b373408c225fe0008f61b562f3dR270-R273))
* Refactored rule display and management logic to separate blacklist rules from grouping rules, ensuring accurate counts and preventing blacklisted domains from being grouped. (`entrypoints/popup/main.ts` [entrypoints/popup/main.tsL190-R309](diffhunk://#diff-0568bcb31e58b72c3e01c26ffdd940d90906754f56cc5183fd5bad38b9a755d1L190-R309))

These changes collectively provide users with fine-grained control over which domains are never grouped, improving the flexibility and usability of the extension.