### PR TITLE
feat: add Z-A sort direction for tab groups (closes #63)

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -235,6 +235,21 @@ export default defineBackground(() => {
             break
           }
 
+          case "getSortGroupsDirection":
+            result = { direction: tabGroupState.sortGroupsDirection }
+            break
+
+          case "setSortGroupsDirection": {
+            tabGroupState.sortGroupsDirection = msg.direction
+            await saveState()
+            if (tabGroupState.sortGroupsAlphabetically) {
+              const { tabSortService } = await import("../services/TabSortService")
+              await tabSortService.sortGroups()
+            }
+            result = { direction: tabGroupState.sortGroupsDirection }
+            break
+          }
+
           case "getIndexGroupTitles":
             result = { enabled: tabGroupState.indexGroupTitles }
             break

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -240,6 +240,9 @@ export default defineBackground(() => {
             break
 
           case "setSortGroupsDirection": {
+            console.log(
+              `[Background] setSortGroupsDirection=${msg.direction} (sortEnabled=${tabGroupState.sortGroupsAlphabetically})`
+            )
             tabGroupState.sortGroupsDirection = msg.direction
             await saveState()
             if (tabGroupState.sortGroupsAlphabetically) {

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -121,11 +121,18 @@
         </button>
         <div class="sorting-content">
           <div class="toggle-container">
-            <span>Keep groups sorted A-Z</span>
+            <span>Keep groups sorted alphabetically</span>
             <label class="switch">
               <input type="checkbox" id="sortGroupsToggle" />
               <span class="slider round"></span>
             </label>
+          </div>
+          <div class="toggle-container sort-direction-container" id="sortDirectionContainer">
+            <span>Direction</span>
+            <div class="group-by-toggle-bar sort-direction-toggle-bar">
+              <button class="toggle-option sort-direction-option active" data-value="asc">A - Z</button>
+              <button class="toggle-option sort-direction-option" data-value="desc">Z - A</button>
+            </div>
           </div>
           <div class="toggle-container sorting-index-container" id="sortingIndexContainer">
             <span>Number groups (1. AI, 2. Docs...)</span>

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -12,7 +12,9 @@ const collapseAllButton = document.getElementById("collapseAllButton") as HTMLBu
 const expandAllButton = document.getElementById("expandAllButton") as HTMLButtonElement
 const autoGroupToggle = document.getElementById("autoGroupToggle") as HTMLInputElement
 const groupNewTabsToggle = document.getElementById("groupNewTabsToggle") as HTMLInputElement
-const groupByToggleOptions = document.querySelectorAll<HTMLButtonElement>(".toggle-option")
+const groupByToggleOptions = document.querySelectorAll<HTMLButtonElement>(
+  ".group-by-toggle-bar:not(.sort-direction-toggle-bar) .toggle-option"
+)
 const minimumTabsInput = document.getElementById("minimumTabsInput") as HTMLInputElement
 
 // Auto-collapse Elements
@@ -30,6 +32,8 @@ const openTabNextToCurrentToggle = document.getElementById(
 const sortingToggle = document.querySelector(".sorting-toggle") as HTMLButtonElement
 const sortingContent = document.querySelector(".sorting-content") as HTMLDivElement
 const sortGroupsToggle = document.getElementById("sortGroupsToggle") as HTMLInputElement
+const sortDirectionContainer = document.getElementById("sortDirectionContainer") as HTMLDivElement
+const sortDirectionOptions = document.querySelectorAll<HTMLButtonElement>(".sort-direction-option")
 const sortingIndexContainer = document.getElementById("sortingIndexContainer") as HTMLDivElement
 const indexGroupTitlesToggle = document.getElementById("indexGroupTitlesToggle") as HTMLInputElement
 const sortingHelp = document.getElementById("sortingHelp") as HTMLDivElement
@@ -653,6 +657,10 @@ sendMessage<{ enabled?: boolean }>({ action: "getSortGroupsAlphabetically" }).th
   updateSortingSubOptions(enabled)
 })
 
+sendMessage<{ direction?: "asc" | "desc" }>({ action: "getSortGroupsDirection" }).then(response => {
+  updateSortDirectionButtons(response?.direction ?? "asc")
+})
+
 sendMessage<{ enabled?: boolean }>({ action: "getIndexGroupTitles" }).then(response => {
   indexGroupTitlesToggle.checked = response?.enabled ?? false
 })
@@ -734,13 +742,21 @@ function toggleSortingSection(): void {
 
 function updateSortingSubOptions(sortEnabled: boolean): void {
   if (sortEnabled) {
+    sortDirectionContainer.classList.add("visible")
     sortingIndexContainer.classList.add("visible")
     sortingHelp.classList.add("visible")
   } else {
+    sortDirectionContainer.classList.remove("visible")
     sortingIndexContainer.classList.remove("visible")
     sortingHelp.classList.remove("visible")
     indexGroupTitlesToggle.checked = false
   }
+}
+
+function updateSortDirectionButtons(direction: string): void {
+  sortDirectionOptions.forEach(option => {
+    option.classList.toggle("active", option.dataset.value === direction)
+  })
 }
 
 sortingToggle?.addEventListener("click", toggleSortingSection)
@@ -752,6 +768,17 @@ sortGroupsToggle.addEventListener("change", event => {
   sendMessage({
     action: "toggleSortGroupsAlphabetically",
     enabled
+  })
+})
+
+// Sort direction event listeners
+sortDirectionOptions.forEach(option => {
+  option.addEventListener("click", () => {
+    const direction = option.dataset.value
+    if (direction === "asc" || direction === "desc") {
+      updateSortDirectionButtons(direction)
+      sendMessage({ action: "setSortGroupsDirection", direction })
+    }
   })
 })
 

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -829,6 +829,19 @@ input:checked + .slider:before {
   display: flex;
 }
 
+.sort-direction-container {
+  display: none;
+  padding-left: 16px;
+}
+
+.sort-direction-container.visible {
+  display: flex;
+}
+
+.sort-direction-toggle-bar {
+  gap: 2px;
+}
+
 .sorting-help {
   display: none;
   padding-left: 16px;

--- a/entrypoints/sidebar/index.html
+++ b/entrypoints/sidebar/index.html
@@ -122,11 +122,18 @@
           </button>
           <div class="sorting-content">
             <div class="toggle-container">
-              <span>Keep groups sorted A-Z</span>
+              <span>Keep groups sorted alphabetically</span>
               <label class="switch">
                 <input type="checkbox" id="sortGroupsToggle" />
                 <span class="slider round"></span>
               </label>
+            </div>
+            <div class="toggle-container sort-direction-container" id="sortDirectionContainer">
+              <span>Direction</span>
+              <div class="group-by-toggle-bar sort-direction-toggle-bar">
+                <button class="toggle-option sort-direction-option active" data-value="asc">A - Z</button>
+                <button class="toggle-option sort-direction-option" data-value="desc">Z - A</button>
+              </div>
             </div>
             <div class="toggle-container sorting-index-container" id="sortingIndexContainer">
               <span>Number groups (1. AI, 2. Docs...)</span>

--- a/entrypoints/sidebar/main.ts
+++ b/entrypoints/sidebar/main.ts
@@ -13,7 +13,9 @@ const collapseAllButton = document.getElementById("collapseAllButton") as HTMLBu
 const expandAllButton = document.getElementById("expandAllButton") as HTMLButtonElement
 const autoGroupToggle = document.getElementById("autoGroupToggle") as HTMLInputElement
 const groupNewTabsToggle = document.getElementById("groupNewTabsToggle") as HTMLInputElement
-const groupByToggleOptions = document.querySelectorAll<HTMLButtonElement>(".toggle-option")
+const groupByToggleOptions = document.querySelectorAll<HTMLButtonElement>(
+  ".group-by-toggle-bar:not(.sort-direction-toggle-bar) .toggle-option"
+)
 const minimumTabsInput = document.getElementById("minimumTabsInput") as HTMLInputElement
 
 // Auto-collapse Elements
@@ -31,6 +33,8 @@ const openTabNextToCurrentToggle = document.getElementById(
 const sortingToggle = document.querySelector(".sorting-toggle") as HTMLButtonElement
 const sortingContent = document.querySelector(".sorting-content") as HTMLDivElement
 const sortGroupsToggle = document.getElementById("sortGroupsToggle") as HTMLInputElement
+const sortDirectionContainer = document.getElementById("sortDirectionContainer") as HTMLDivElement
+const sortDirectionOptions = document.querySelectorAll<HTMLButtonElement>(".sort-direction-option")
 const sortingIndexContainer = document.getElementById("sortingIndexContainer") as HTMLDivElement
 const indexGroupTitlesToggle = document.getElementById("indexGroupTitlesToggle") as HTMLInputElement
 const sortingHelp = document.getElementById("sortingHelp") as HTMLDivElement
@@ -697,6 +701,10 @@ sendMessage<{ enabled?: boolean }>({ action: "getSortGroupsAlphabetically" }).th
   updateSortingSubOptions(enabled)
 })
 
+sendMessage<{ direction?: "asc" | "desc" }>({ action: "getSortGroupsDirection" }).then(response => {
+  updateSortDirectionButtons(response?.direction ?? "asc")
+})
+
 sendMessage<{ enabled?: boolean }>({ action: "getIndexGroupTitles" }).then(response => {
   indexGroupTitlesToggle.checked = response?.enabled ?? false
 })
@@ -778,13 +786,21 @@ function toggleSortingSection(): void {
 
 function updateSortingSubOptions(sortEnabled: boolean): void {
   if (sortEnabled) {
+    sortDirectionContainer.classList.add("visible")
     sortingIndexContainer.classList.add("visible")
     sortingHelp.classList.add("visible")
   } else {
+    sortDirectionContainer.classList.remove("visible")
     sortingIndexContainer.classList.remove("visible")
     sortingHelp.classList.remove("visible")
     indexGroupTitlesToggle.checked = false
   }
+}
+
+function updateSortDirectionButtons(direction: string): void {
+  sortDirectionOptions.forEach(option => {
+    option.classList.toggle("active", option.dataset.value === direction)
+  })
 }
 
 sortingToggle?.addEventListener("click", toggleSortingSection)
@@ -796,6 +812,17 @@ sortGroupsToggle.addEventListener("change", event => {
   sendMessage({
     action: "toggleSortGroupsAlphabetically",
     enabled
+  })
+})
+
+// Sort direction event listeners
+sortDirectionOptions.forEach(option => {
+  option.addEventListener("click", () => {
+    const direction = option.dataset.value
+    if (direction === "asc" || direction === "desc") {
+      updateSortDirectionButtons(direction)
+      sendMessage({ action: "setSortGroupsDirection", direction })
+    }
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/services/TabGroupState.ts
+++ b/services/TabGroupState.ts
@@ -8,6 +8,7 @@ import type {
   CustomRulesMapping,
   GroupByMode,
   RuleMatchingMode,
+  SortDirection,
   StorageSchema
 } from "../types"
 import { DEFAULT_STATE } from "../types/storage"
@@ -23,6 +24,7 @@ class TabGroupState {
   autoCollapseDelayMs: number
   openTabNextToCurrent: boolean
   sortGroupsAlphabetically: boolean
+  sortGroupsDirection: SortDirection
   indexGroupTitles: boolean
 
   constructor() {
@@ -36,6 +38,7 @@ class TabGroupState {
     this.autoCollapseDelayMs = DEFAULT_STATE.autoCollapseDelayMs
     this.openTabNextToCurrent = DEFAULT_STATE.openTabNextToCurrent
     this.sortGroupsAlphabetically = DEFAULT_STATE.sortGroupsAlphabetically
+    this.sortGroupsDirection = DEFAULT_STATE.sortGroupsDirection
     this.indexGroupTitles = DEFAULT_STATE.indexGroupTitles
   }
 
@@ -52,6 +55,7 @@ class TabGroupState {
     this.autoCollapseDelayMs = data.autoCollapseDelayMs ?? this.autoCollapseDelayMs
     this.openTabNextToCurrent = data.openTabNextToCurrent ?? this.openTabNextToCurrent
     this.sortGroupsAlphabetically = data.sortGroupsAlphabetically ?? this.sortGroupsAlphabetically
+    this.sortGroupsDirection = data.sortGroupsDirection ?? this.sortGroupsDirection
     this.indexGroupTitles = data.indexGroupTitles ?? this.indexGroupTitles
 
     this.customRules.clear()
@@ -79,6 +83,7 @@ class TabGroupState {
       autoCollapseDelayMs: this.autoCollapseDelayMs,
       openTabNextToCurrent: this.openTabNextToCurrent,
       sortGroupsAlphabetically: this.sortGroupsAlphabetically,
+      sortGroupsDirection: this.sortGroupsDirection,
       indexGroupTitles: this.indexGroupTitles,
       // AI settings managed by AiService, pass defaults for storage schema
       aiEnabled: DEFAULT_STATE.aiEnabled,

--- a/services/TabSortService.ts
+++ b/services/TabSortService.ts
@@ -43,9 +43,9 @@ function isAlreadySorted(
 
 class TabSortService {
   /**
-   * Sorts tab groups alphabetically (A-Z by title) in the current window,
-   * then moves ungrouped non-pinned tabs to the end of the tab strip.
-   * When indexing is enabled, applies numbered prefixes to titles.
+   * Sorts tab groups alphabetically by title (A-Z or Z-A) in the current
+   * window, then moves ungrouped non-pinned tabs to the end of the tab
+   * strip. When indexing is enabled, applies numbered prefixes to titles.
    *
    * Optimized: compares current vs desired order and only moves groups
    * that are actually out of place to minimize visual flash.
@@ -71,11 +71,19 @@ class TabSortService {
         return
       }
 
-      // Compute desired alphabetical order by stripped title
-      const sorted = [...groups].sort((a, b) =>
-        stripIndexPrefix(a.title ?? "").localeCompare(stripIndexPrefix(b.title ?? ""), undefined, {
-          sensitivity: "base"
-        })
+      // Compute desired alphabetical order by stripped title, respecting
+      // the configured direction ("asc" = A-Z, "desc" = Z-A)
+      const directionFactor = tabGroupState.sortGroupsDirection === "desc" ? -1 : 1
+      const sorted = [...groups].sort(
+        (a, b) =>
+          directionFactor *
+          stripIndexPrefix(a.title ?? "").localeCompare(
+            stripIndexPrefix(b.title ?? ""),
+            undefined,
+            {
+              sensitivity: "base"
+            }
+          )
       )
 
       // Update index prefixes if enabled (title-only, no moves yet)

--- a/services/TabSortService.ts
+++ b/services/TabSortService.ts
@@ -56,6 +56,7 @@ class TabSortService {
     const tabGroups = browser.tabGroups as unknown as TabGroupsWithMove | undefined
 
     if (!tabGroups?.move) {
+      console.log("[TabSortService] tabGroups.move unavailable (Firefox?), skipping sort")
       return
     }
 
@@ -65,11 +66,35 @@ class TabSortService {
         return
       }
 
-      const groups = await tabGroups.query({ windowId: currentWindow.id })
+      const queriedGroups = await tabGroups.query({ windowId: currentWindow.id })
 
-      if (groups.length === 0) {
+      if (queriedGroups.length === 0) {
         return
       }
+
+      // browser.tabGroups.query() does not return groups in visual tab-strip
+      // order (it's stable by creation/ID). To compare against the current
+      // layout, derive visual order from the first tab of each group in
+      // tab-index order. Falls back to queried order if no tabs resolve
+      // groups (e.g., in tests).
+      const allTabs = await browser.tabs.query({ windowId: currentWindow.id })
+      const tabsByIndex = [...allTabs].sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+      const groupById = new Map(queriedGroups.map(g => [g.id, g]))
+      const visualGroupIds: number[] = []
+      const seenGroupIds = new Set<number>()
+      for (const tab of tabsByIndex) {
+        const gid = tab.groupId
+        if (gid && gid !== -1 && !seenGroupIds.has(gid) && groupById.has(gid)) {
+          seenGroupIds.add(gid)
+          visualGroupIds.push(gid)
+        }
+      }
+      const groups =
+        visualGroupIds.length > 0
+          ? visualGroupIds
+              .map(id => groupById.get(id))
+              .filter((g): g is NonNullable<typeof g> => g !== undefined)
+          : queriedGroups
 
       // Compute desired alphabetical order by stripped title, respecting
       // the configured direction ("asc" = A-Z, "desc" = Z-A)
@@ -84,6 +109,14 @@ class TabSortService {
               sensitivity: "base"
             }
           )
+      )
+
+      console.log(
+        `[TabSortService] sortGroups: direction=${tabGroupState.sortGroupsDirection}`,
+        "current=",
+        groups.map(g => g.title),
+        "desired=",
+        sorted.map(g => g.title)
       )
 
       // Update index prefixes if enabled (title-only, no moves yet)

--- a/tests/TabGroupState.test.ts
+++ b/tests/TabGroupState.test.ts
@@ -70,6 +70,15 @@ describe("TabGroupState", () => {
       expect(tabGroupState.sortGroupsAlphabetically).toBe(false)
     })
 
+    it("should update sortGroupsDirection", () => {
+      tabGroupState.updateFromStorage({ sortGroupsDirection: "desc" })
+      expect(tabGroupState.sortGroupsDirection).toBe("desc")
+    })
+
+    it("should default sortGroupsDirection to asc", () => {
+      expect(tabGroupState.sortGroupsDirection).toBe("asc")
+    })
+
     it("should update indexGroupTitles", () => {
       tabGroupState.updateFromStorage({ indexGroupTitles: true })
       expect(tabGroupState.indexGroupTitles).toBe(true)
@@ -142,6 +151,7 @@ describe("TabGroupState", () => {
       expect(data).toHaveProperty("groupColorMapping")
       expect(data).toHaveProperty("minimumTabsForGroup")
       expect(data).toHaveProperty("sortGroupsAlphabetically")
+      expect(data).toHaveProperty("sortGroupsDirection")
       expect(data).toHaveProperty("indexGroupTitles")
     })
 

--- a/tests/TabSortService.test.ts
+++ b/tests/TabSortService.test.ts
@@ -263,6 +263,31 @@ describe("TabSortService", () => {
       expect(mockBrowser.tabGroups.move).toHaveBeenNthCalledWith(1, 2, { index: -1 })
       expect(mockBrowser.tabGroups.move).toHaveBeenNthCalledWith(2, 1, { index: -1 })
     })
+
+    it("should flip A-Z to Z-A when tab-strip order differs from tabGroups.query order", async () => {
+      // Regression: tabGroups.query() is stable by creation/ID, not visual
+      // tab-strip order. Relying on it caused Z-A (and reverse flips) to no-op
+      // after an initial sort had already been applied.
+      tabGroupState.sortGroupsDirection = "desc"
+      // Chrome returned groups in creation order: Youtube(1) then Google(2)
+      mockBrowser.tabGroups.query.mockResolvedValue([
+        { id: 1, title: "Youtube", windowId: 1 },
+        { id: 2, title: "Google", windowId: 1 }
+      ])
+      // But visually (after a prior A-Z sort) the strip is Google, Youtube
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 100, groupId: 2, pinned: false, index: 0 },
+        { id: 101, groupId: 1, pinned: false, index: 1 }
+      ])
+
+      await tabSortService.sortGroups()
+
+      // Visual order is [Google(2), Youtube(1)], desired Z-A is [Youtube(1), Google(2)] —
+      // every position differs, so both groups get moved.
+      expect(mockBrowser.tabGroups.move).toHaveBeenCalledTimes(2)
+      expect(mockBrowser.tabGroups.move).toHaveBeenNthCalledWith(1, 1, { index: -1 })
+      expect(mockBrowser.tabGroups.move).toHaveBeenNthCalledWith(2, 2, { index: -1 })
+    })
   })
 
   describe("sortGroups with indexing", () => {

--- a/tests/TabSortService.test.ts
+++ b/tests/TabSortService.test.ts
@@ -200,6 +200,71 @@ describe("TabSortService", () => {
     })
   })
 
+  describe("sortGroups with Z-A direction", () => {
+    it("should sort groups in reverse alphabetical order when direction is desc", async () => {
+      tabGroupState.sortGroupsDirection = "desc"
+      mockBrowser.tabGroups.query.mockResolvedValue([
+        { id: 1, title: "Amazon", windowId: 1 },
+        { id: 2, title: "GitHub", windowId: 1 },
+        { id: 3, title: "Docs", windowId: 1 }
+      ])
+      mockBrowser.tabs.query.mockResolvedValue([])
+
+      await tabSortService.sortGroups()
+
+      // Z-A order: GitHub(2), Docs(3), Amazon(1)
+      expect(mockBrowser.tabGroups.move).toHaveBeenCalledTimes(3)
+      expect(mockBrowser.tabGroups.move).toHaveBeenNthCalledWith(1, 2, { index: -1 })
+      expect(mockBrowser.tabGroups.move).toHaveBeenNthCalledWith(2, 3, { index: -1 })
+      expect(mockBrowser.tabGroups.move).toHaveBeenNthCalledWith(3, 1, { index: -1 })
+    })
+
+    it("should apply index prefixes in Z-A order when indexing is enabled", async () => {
+      tabGroupState.sortGroupsDirection = "desc"
+      tabGroupState.indexGroupTitles = true
+      mockBrowser.tabGroups.query.mockResolvedValue([
+        { id: 1, title: "Amazon", windowId: 1 },
+        { id: 2, title: "GitHub", windowId: 1 }
+      ])
+      mockBrowser.tabs.query.mockResolvedValue([])
+
+      await tabSortService.sortGroups()
+
+      // Z-A order means GitHub is 1, Amazon is 2
+      expect(mockBrowser.tabGroups.update).toHaveBeenCalledWith(2, { title: "1. GitHub" })
+      expect(mockBrowser.tabGroups.update).toHaveBeenCalledWith(1, { title: "2. Amazon" })
+    })
+
+    it("should skip moves when groups are already in Z-A order", async () => {
+      tabGroupState.sortGroupsDirection = "desc"
+      mockBrowser.tabGroups.query.mockResolvedValue([
+        { id: 1, title: "GitHub", windowId: 1 },
+        { id: 2, title: "Docs", windowId: 1 },
+        { id: 3, title: "Amazon", windowId: 1 }
+      ])
+      mockBrowser.tabs.query.mockResolvedValue([])
+
+      await tabSortService.sortGroups()
+
+      expect(mockBrowser.tabGroups.move).not.toHaveBeenCalled()
+    })
+
+    it("should fall back to A-Z order when direction is asc", async () => {
+      tabGroupState.sortGroupsDirection = "asc"
+      mockBrowser.tabGroups.query.mockResolvedValue([
+        { id: 1, title: "GitHub", windowId: 1 },
+        { id: 2, title: "Amazon", windowId: 1 }
+      ])
+      mockBrowser.tabs.query.mockResolvedValue([])
+
+      await tabSortService.sortGroups()
+
+      // A-Z: Amazon(2), GitHub(1)
+      expect(mockBrowser.tabGroups.move).toHaveBeenNthCalledWith(1, 2, { index: -1 })
+      expect(mockBrowser.tabGroups.move).toHaveBeenNthCalledWith(2, 1, { index: -1 })
+    })
+  })
+
   describe("sortGroups with indexing", () => {
     it("should apply index prefixes after sorting when indexGroupTitles is enabled", async () => {
       tabGroupState.indexGroupTitles = true

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -4,7 +4,7 @@
 
 import type { AiMessage, AiMessageAction } from "./ai-messages"
 import type { CustomRule, RuleData, RulesExportData, RulesStats } from "./rules"
-import type { GroupByMode } from "./storage"
+import type { GroupByMode, SortDirection } from "./storage"
 
 /**
  * All possible message actions
@@ -31,6 +31,8 @@ export type MessageAction =
   | "toggleOpenTabNextToCurrent"
   | "getSortGroupsAlphabetically"
   | "toggleSortGroupsAlphabetically"
+  | "getSortGroupsDirection"
+  | "setSortGroupsDirection"
   | "getIndexGroupTitles"
   | "toggleIndexGroupTitles"
   | "getCustomRules"
@@ -71,6 +73,7 @@ export interface SimpleMessage extends BaseMessage {
     | "getMinimumTabsForGroup"
     | "getOpenTabNextToCurrent"
     | "getSortGroupsAlphabetically"
+    | "getSortGroupsDirection"
     | "getIndexGroupTitles"
     | "getCustomRules"
     | "getRulesStats"
@@ -130,6 +133,14 @@ export interface ToggleOpenTabNextToCurrentMessage extends BaseMessage {
 export interface ToggleSortGroupsMessage extends BaseMessage {
   action: "toggleSortGroupsAlphabetically"
   enabled: boolean
+}
+
+/**
+ * Set sort groups direction message
+ */
+export interface SetSortGroupsDirectionMessage extends BaseMessage {
+  action: "setSortGroupsDirection"
+  direction: SortDirection
 }
 
 /**
@@ -194,6 +205,7 @@ export type Message =
   | SetMinimumTabsMessage
   | ToggleOpenTabNextToCurrentMessage
   | ToggleSortGroupsMessage
+  | SetSortGroupsDirectionMessage
   | ToggleIndexGroupTitlesMessage
   | AddCustomRuleMessage
   | UpdateCustomRuleMessage
@@ -252,6 +264,13 @@ export interface AutoGroupStateResponse {
  */
 export interface GroupByModeResponse {
   mode: GroupByMode
+}
+
+/**
+ * Response for get sort groups direction
+ */
+export interface SortGroupsDirectionResponse {
+  direction: SortDirection
 }
 
 /**

--- a/types/storage.ts
+++ b/types/storage.ts
@@ -16,6 +16,11 @@ export type GroupByMode = "rules-only" | "domain" | "subdomain"
 export type RuleMatchingMode = "exact" | "contains" | "regex"
 
 /**
+ * Direction for alphabetical sorting of tab groups
+ */
+export type SortDirection = "asc" | "desc"
+
+/**
  * Mapping of group titles to their colors
  */
 export type GroupColorMapping = Record<string, TabGroupColor>
@@ -55,8 +60,10 @@ export interface StorageSchema {
   aiModelId: string
   /** Whether to open new tabs next to the current tab (opt-in, default off) */
   openTabNextToCurrent: boolean
-  /** Whether to keep tab groups sorted alphabetically (A-Z) */
+  /** Whether to keep tab groups sorted alphabetically */
   sortGroupsAlphabetically: boolean
+  /** Sort direction when alphabetical sorting is enabled ("asc" = A-Z, "desc" = Z-A) */
+  sortGroupsDirection: SortDirection
   /** Whether to prefix group titles with their sort position (e.g., "1. AI") */
   indexGroupTitles: boolean
 }
@@ -79,6 +86,7 @@ export const DEFAULT_STATE: StorageSchema = {
   aiModelId: "Qwen2.5-3B-Instruct-q4f16_1-MLC",
   openTabNextToCurrent: false,
   sortGroupsAlphabetically: false,
+  sortGroupsDirection: "asc",
   indexGroupTitles: false
 }
 

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -11,6 +11,7 @@ import type {
   GroupByMode,
   GroupColorMapping,
   RuleMatchingMode,
+  SortDirection,
   StorageSchema,
   TabGroupColor
 } from "../types"
@@ -76,6 +77,10 @@ export const sortGroupsAlphabetically = storage.defineItem<boolean>(
   { fallback: DEFAULT_STATE.sortGroupsAlphabetically }
 )
 
+export const sortGroupsDirection = storage.defineItem<SortDirection>("local:sortGroupsDirection", {
+  fallback: DEFAULT_STATE.sortGroupsDirection
+})
+
 export const indexGroupTitles = storage.defineItem<boolean>("local:indexGroupTitles", {
   fallback: DEFAULT_STATE.indexGroupTitles
 })
@@ -107,6 +112,7 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     aiModelIdValue,
     openTabNextToCurrentValue,
     sortGroupsAlphabeticallyValue,
+    sortGroupsDirectionValue,
     indexGroupTitlesValue
   ] = await Promise.all([
     autoGroupingEnabled.getValue(),
@@ -123,6 +129,7 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     aiModelId.getValue(),
     openTabNextToCurrent.getValue(),
     sortGroupsAlphabetically.getValue(),
+    sortGroupsDirection.getValue(),
     indexGroupTitles.getValue()
   ])
 
@@ -141,6 +148,7 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     aiModelId: aiModelIdValue,
     openTabNextToCurrent: openTabNextToCurrentValue,
     sortGroupsAlphabetically: sortGroupsAlphabeticallyValue,
+    sortGroupsDirection: sortGroupsDirectionValue,
     indexGroupTitles: indexGroupTitlesValue
   }
 }
@@ -192,6 +200,9 @@ export async function saveAllStorage(data: Partial<StorageSchema>): Promise<void
   }
   if (data.sortGroupsAlphabetically !== undefined) {
     promises.push(sortGroupsAlphabetically.setValue(data.sortGroupsAlphabetically))
+  }
+  if (data.sortGroupsDirection !== undefined) {
+    promises.push(sortGroupsDirection.setValue(data.sortGroupsDirection))
   }
   if (data.indexGroupTitles !== undefined) {
     promises.push(indexGroupTitles.setValue(data.indexGroupTitles))


### PR DESCRIPTION
## Summary
- Adds an A-Z / Z-A direction toggle to the Sorting section in popup and sidebar.
- Persists `sortGroupsDirection` ("asc" | "desc") in storage and re-runs sort immediately when changed (when alphabetical sort is enabled).
- Comparator multiplies `localeCompare` by -1 for "desc", so both ordering and indexing honor the chosen direction.

## Bug fix bundled in
While testing, Z-A only worked the first time and silently no-op'd afterward. Root cause: `browser.tabGroups.query()` returns groups in stable creation/ID order, **not** visual tab-strip order. After A-Z had already arranged the strip, the next query still returned the original order, so `isAlreadySorted` matched the desired Z-A and skipped every move.

`TabSortService.sortGroups()` now derives visual order from `browser.tabs.query()` (which *is* indexed by tab position) by walking tabs in index order and recording the first `groupId` per group. Falls back to the queried order only when no tabs resolve a group (test-only path).

## Test plan
- [x] `bun run code:check` (biome + tsc) clean.
- [x] `bunx vitest run` — 774/774 pass, including a new regression test reproducing the `[Youtube, Google]` creation-order vs `[Google, Youtube]` visual-order scenario.
- [x] Manual: Chrome popup — toggling A-Z ↔ Z-A repeatedly flips group order every time.
- [x] Manual: indexing prefixes correctly track direction (Z-A reverses numbering).
- [x] Manual smoke test in Firefox (sortGroups is Chrome-only — should silently no-op with a single console line).