### PR TITLE
feat: runtime language picker with 7 locales + Advanced section (hide context menu)

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -20,6 +20,7 @@ import {
   parseAiSuggestionResponse,
   parseConflictResolutionResponse
 } from "../utils/AiResponseParser"
+import { initI18n } from "../utils/i18n"
 import {
   conflictResolutionPrompt,
   ruleGenerationPrompt,
@@ -42,6 +43,7 @@ export default defineBackground(() => {
         const storageData = await loadAllStorage()
         tabGroupState.updateFromStorage(storageData)
         aiService.updateFromStorage(storageData)
+        await initI18n(tabGroupState.userLocale)
         stateInitialized = true
         console.log("State loaded successfully from storage")
         console.log("Auto-grouping enabled:", tabGroupState.autoGroupingEnabled)
@@ -266,6 +268,18 @@ export default defineBackground(() => {
             await saveState()
             await contextMenuService.applyVisibility()
             result = { enabled: tabGroupState.hideContextMenu }
+            break
+
+          case "getUserLocale":
+            result = { locale: tabGroupState.userLocale }
+            break
+
+          case "setUserLocale":
+            tabGroupState.userLocale = msg.locale
+            await saveState()
+            await initI18n(msg.locale)
+            await contextMenuService.rebuildMenus()
+            result = { locale: tabGroupState.userLocale }
             break
 
           case "toggleIndexGroupTitles": {

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -239,6 +239,17 @@ export default defineBackground(() => {
             result = { enabled: tabGroupState.indexGroupTitles }
             break
 
+          case "getHideContextMenu":
+            result = { enabled: tabGroupState.hideContextMenu }
+            break
+
+          case "toggleHideContextMenu":
+            tabGroupState.hideContextMenu = msg.enabled
+            await saveState()
+            await contextMenuService.applyVisibility()
+            result = { enabled: tabGroupState.hideContextMenu }
+            break
+
           case "toggleIndexGroupTitles": {
             tabGroupState.indexGroupTitles = msg.enabled
             await saveState()

--- a/entrypoints/import-rules.unlisted/index.html
+++ b/entrypoints/import-rules.unlisted/index.html
@@ -8,15 +8,15 @@
   </head>
   <body>
     <div class="modal-container">
-      <h1>Import Rules</h1>
+      <h1 data-i18n="importPageTitle">Import Rules</h1>
 
       <!-- File Selection Area -->
       <div class="drop-zone" id="dropZone">
         <div class="drop-zone-content">
           <span class="drop-icon">📁</span>
-          <p>Drag & drop a JSON file here</p>
-          <p class="drop-zone-separator">or</p>
-          <button type="button" class="button secondary" id="selectFileButton">
+          <p data-i18n="importDropInstruction">Drag &amp; drop a JSON file here</p>
+          <p class="drop-zone-separator" data-i18n="importOr">or</p>
+          <button type="button" class="button secondary" id="selectFileButton" data-i18n="importBrowseFiles">
             Browse Files
           </button>
           <input type="file" id="fileInput" accept=".json" style="display: none" />
@@ -31,7 +31,7 @@
 
       <!-- Preview Section (shown after file parsed) -->
       <div class="preview-section" id="previewSection">
-        <h2>Preview</h2>
+        <h2 data-i18n="importPreviewHeading">Preview</h2>
         <div class="preview-stats" id="previewStats"></div>
         <div class="preview-list" id="previewList"></div>
         <div class="preview-errors" id="previewErrors"></div>
@@ -39,25 +39,25 @@
 
       <!-- Import Options -->
       <div class="form-group import-options" id="importOptions">
-        <label>Import Mode</label>
+        <label data-i18n="importModeLabel">Import Mode</label>
         <div class="radio-group">
           <label class="radio-option">
             <input type="radio" name="importMode" value="merge" checked />
-            <span>Merge with existing rules</span>
+            <span data-i18n="importMerge">Merge with existing rules</span>
           </label>
           <label class="radio-option">
             <input type="radio" name="importMode" value="replace" />
-            <span>Replace all existing rules</span>
+            <span data-i18n="importReplace">Replace all existing rules</span>
           </label>
         </div>
       </div>
 
       <!-- Action Buttons -->
       <div class="button-group">
-        <button type="button" class="button primary" id="importButton" disabled>
+        <button type="button" class="button primary" id="importButton" disabled data-i18n="importButton">
           Import Rules
         </button>
-        <button type="button" class="button secondary" id="cancelButton">Cancel</button>
+        <button type="button" class="button secondary" id="cancelButton" data-i18n="importCancel">Cancel</button>
       </div>
 
       <!-- Result Message -->

--- a/entrypoints/import-rules.unlisted/main.ts
+++ b/entrypoints/import-rules.unlisted/main.ts
@@ -1,6 +1,12 @@
 import "./style.css"
-import type { RuleData } from "../../types"
-import { applyI18nToDom, t } from "../../utils/i18n"
+import type { RuleData, UserLocale } from "../../types"
+import {
+  applyDirectionToDom,
+  applyI18nToDom,
+  initI18n,
+  resolveEffectiveLocale,
+  t
+} from "../../utils/i18n"
 
 // DOM Elements
 const dropZone = document.getElementById("dropZone") as HTMLDivElement
@@ -234,9 +240,15 @@ function showResult(message: string, type: "success" | "error"): void {
   resultMessage.className = `result-message ${type}`
   resultMessage.style.display = "block"
 }
-
-// Apply i18n to static DOM elements
-applyI18nToDom()
+// Initialize — resolve locale from background, load override catalog if any,
+// then translate the DOM and set text direction.
+;(async () => {
+  const resp = await sendMessage<{ locale?: UserLocale }>({ action: "getUserLocale" })
+  const locale: UserLocale = resp?.locale ?? "auto"
+  await initI18n(locale)
+  applyI18nToDom()
+  applyDirectionToDom(resolveEffectiveLocale(locale))
+})()
 
 // Drag and drop handlers
 dropZone.addEventListener("dragover", e => {

--- a/entrypoints/import-rules.unlisted/main.ts
+++ b/entrypoints/import-rules.unlisted/main.ts
@@ -1,5 +1,6 @@
 import "./style.css"
 import type { RuleData } from "../../types"
+import { applyI18nToDom, t } from "../../utils/i18n"
 
 // DOM Elements
 const dropZone = document.getElementById("dropZone") as HTMLDivElement
@@ -52,11 +53,12 @@ function createPreviewRuleElement(rule: RuleData): HTMLDivElement {
 
   const nameSpan = document.createElement("span")
   nameSpan.className = "preview-rule-name"
-  nameSpan.textContent = rule.name || "Unnamed"
+  nameSpan.textContent = rule.name || t("importUnnamed", "Unnamed")
 
   const domainsSpan = document.createElement("span")
   domainsSpan.className = "preview-rule-domains"
-  domainsSpan.textContent = `${rule.domains?.length || 0} patterns`
+  const count = String(rule.domains?.length || 0)
+  domainsSpan.textContent = t("importPatternsSuffix", `${count} patterns`, count)
 
   ruleDiv.appendChild(nameSpan)
   ruleDiv.appendChild(domainsSpan)
@@ -67,14 +69,15 @@ function createPreviewRuleElement(rule: RuleData): HTMLDivElement {
 function createMoreRulesElement(additionalCount: number): HTMLDivElement {
   const moreDiv = document.createElement("div")
   moreDiv.className = "preview-more"
-  moreDiv.textContent = `...and ${additionalCount} more rules`
+  const count = String(additionalCount)
+  moreDiv.textContent = t("importMoreRules", `...and ${count} more rules`, count)
   return moreDiv
 }
 
 // File handling
 function handleFile(file: File): void {
   if (!file.name.endsWith(".json")) {
-    showError("Please select a JSON file")
+    showError(t("importSelectJson", "Please select a JSON file"))
     return
   }
 
@@ -98,7 +101,7 @@ function parseAndPreviewRules(jsonText: string): void {
     const data = JSON.parse(jsonText) as { rules?: Record<string, RuleData> }
 
     if (!data.rules || typeof data.rules !== "object") {
-      showError("Invalid file format: Missing 'rules' property")
+      showError(t("importInvalidFormat", "Invalid file format: Missing 'rules' property"))
       return
     }
 
@@ -106,7 +109,7 @@ function parseAndPreviewRules(jsonText: string): void {
     const ruleCount = Object.keys(parsedRules).length
 
     if (ruleCount === 0) {
-      showError("No rules found in file")
+      showError(t("importNoRules", "No rules found in file"))
       return
     }
 
@@ -117,7 +120,7 @@ function parseAndPreviewRules(jsonText: string): void {
     importButton.disabled = false
     clearError()
   } catch (error) {
-    showError(`Invalid JSON: ${(error as Error).message}`)
+    showError(`${t("importInvalidJson", "Invalid JSON")}: ${(error as Error).message}`)
   }
 }
 
@@ -128,10 +131,14 @@ function displayPreview(rules: Record<string, RuleData>): void {
 
   // Stats - using DOM manipulation instead of innerHTML
   previewStats.replaceChildren()
-  previewStats.appendChild(createStatElement(validRules.length, "Valid Rules"))
+  previewStats.appendChild(
+    createStatElement(validRules.length, t("importStatValid", "Valid Rules"))
+  )
 
   if (invalidCount > 0) {
-    previewStats.appendChild(createStatElement(invalidCount, "Invalid (will be skipped)", true))
+    previewStats.appendChild(
+      createStatElement(invalidCount, t("importStatInvalid", "Invalid (will be skipped)"), true)
+    )
   }
 
   // Rule list preview (show first 5) - using DOM manipulation
@@ -180,7 +187,7 @@ async function performImport(): Promise<void> {
   const replaceExisting = importModeInput?.value === "replace"
 
   importButton.disabled = true
-  importButton.textContent = "Importing..."
+  importButton.textContent = t("importImporting", "Importing...")
 
   try {
     const response = await sendMessage<{
@@ -196,23 +203,30 @@ async function performImport(): Promise<void> {
     })
 
     if (response?.success) {
-      const skippedText = response.skipped ? ` (${response.skipped} skipped)` : ""
-      showResult(`Successfully imported ${response.imported} rules${skippedText}`, "success")
+      const imported = String(response.imported ?? 0)
+      const message = response.skipped
+        ? t(
+            "importSuccessWithSkipped",
+            `Successfully imported ${imported} rules (${response.skipped} skipped)`,
+            [imported, String(response.skipped)]
+          )
+        : t("importSuccess", `Successfully imported ${imported} rules`, imported)
+      showResult(message, "success")
 
       // Auto-close after success (with delay for user to see message)
       setTimeout(() => {
         window.close()
       }, 2000)
     } else {
-      showResult(response?.error || "Import failed", "error")
+      showResult(response?.error || t("importFailed", "Import failed"), "error")
       importButton.disabled = false
     }
   } catch (error) {
-    showResult(`Import failed: ${(error as Error).message}`, "error")
+    showResult(`${t("importFailed", "Import failed")}: ${(error as Error).message}`, "error")
     importButton.disabled = false
   }
 
-  importButton.textContent = "Import Rules"
+  importButton.textContent = t("importButton", "Import Rules")
 }
 
 function showResult(message: string, type: "success" | "error"): void {
@@ -220,6 +234,9 @@ function showResult(message: string, type: "success" | "error"): void {
   resultMessage.className = `result-message ${type}`
   resultMessage.style.display = "block"
 }
+
+// Apply i18n to static DOM elements
+applyI18nToDom()
 
 // Drag and drop handlers
 dropZone.addEventListener("dragover", e => {

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -34,6 +34,19 @@
       <div class="separator"></div>
       <div class="settings-container">
         <h2 data-i18n="settingsHeading">Settings</h2>
+        <div class="toggle-container language-row">
+          <span data-i18n="settingLanguage">Language</span>
+          <select
+            id="languageSelect"
+            class="language-select"
+            aria-label="Language"
+            data-i18n-aria-label="settingLanguage"
+          >
+            <option value="auto" data-i18n="settingLanguageAuto">Auto (browser default)</option>
+            <option value="en">English</option>
+            <option value="he">עברית</option>
+          </select>
+        </div>
         <div class="toggle-container">
           <span data-i18n="settingAutoGroupMode">Auto-Group Mode</span>
           <label class="switch">

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -8,54 +8,56 @@
     <link rel="stylesheet" href="/fonts/inter.css" />
   </head>
   <body class="popup-container">
-    <h1>Auto Tab Groups</h1>
+    <h1 data-i18n="popupTitle">Auto Tab Groups</h1>
     <main>
       <div class="button-group-row">
-        <button id="group" class="button primaryButton">Group Tabs</button>
-        <button id="ungroup" class="button primaryButton">Ungroup All</button>
+        <button id="group" class="button primaryButton" data-i18n="popupGroupTabs">Group Tabs</button>
+        <button id="ungroup" class="button primaryButton" data-i18n="popupUngroupAll">Ungroup All</button>
       </div>
       <button
         id="generateNewColors"
         class="button gradientButton"
+        data-i18n="popupGenerateNewColors"
+        data-i18n-title="popupGenerateNewColorsTitle"
         title="Randomize group colors. Colors are saved and restored automatically for each domain/rule."
       >
         Generate New Colors
       </button>
       <div class="button-group-row">
-        <button id="collapseAllButton" class="button secondaryButton collapse-all-button">
+        <button id="collapseAllButton" class="button secondaryButton collapse-all-button" data-i18n="popupCollapseAll">
           Collapse All
         </button>
-        <button id="expandAllButton" class="button secondaryButton expand-all-button">
+        <button id="expandAllButton" class="button secondaryButton expand-all-button" data-i18n="popupExpandAll">
           Expand All
         </button>
       </div>
       <div class="separator"></div>
       <div class="settings-container">
-        <h2>Settings</h2>
+        <h2 data-i18n="settingsHeading">Settings</h2>
         <div class="toggle-container">
-          <span>Auto-Group Mode</span>
+          <span data-i18n="settingAutoGroupMode">Auto-Group Mode</span>
           <label class="switch">
             <input type="checkbox" id="autoGroupToggle" />
             <span class="slider round"></span>
           </label>
         </div>
         <div class="toggle-container">
-          <span>Group by</span>
+          <span data-i18n="settingGroupBy">Group by</span>
           <div class="group-by-toggle-bar">
-            <button class="toggle-option" data-value="rules-only">Rules only</button>
-            <button class="toggle-option active" data-value="domain">Rules & Domain</button>
-            <button class="toggle-option" data-value="subdomain">Rules & Sub-domain</button>
+            <button class="toggle-option" data-value="rules-only" data-i18n="settingGroupByRulesOnly">Rules only</button>
+            <button class="toggle-option active" data-value="domain" data-i18n="settingGroupByRulesAndDomain">Rules &amp; Domain</button>
+            <button class="toggle-option" data-value="subdomain" data-i18n="settingGroupByRulesAndSubdomain">Rules &amp; Sub-domain</button>
           </div>
         </div>
         <div class="toggle-container">
-          <span>Group new empty tabs under "System"</span>
+          <span data-i18n="settingGroupNewEmptyTabs">Group new empty tabs under "System"</span>
           <label class="switch">
             <input type="checkbox" id="groupNewTabsToggle" />
             <span class="slider round"></span>
           </label>
         </div>
         <div class="toggle-container">
-          <span>Minimum tabs to form a group</span>
+          <span data-i18n="settingMinimumTabsForGroup">Minimum tabs to form a group</span>
           <div class="number-input-container">
             <input
               type="number"
@@ -68,14 +70,14 @@
           </div>
         </div>
         <div class="toggle-container">
-          <span>Auto-collapse inactive groups</span>
+          <span data-i18n="settingAutoCollapseInactive">Auto-collapse inactive groups</span>
           <label class="switch">
             <input type="checkbox" id="autoCollapseToggle" />
             <span class="slider round"></span>
           </label>
         </div>
         <div class="toggle-container collapse-delay-container" id="collapseDelayContainer">
-          <span>Collapse delay</span>
+          <span data-i18n="settingCollapseDelay">Collapse delay</span>
           <div class="delay-input-group">
             <input
               type="number"
@@ -89,11 +91,11 @@
             <span class="delay-unit">ms</span>
           </div>
         </div>
-        <div class="help-text collapse-help" id="collapseHelp">
+        <div class="help-text collapse-help" id="collapseHelp" data-i18n="settingCollapseDelayHelp">
           0 = immediate, or set delay (100-5000ms) before collapsing
         </div>
         <div class="toggle-container">
-          <span>Open new tabs next to current tab</span>
+          <span data-i18n="settingOpenNewTabsNextToCurrent">Open new tabs next to current tab</span>
           <label class="switch">
             <input type="checkbox" id="openTabNextToCurrentToggle" />
             <span class="slider round"></span>
@@ -101,14 +103,14 @@
         </div>
         <div class="settings-info">
           <span class="info-icon">&#128204;</span>
-          <span>Pinned tabs are never grouped automatically</span>
+          <span data-i18n="settingPinnedTabsNote">Pinned tabs are never grouped automatically</span>
         </div>
       </div>
 
       <!-- Sorting Section -->
       <div class="sorting-section">
         <button class="sorting-toggle">
-          <span class="noselect">Sorting</span>
+          <span class="noselect" data-i18n="sortingSectionTitle">Sorting</span>
           <span class="up-arrow">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
               <path
@@ -121,20 +123,20 @@
         </button>
         <div class="sorting-content">
           <div class="toggle-container">
-            <span>Keep groups sorted A-Z</span>
+            <span data-i18n="settingSortGroupsAlphabetically">Keep groups sorted A-Z</span>
             <label class="switch">
               <input type="checkbox" id="sortGroupsToggle" />
               <span class="slider round"></span>
             </label>
           </div>
           <div class="toggle-container sorting-index-container" id="sortingIndexContainer">
-            <span>Number groups (1. AI, 2. Docs...)</span>
+            <span data-i18n="settingNumberGroups">Number groups (1. AI, 2. Docs...)</span>
             <label class="switch">
               <input type="checkbox" id="indexGroupTitlesToggle" />
               <span class="slider round"></span>
             </label>
           </div>
-          <div class="help-text sorting-help" id="sortingHelp">
+          <div class="help-text sorting-help" id="sortingHelp" data-i18n="settingNumberGroupsHelp">
             Adds position numbers to group titles for quick reference
           </div>
         </div>
@@ -143,8 +145,8 @@
       <!-- AI Features Section -->
       <div class="ai-section">
         <button class="ai-toggle">
-          <span class="noselect">AI Features <span class="ai-experimental">Experimental</span><span class="ai-help-icon" data-tooltip="AI-powered tab grouping suggestions. This feature is experimental. All processing runs locally in your browser — no data is sent to external servers.">?</span></span>
-          <span class="ai-badge" id="aiBadge">Off</span>
+          <span class="noselect"><span data-i18n="aiSectionTitle">AI Features</span> <span class="ai-experimental" data-i18n="aiExperimentalBadge">Experimental</span><span class="ai-help-icon" data-tooltip="AI-powered tab grouping suggestions. This feature is experimental. All processing runs locally in your browser — no data is sent to external servers." data-i18n-tooltip="aiHelpTooltip">?</span></span>
+          <span class="ai-badge" id="aiBadge" data-i18n="aiBadgeOff">Off</span>
           <span class="up-arrow">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
               <path
@@ -157,7 +159,7 @@
         </button>
         <div class="ai-content">
           <div class="toggle-container">
-            <span>Enable AI</span>
+            <span data-i18n="aiEnable">Enable AI</span>
             <label class="switch">
               <input type="checkbox" id="aiEnabledToggle" />
               <span class="slider round"></span>
@@ -165,25 +167,25 @@
           </div>
           <div class="ai-settings" id="aiSettings">
             <div class="toggle-container">
-              <span>Model</span>
+              <span data-i18n="aiModelLabel">Model</span>
               <select id="aiModelSelect" class="ai-select"></select>
             </div>
             <div class="ai-status-row">
-              <span class="ai-status-label">Status:</span>
-              <span class="ai-status-badge" id="aiStatusBadge">Idle</span>
+              <span class="ai-status-label" data-i18n="aiStatusLabel">Status:</span>
+              <span class="ai-status-badge" id="aiStatusBadge" data-i18n="aiStatusIdle">Idle</span>
             </div>
             <div class="ai-progress-bar" id="aiProgressBar">
               <div class="ai-progress-fill" id="aiProgressFill"></div>
             </div>
-            <button id="aiLoadButton" class="button ai-load-button">Load Model</button>
-            <div class="ai-webgpu-warning" id="aiWebGpuWarning">
+            <button id="aiLoadButton" class="button ai-load-button" data-i18n="aiLoadModel">Load Model</button>
+            <div class="ai-webgpu-warning" id="aiWebGpuWarning" data-i18n="aiWebGpuUnavailable">
               WebGPU is not available. AI features require a browser with WebGPU support.
             </div>
-            <div class="help-text ai-help-text">
+            <div class="help-text ai-help-text" data-i18n="aiDownloadNote">
               Models run locally in your browser. First load downloads the model (~250MB-900MB).
             </div>
             <div class="ai-suggest-section" id="aiSuggestSection">
-              <button id="aiSuggestButton" class="button ai-suggest-button" disabled>
+              <button id="aiSuggestButton" class="button ai-suggest-button" disabled data-i18n="aiSuggestGroups">
                 Suggest Groups
               </button>
               <div class="ai-suggest-status" id="aiSuggestStatus"></div>
@@ -196,7 +198,7 @@
       <!-- Custom Rules Section -->
       <div class="rules-section">
         <button class="rules-toggle">
-          <span class="noselect">Custom Rules</span>
+          <span class="noselect" data-i18n="rulesSectionTitle">Custom Rules</span>
           <span class="rules-count" id="rulesCount">(0)</span>
           <span class="up-arrow">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
@@ -213,11 +215,13 @@
             <!-- Rules will be dynamically added here -->
           </div>
           <div class="rules-actions">
-            <button id="addRuleButton" class="button rules-button">Add New Rule</button>
+            <button id="addRuleButton" class="button rules-button" data-i18n="rulesAddNewRule">Add New Rule</button>
             <div class="rules-import-export">
               <button
                 id="exportRulesButton"
                 class="button rules-button secondary"
+                data-i18n="rulesExport"
+                data-i18n-title="rulesExportTitle"
                 title="Export all rules to JSON file"
               >
                 Export
@@ -225,13 +229,15 @@
               <button
                 id="importRulesButton"
                 class="button rules-button secondary"
+                data-i18n="rulesImport"
+                data-i18n-title="rulesImportTitle"
                 title="Import rules from JSON file"
               >
                 Import
               </button>
               <input type="file" id="importFileInput" accept=".json" style="display: none" />
             </div>
-            <div class="help-text export-import-help">
+            <div class="help-text export-import-help" data-i18n="rulesExportImportHelp">
               Export/import rules as JSON files for backup or sharing
             </div>
           </div>
@@ -241,7 +247,7 @@
       <!-- Blacklist Section -->
       <div class="blacklist-section">
         <button class="blacklist-toggle">
-          <span class="noselect">Blacklist</span>
+          <span class="noselect" data-i18n="blacklistSectionTitle">Blacklist</span>
           <span class="blacklist-count" id="blacklistCount">(0)</span>
           <span class="up-arrow">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
@@ -258,10 +264,38 @@
             <!-- Blacklist rules will be dynamically added here -->
           </div>
           <div class="blacklist-actions">
-            <button id="addBlacklistButton" class="button blacklist-button">Add to Blacklist</button>
+            <button id="addBlacklistButton" class="button blacklist-button" data-i18n="blacklistAddButton">Add to Blacklist</button>
           </div>
-          <div class="help-text blacklist-help">
+          <div class="help-text blacklist-help" data-i18n="blacklistHelp">
             Blacklisted domains will never be grouped
+          </div>
+        </div>
+      </div>
+
+      <!-- Advanced Section -->
+      <div class="advanced-section">
+        <button class="advanced-toggle">
+          <span class="noselect" data-i18n="advancedSectionTitle">Advanced</span>
+          <span class="up-arrow">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+              <path
+                d="m16.707 13.293-4-4a1 1 0 0 0-1.414 0l-4 4A1 1 0 0 0 8 15h8a1 1 0 0 0 .707-1.707z"
+                style="fill: #6b7280"
+                data-name="Up"
+              />
+            </svg>
+          </span>
+        </button>
+        <div class="advanced-content">
+          <div class="toggle-container">
+            <span data-i18n="advancedHideContextMenu">Hide right-click context menu</span>
+            <label class="switch">
+              <input type="checkbox" id="hideContextMenuToggle" />
+              <span class="slider round"></span>
+            </label>
+          </div>
+          <div class="help-text advanced-help" data-i18n="advancedHideContextMenuHelp">
+            When enabled, Auto Tab Groups will not add its items to the page right-click menu.
           </div>
         </div>
       </div>
@@ -269,18 +303,19 @@
     <footer class="footer-container">
       <div class="separator"></div>
       <div>
-        Made by <span class="author selectable">Nitzan Papini</span>, for
+        <span data-i18n="footerMadeBy">Made by</span> <span class="author selectable">Nitzan Papini</span>, <span data-i18n="footerFor">for</span>
         <span id="browserName">Chrome</span> <span id="browserEmoji"></span>
       </div>
       <div class="feedback-link">
         <a
           href="https://docs.google.com/forms/d/1ViwZsXRSlJqij4nGp84F4gT2f4vBhZkGDQU25F9ESPI"
           target="_blank"
-          >Feedback & Requests & Support</a
+          data-i18n="footerFeedback"
+          >Feedback &amp; Requests &amp; Support</a
         >
       </div>
       <div class="version">
-        <span>Version: <span id="versionNumber"></span></span>
+        <span><span data-i18n="footerVersion">Version:</span> <span id="versionNumber"></span></span>
       </div>
     </footer>
     <script type="module" src="./main.ts"></script>

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -44,7 +44,12 @@
           >
             <option value="auto" data-i18n="settingLanguageAuto">Auto (browser default)</option>
             <option value="en">English</option>
+            <option value="ar">العربية</option>
+            <option value="es">Español</option>
             <option value="he">עברית</option>
+            <option value="hi">हिन्दी</option>
+            <option value="ru">Русский</option>
+            <option value="zh">中文</option>
           </select>
         </div>
         <div class="toggle-container">

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -2,6 +2,7 @@ import "./style.css"
 import type { CustomRule } from "../../types"
 import type { AiGroupSuggestion } from "../../types/ai-messages"
 import { extractDomain } from "../../utils/DomainUtils"
+import { applyI18nToDom, t } from "../../utils/i18n"
 import { cachedAiSuggestions } from "../../utils/storage"
 
 // DOM Elements
@@ -50,6 +51,11 @@ const blacklistCount = document.getElementById("blacklistCount") as HTMLSpanElem
 const blacklistList = document.getElementById("blacklistList") as HTMLDivElement
 const addBlacklistButton = document.getElementById("addBlacklistButton") as HTMLButtonElement
 
+// Advanced Elements
+const advancedToggle = document.querySelector(".advanced-toggle") as HTMLButtonElement
+const advancedContent = document.querySelector(".advanced-content") as HTMLDivElement
+const hideContextMenuToggle = document.getElementById("hideContextMenuToggle") as HTMLInputElement
+
 // AI Elements
 const aiToggle = document.querySelector(".ai-toggle") as HTMLButtonElement
 const aiContent = document.querySelector(".ai-content") as HTMLDivElement
@@ -74,6 +80,7 @@ let aiStatusPollingInterval: ReturnType<typeof setInterval> | null = null
 let sortingSectionExpanded = false
 let customRulesExpanded = false
 let blacklistExpanded = false
+let advancedExpanded = false
 let currentRules: Record<string, CustomRule> = {}
 
 // Color mapping for display
@@ -115,10 +122,10 @@ function updateBrowserDisplay(): void {
   // Check if Firefox
   const isFirefox = navigator.userAgent.includes("Firefox")
   if (isFirefox) {
-    browserNameElement.textContent = "Firefox"
+    browserNameElement.textContent = t("footerBrowserFirefox", "Firefox")
     browserEmojiElement.textContent = ""
   } else {
-    browserNameElement.textContent = "Chrome"
+    browserNameElement.textContent = t("footerBrowserChrome", "Chrome")
     browserEmojiElement.textContent = ""
   }
 }
@@ -147,7 +154,7 @@ function updateGroupByToggle(mode: string): void {
 // Format domains display
 function formatDomainsDisplay(domains: string[], maxLength = 40): string {
   if (!Array.isArray(domains) || domains.length === 0) {
-    return "No domains"
+    return t("rulesNoDomains", "No domains")
   }
 
   if (domains.length === 1) {
@@ -174,7 +181,7 @@ function formatDomainsDisplay(domains: string[], maxLength = 40): string {
   }
 
   const remaining = domains.length - count
-  return `${truncated}${remaining > 0 ? ` and ${remaining} more` : ""}`
+  return `${truncated}${remaining > 0 ? t("rulesDomainsSeparator", ` and ${remaining} more`, String(remaining)) : ""}`
 }
 
 // Load and display custom rules
@@ -191,7 +198,7 @@ async function loadCustomRules(): Promise<void> {
     }
   } catch (error) {
     console.error("Error loading custom rules:", error)
-    showRulesError("Failed to load custom rules")
+    showRulesError(t("rulesFailedToLoad", "Failed to load custom rules"))
   }
 }
 
@@ -206,7 +213,9 @@ function updateRulesDisplay(): void {
   if (exportRulesButton) {
     exportRulesButton.disabled = allRules.length === 0
     exportRulesButton.title =
-      allRules.length === 0 ? "No rules to export" : "Export all rules to JSON file"
+      allRules.length === 0
+        ? t("rulesNoExport", "No rules to export")
+        : t("rulesExportTitle", "Export all rules to JSON file")
   }
 
   while (rulesList.firstChild) rulesList.removeChild(rulesList.firstChild)
@@ -214,8 +223,10 @@ function updateRulesDisplay(): void {
   if (groupingRules.length === 0) {
     const emptyDiv = document.createElement("div")
     emptyDiv.className = "empty-rules"
-    emptyDiv.textContent =
+    emptyDiv.textContent = t(
+      "rulesEmptyState",
       "No custom rules yet. Create your first rule to group tabs by your preferences!"
+    )
     rulesList.appendChild(emptyDiv)
   } else {
     groupingRules.sort((a, b) => {
@@ -247,7 +258,7 @@ function updateBlacklistDisplay(): void {
   if (blacklistRules.length === 0) {
     const emptyDiv = document.createElement("div")
     emptyDiv.className = "empty-rules"
-    emptyDiv.textContent = "No blacklisted domains yet."
+    emptyDiv.textContent = t("blacklistEmpty", "No blacklisted domains yet.")
     blacklistList.appendChild(emptyDiv)
     return
   }
@@ -284,15 +295,15 @@ function createBlacklistElement(rule: CustomRule): HTMLDivElement {
 
   const editBtn = document.createElement("button")
   editBtn.className = "rule-action-btn edit"
-  editBtn.title = "Edit blacklist rule"
+  editBtn.title = t("blacklistEditTitle", "Edit blacklist rule")
   editBtn.setAttribute("data-rule-id", rule.id)
-  editBtn.textContent = "Edit"
+  editBtn.textContent = t("rulesEdit", "Edit")
 
   const deleteBtn = document.createElement("button")
   deleteBtn.className = "rule-action-btn delete"
-  deleteBtn.title = "Delete blacklist rule"
+  deleteBtn.title = t("blacklistDeleteTitle", "Delete blacklist rule")
   deleteBtn.setAttribute("data-rule-id", rule.id)
-  deleteBtn.textContent = "Delete"
+  deleteBtn.textContent = t("rulesDelete", "Delete")
 
   ruleActions.appendChild(editBtn)
   ruleActions.appendChild(deleteBtn)
@@ -338,21 +349,21 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
 
   const addTabBtn = document.createElement("button")
   addTabBtn.className = "rule-action-btn add-tab"
-  addTabBtn.title = "Add Tab to Existing Rule"
+  addTabBtn.title = t("rulesAddTabTitle", "Add Tab to Existing Rule")
   addTabBtn.setAttribute("data-rule-id", rule.id)
   addTabBtn.textContent = "+"
 
   const editBtn = document.createElement("button")
   editBtn.className = "rule-action-btn edit"
-  editBtn.title = "Edit rule"
+  editBtn.title = t("rulesEditTitle", "Edit rule")
   editBtn.setAttribute("data-rule-id", rule.id)
-  editBtn.textContent = "Edit"
+  editBtn.textContent = t("rulesEdit", "Edit")
 
   const deleteBtn = document.createElement("button")
   deleteBtn.className = "rule-action-btn delete"
-  deleteBtn.title = "Delete rule"
+  deleteBtn.title = t("rulesDeleteTitle", "Delete rule")
   deleteBtn.setAttribute("data-rule-id", rule.id)
-  deleteBtn.textContent = "Delete"
+  deleteBtn.textContent = t("rulesDelete", "Delete")
 
   ruleActions.appendChild(addTabBtn)
   ruleActions.appendChild(editBtn)
@@ -427,7 +438,7 @@ async function addCurrentTabToRule(ruleId: string, button: HTMLButtonElement): P
     const [activeTab] = await browser.tabs.query({ active: true, currentWindow: true })
     if (!activeTab?.url) {
       button.textContent = "!"
-      button.title = "No active tab found"
+      button.title = t("rulesAddTabNoTab", "No active tab found")
       setTimeout(resetButton, 1500)
       return
     }
@@ -435,7 +446,7 @@ async function addCurrentTabToRule(ruleId: string, button: HTMLButtonElement): P
     const domain = extractDomain(activeTab.url)
     if (!domain || domain === "system") {
       button.textContent = "!"
-      button.title = "Cannot extract domain from this tab"
+      button.title = t("rulesAddTabCantExtract", "Cannot extract domain from this tab")
       setTimeout(resetButton, 1500)
       return
     }
@@ -453,19 +464,19 @@ async function addCurrentTabToRule(ruleId: string, button: HTMLButtonElement): P
     if (response?.success) {
       if (response.alreadyExists) {
         button.textContent = "="
-        button.title = "Domain already in this rule"
+        button.title = t("rulesAddTabAlreadyExists", "Domain already in this rule")
       } else {
         button.textContent = "\u2713"
-        button.title = "Added!"
+        button.title = t("rulesAddTabAdded", "Added!")
         await loadCustomRules()
       }
     } else {
       button.textContent = "!"
-      button.title = response?.error || "Failed to add domain"
+      button.title = response?.error || t("rulesAddTabFailed", "Failed to add domain")
     }
   } catch {
     button.textContent = "!"
-    button.title = "Failed to add domain"
+    button.title = t("rulesAddTabFailed", "Failed to add domain")
   }
 
   setTimeout(resetButton, 1500)
@@ -528,7 +539,12 @@ function toggleBlacklistSection(): void {
 
 // Delete rule
 async function deleteRule(ruleId: string, ruleName: string): Promise<void> {
-  if (!confirm(`Are you sure you want to delete the rule "${ruleName}"?`)) {
+  const prompt = t(
+    "rulesDeleteConfirm",
+    `Are you sure you want to delete the rule "${ruleName}"?`,
+    ruleName
+  )
+  if (!confirm(prompt)) {
     return
   }
 
@@ -542,11 +558,11 @@ async function deleteRule(ruleId: string, ruleName: string): Promise<void> {
       delete currentRules[ruleId]
       updateRulesDisplay()
     } else {
-      alert(response?.error || "Failed to delete rule")
+      alert(response?.error || t("rulesFailedToDelete", "Failed to delete rule"))
     }
   } catch (error) {
     console.error("Error deleting rule:", error)
-    alert("Failed to delete rule")
+    alert(t("rulesFailedToDelete", "Failed to delete rule"))
   }
 }
 
@@ -571,13 +587,13 @@ async function exportRules(): Promise<void> {
       a.click()
       document.body.removeChild(a)
       URL.revokeObjectURL(url)
-      showRulesMessage("Rules exported successfully!", "success")
+      showRulesMessage(t("rulesExportSuccess", "Rules exported successfully!"), "success")
     } else {
-      alert(response?.error || "Failed to export rules")
+      alert(response?.error || t("rulesFailedToExport", "Failed to export rules"))
     }
   } catch (error) {
     console.error("Error exporting rules:", error)
-    alert("Failed to export rules")
+    alert(t("rulesFailedToExport", "Failed to export rules"))
   }
 }
 
@@ -593,6 +609,7 @@ async function importRules(): Promise<void> {
 }
 
 // Initialize
+applyI18nToDom()
 updateVersionDisplay()
 updateBrowserDisplay()
 
@@ -787,8 +804,13 @@ async function initializeAiSection(): Promise<void> {
   try {
     // AI features are Chrome-only for now (WebLLM's tokenizer exceeds Firefox store limits)
     if (navigator.userAgent.includes("Firefox")) {
-      aiContent.innerHTML =
-        '<div class="ai-firefox-notice">AI features are currently available on Chrome only. Firefox support is coming soon.</div>'
+      const notice = document.createElement("div")
+      notice.className = "ai-firefox-notice"
+      notice.textContent = t(
+        "aiFirefoxNotice",
+        "AI features are currently available on Chrome only. Firefox support is coming soon."
+      )
+      aiContent.replaceChildren(notice)
       return
     }
 
@@ -825,7 +847,8 @@ async function initializeAiSection(): Promise<void> {
 
     if (webGpuResponse?.webGpu && !webGpuResponse.webGpu.available) {
       aiWebGpuWarning.classList.add("visible")
-      aiWebGpuWarning.textContent = webGpuResponse.webGpu.reason || "WebGPU is not available"
+      aiWebGpuWarning.textContent =
+        webGpuResponse.webGpu.reason || t("aiWebGpuUnavailable", "WebGPU is not available")
       aiLoadButton.disabled = true
     }
   } catch (error) {
@@ -843,7 +866,7 @@ function updateAiSettingsVisibility(enabled: boolean): void {
 }
 
 function updateAiBadge(enabled: boolean): void {
-  aiBadge.textContent = enabled ? "On" : "Off"
+  aiBadge.textContent = enabled ? t("aiBadgeOn", "On") : t("aiBadgeOff", "Off")
   aiBadge.classList.toggle("enabled", enabled)
 }
 
@@ -857,12 +880,12 @@ function updateAiModelStatus(modelStatus: {
   // Update status badge
   aiStatusBadge.textContent =
     status === "idle"
-      ? "Idle"
+      ? t("aiStatusIdle", "Idle")
       : status === "loading"
-        ? `Loading ${progress}%`
+        ? t("aiStatusLoading", `Loading ${progress}%`, String(progress))
         : status === "ready"
-          ? "Ready"
-          : "Error"
+          ? t("aiStatusReady", "Ready")
+          : t("aiStatusError", "Error")
 
   aiStatusBadge.className = "ai-status-badge"
   if (status !== "idle") {
@@ -879,20 +902,20 @@ function updateAiModelStatus(modelStatus: {
 
   // Update load button
   if (status === "ready") {
-    aiLoadButton.textContent = "Unload Model"
+    aiLoadButton.textContent = t("aiUnloadModel", "Unload Model")
     aiLoadButton.classList.add("unload")
     aiLoadButton.disabled = false
     aiModelSelect.disabled = true
     aiSuggestButton.disabled = false
     stopAiStatusPolling()
   } else if (status === "loading") {
-    aiLoadButton.textContent = "Loading..."
+    aiLoadButton.textContent = t("aiLoadingButton", "Loading...")
     aiLoadButton.disabled = true
     aiModelSelect.disabled = true
     aiSuggestButton.disabled = true
     startAiStatusPolling()
   } else if (status === "error") {
-    aiLoadButton.textContent = "Retry Load"
+    aiLoadButton.textContent = t("aiRetryLoad", "Retry Load")
     aiLoadButton.classList.remove("unload")
     aiLoadButton.disabled = false
     aiModelSelect.disabled = false
@@ -902,7 +925,7 @@ function updateAiModelStatus(modelStatus: {
       console.error("AI model error:", error)
     }
   } else {
-    aiLoadButton.textContent = "Load Model"
+    aiLoadButton.textContent = t("aiLoadModel", "Load Model")
     aiLoadButton.classList.remove("unload")
     aiLoadButton.disabled = false
     aiModelSelect.disabled = false
@@ -937,7 +960,7 @@ function stopAiStatusPolling(): void {
 
 async function handleSuggestGroups(): Promise<void> {
   aiSuggestButton.disabled = true
-  aiSuggestStatus.textContent = "Analyzing your tabs..."
+  aiSuggestStatus.textContent = t("aiAnalyzing", "Analyzing your tabs...")
   aiSuggestStatus.className = "ai-suggest-status loading"
   aiSuggestionsContainer.innerHTML = ""
 
@@ -954,12 +977,13 @@ async function handleSuggestGroups(): Promise<void> {
       aiSuggestStatus.className = "ai-suggest-status"
       renderSuggestions(response.suggestions, [])
     } else {
-      aiSuggestStatus.textContent = response?.error || "Failed to get suggestions"
+      aiSuggestStatus.textContent =
+        response?.error || t("aiFailedToGetSuggestions", "Failed to get suggestions")
       aiSuggestStatus.className = "ai-suggest-status error"
     }
   } catch (error) {
     console.error("Error suggesting groups:", error)
-    aiSuggestStatus.textContent = "Failed to get suggestions"
+    aiSuggestStatus.textContent = t("aiFailedToGetSuggestions", "Failed to get suggestions")
     aiSuggestStatus.className = "ai-suggest-status error"
   } finally {
     aiSuggestButton.disabled = false
@@ -973,14 +997,14 @@ function renderSuggestions(
   aiSuggestionsContainer.innerHTML = ""
 
   if (suggestions.length === 0) {
-    aiSuggestStatus.textContent = "No suggestions found"
+    aiSuggestStatus.textContent = t("aiNoSuggestions", "No suggestions found")
     aiSuggestStatus.className = "ai-suggest-status"
     return
   }
 
   const dismissBtn = document.createElement("button")
   dismissBtn.className = "suggestion-dismiss-btn"
-  dismissBtn.textContent = "Dismiss"
+  dismissBtn.textContent = t("aiDismiss", "Dismiss")
   dismissBtn.addEventListener("click", async () => {
     await cachedAiSuggestions.setValue(null)
     aiSuggestionsContainer.innerHTML = ""
@@ -1007,7 +1031,11 @@ function renderSuggestions(
 
     const tabCount = document.createElement("span")
     tabCount.className = "suggestion-tab-count"
-    tabCount.textContent = `${suggestion.tabs.length} tab${suggestion.tabs.length !== 1 ? "s" : ""}`
+    const plural = suggestion.tabs.length !== 1 ? "s" : ""
+    tabCount.textContent = t("aiTabsCount", `${suggestion.tabs.length} tab${plural}`, [
+      String(suggestion.tabs.length),
+      plural
+    ])
 
     header.appendChild(colorDot)
     header.appendChild(name)
@@ -1029,7 +1057,7 @@ function renderSuggestions(
 
     const applyBtn = document.createElement("button")
     applyBtn.className = `suggestion-apply-btn${isApplied ? " applied" : ""}`
-    applyBtn.textContent = isApplied ? "Applied!" : "Apply"
+    applyBtn.textContent = isApplied ? t("aiApplied", "Applied!") : t("aiApply", "Apply")
     applyBtn.disabled = isApplied
     if (!isApplied) {
       applyBtn.addEventListener("click", () => handleApplySuggestion(suggestion, applyBtn))
@@ -1037,7 +1065,7 @@ function renderSuggestions(
 
     const ruleBtn = document.createElement("button")
     ruleBtn.className = "suggestion-rule-btn"
-    ruleBtn.textContent = "Create Rule"
+    ruleBtn.textContent = t("aiCreateRule", "Create Rule")
     ruleBtn.addEventListener("click", () => createRuleFromSuggestion(suggestion))
 
     actions.appendChild(applyBtn)
@@ -1055,7 +1083,7 @@ async function handleApplySuggestion(
   button: HTMLButtonElement
 ): Promise<void> {
   button.disabled = true
-  button.textContent = "Applying..."
+  button.textContent = t("aiApplying", "Applying...")
 
   try {
     const response = await sendMessage<{
@@ -1069,19 +1097,24 @@ async function handleApplySuggestion(
     })
 
     if (response?.success) {
-      button.textContent = "Applied!"
+      button.textContent = t("aiApplied", "Applied!")
       button.classList.add("applied")
       if (response.staleTabIds && response.staleTabIds.length > 0) {
-        button.textContent = `Applied (${response.staleTabIds.length} tab${response.staleTabIds.length !== 1 ? "s" : ""} closed)`
+        const count = response.staleTabIds.length
+        const plural = count !== 1 ? "s" : ""
+        button.textContent = t("aiAppliedWithStale", `Applied (${count} tab${plural} closed)`, [
+          String(count),
+          plural
+        ])
       }
     } else {
-      button.textContent = "Failed"
+      button.textContent = t("aiFailed", "Failed")
       button.disabled = false
       console.error("Failed to apply suggestion:", response?.error)
     }
   } catch (error) {
     console.error("Error applying suggestion:", error)
-    button.textContent = "Failed"
+    button.textContent = t("aiFailed", "Failed")
     button.disabled = false
   }
 }
@@ -1169,6 +1202,28 @@ importRulesButton?.addEventListener("click", importRules)
 // Blacklist event listeners
 blacklistToggle?.addEventListener("click", toggleBlacklistSection)
 addBlacklistButton?.addEventListener("click", addBlacklistRule)
+
+// Advanced section toggle
+function toggleAdvancedSection(): void {
+  advancedExpanded = !advancedExpanded
+  advancedToggle.classList.toggle("expanded", advancedExpanded)
+  advancedContent.classList.toggle("expanded", advancedExpanded)
+}
+
+advancedToggle?.addEventListener("click", toggleAdvancedSection)
+
+// Initialize hide context menu state
+sendMessage<{ enabled?: boolean }>({ action: "getHideContextMenu" }).then(response => {
+  hideContextMenuToggle.checked = response?.enabled ?? false
+})
+
+// Hide context menu event listener
+hideContextMenuToggle?.addEventListener("change", event => {
+  sendMessage({
+    action: "toggleHideContextMenu",
+    enabled: (event.target as HTMLInputElement).checked
+  })
+})
 
 // Initialize AI badge on popup open
 sendMessage<{

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -621,8 +621,10 @@ async function importRules(): Promise<void> {
   }
 }
 // Initialize — resolve locale from background, load override catalog if any,
-// then translate the DOM and set text direction.
-;(async () => {
+// then translate the DOM and set text direction. Dynamic lists (rules, blacklist,
+// cached AI suggestions) are loaded AFTER i18n is ready so their dynamically
+// rendered strings (Edit/Delete buttons, empty states) pick up the right locale.
+const i18nReady: Promise<void> = (async () => {
   const resp = await sendMessage<{ locale?: UserLocale }>({ action: "getUserLocale" })
   const locale: UserLocale = resp?.locale ?? "auto"
   languageSelect.value = locale
@@ -633,13 +635,17 @@ async function importRules(): Promise<void> {
 updateVersionDisplay()
 updateBrowserDisplay()
 
-// Language picker change handler
+// Language picker change handler — also re-renders dynamic lists so their
+// JS-rendered strings (Edit/Delete buttons, truncation suffix, empty states)
+// switch along with the static DOM.
 languageSelect.addEventListener("change", async () => {
   const locale = languageSelect.value as UserLocale
   await sendMessage({ action: "setUserLocale", locale })
   await initI18n(locale)
   applyI18nToDom()
   applyDirectionToDom(resolveEffectiveLocale(locale))
+  updateRulesDisplay()
+  updateBlacklistDisplay()
 })
 
 // Button event listeners
@@ -1299,7 +1305,11 @@ async function loadCachedSuggestions(): Promise<void> {
 
   renderSuggestions(cached.suggestions, cached.appliedIndices)
 }
-loadCachedSuggestions()
-
-// Load custom rules on popup open
-loadCustomRules()
+// Gate initial dynamic loads on i18n readiness so JS-rendered strings
+// (Edit/Delete buttons, empty state, truncation suffix, etc.) render in the
+// user's chosen locale on first paint. Subsequent calls (from event handlers)
+// already run after i18nReady has resolved.
+i18nReady.then(() => {
+  loadCachedSuggestions()
+  loadCustomRules()
+})

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -1,8 +1,14 @@
 import "./style.css"
-import type { CustomRule } from "../../types"
+import type { CustomRule, UserLocale } from "../../types"
 import type { AiGroupSuggestion } from "../../types/ai-messages"
 import { extractDomain } from "../../utils/DomainUtils"
-import { applyI18nToDom, t } from "../../utils/i18n"
+import {
+  applyDirectionToDom,
+  applyI18nToDom,
+  initI18n,
+  resolveEffectiveLocale,
+  t
+} from "../../utils/i18n"
 import { cachedAiSuggestions } from "../../utils/storage"
 
 // DOM Elements
@@ -59,6 +65,9 @@ const addBlacklistButton = document.getElementById("addBlacklistButton") as HTML
 const advancedToggle = document.querySelector(".advanced-toggle") as HTMLButtonElement
 const advancedContent = document.querySelector(".advanced-content") as HTMLDivElement
 const hideContextMenuToggle = document.getElementById("hideContextMenuToggle") as HTMLInputElement
+
+// Language picker
+const languageSelect = document.getElementById("languageSelect") as HTMLSelectElement
 
 // AI Elements
 const aiToggle = document.querySelector(".ai-toggle") as HTMLButtonElement
@@ -611,11 +620,27 @@ async function importRules(): Promise<void> {
     console.error("Error opening import page:", error)
   }
 }
-
-// Initialize
-applyI18nToDom()
+// Initialize — resolve locale from background, load override catalog if any,
+// then translate the DOM and set text direction.
+;(async () => {
+  const resp = await sendMessage<{ locale?: UserLocale }>({ action: "getUserLocale" })
+  const locale: UserLocale = resp?.locale ?? "auto"
+  languageSelect.value = locale
+  await initI18n(locale)
+  applyI18nToDom()
+  applyDirectionToDom(resolveEffectiveLocale(locale))
+})()
 updateVersionDisplay()
 updateBrowserDisplay()
+
+// Language picker change handler
+languageSelect.addEventListener("change", async () => {
+  const locale = languageSelect.value as UserLocale
+  await sendMessage({ action: "setUserLocale", locale })
+  await initI18n(locale)
+  applyI18nToDom()
+  applyDirectionToDom(resolveEffectiveLocale(locale))
+})
 
 // Button event listeners
 groupButton.addEventListener("click", () => sendMessage({ action: "group" }))

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -1417,3 +1417,69 @@ input:checked + .slider:before {
   color: #6c757d;
   text-align: center;
 }
+
+/* Advanced Section */
+.advanced-section {
+  margin-top: 12px;
+}
+
+.advanced-toggle {
+  width: 100%;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  background: #f8f9fa;
+  border: 1px solid #e9ecef;
+  border-radius: 8px;
+  padding: 12px 16px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 14px;
+  font-weight: 500;
+  color: #495057;
+}
+
+.advanced-toggle:hover {
+  background: #e9ecef;
+  border-color: #dee2e6;
+}
+
+.advanced-toggle.expanded {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: none;
+  background: #e9ecef;
+}
+
+.advanced-toggle .noselect {
+  flex: 1;
+  text-align: left;
+}
+
+.advanced-toggle .up-arrow {
+  transition: transform 0.2s ease;
+}
+
+.advanced-toggle.expanded .up-arrow {
+  transform: rotate(180deg);
+}
+
+.advanced-content {
+  display: none;
+  background: white;
+  border: 1px solid #e9ecef;
+  border-top: none;
+  border-radius: 0 0 8px 8px;
+  padding: 16px;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.advanced-content.expanded {
+  display: flex;
+}
+
+.advanced-help {
+  font-size: 11px;
+  color: #6c757d;
+}

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -1496,3 +1496,48 @@ input:checked + .slider:before {
   font-size: 11px;
   color: #6c757d;
 }
+
+/* Language picker */
+.language-row {
+  margin-bottom: 4px;
+}
+
+.language-select {
+  padding: 6px 10px;
+  border: 2px solid #e5e7eb;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  background-color: #ffffff;
+  color: #111827;
+  cursor: pointer;
+  transition: border-color 0.2s;
+  min-width: 160px;
+}
+
+.language-select:focus {
+  outline: none;
+  border-color: #3b82f6;
+}
+
+.language-select:hover {
+  border-color: #d1d5db;
+}
+
+/* RTL adjustments. Most of the layout is flex-based and mirrors for free
+   under `dir="rtl"`; these overrides handle the few spots where visual
+   order is baked in (rotated arrows, left/right padding on badges). */
+[dir="rtl"] .up-arrow svg {
+  transform: scaleX(-1);
+}
+
+[dir="rtl"] .ai-badge,
+[dir="rtl"] .sorting-badge {
+  margin-right: 8px;
+  margin-left: 0;
+}
+
+[dir="rtl"] .help-text,
+[dir="rtl"] .settings-info {
+  text-align: right;
+}

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -444,7 +444,7 @@ input:checked + .slider:before {
 
 .rules-toggle .noselect {
   flex: 1;
-  text-align: left;
+  text-align: start;
 }
 
 .rules-count {
@@ -794,7 +794,7 @@ input:checked + .slider:before {
 
 .sorting-toggle .noselect {
   flex: 1;
-  text-align: left;
+  text-align: start;
 }
 
 .sorting-toggle .up-arrow {
@@ -890,7 +890,7 @@ input:checked + .slider:before {
 
 .ai-toggle .noselect {
   flex: 1;
-  text-align: left;
+  text-align: start;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -1357,7 +1357,7 @@ input:checked + .slider:before {
 
 .blacklist-toggle .noselect {
   flex: 1;
-  text-align: left;
+  text-align: start;
 }
 
 .blacklist-count {
@@ -1466,7 +1466,7 @@ input:checked + .slider:before {
 
 .advanced-toggle .noselect {
   flex: 1;
-  text-align: left;
+  text-align: start;
 }
 
 .advanced-toggle .up-arrow {

--- a/entrypoints/rules-modal.unlisted/index.html
+++ b/entrypoints/rules-modal.unlisted/index.html
@@ -8,42 +8,43 @@
   </head>
   <body>
     <div class="modal-container">
-      <h1 id="modalTitle">Create Custom Rule</h1>
+      <h1 id="modalTitle" data-i18n="ruleModalCreateTitle">Create Custom Rule</h1>
       <form id="ruleForm">
         <div class="form-group">
-          <label for="ruleName">Rule Name</label>
-          <input type="text" id="ruleName" placeholder="e.g., Work Apps, 工作, 仕事" required />
-          <div class="help-text">Supports any language including Chinese, Japanese, Korean, and emojis</div>
+          <label for="ruleName" data-i18n="ruleModalNameLabel">Rule Name</label>
+          <input type="text" id="ruleName" placeholder="e.g., Work Apps, 工作, 仕事" data-i18n-placeholder="ruleModalNamePlaceholder" required />
+          <div class="help-text" data-i18n="ruleModalNameHelp">Supports any language including Chinese, Japanese, Korean, and emojis</div>
         </div>
         <div id="aiAssistSection" class="form-group ai-assist-section">
-          <label>AI Assist</label>
+          <label data-i18n="ruleModalAiAssistLabel">AI Assist</label>
           <div class="ai-assist-container">
             <textarea
               id="aiDescription"
               rows="2"
               placeholder="Describe your rule, e.g., 'Group all Google services' or 'Group AWS console tabs'"
+              data-i18n-placeholder="ruleModalAiAssistPlaceholder"
             ></textarea>
-            <button type="button" id="aiGenerateBtn" class="button ai-generate-btn" disabled>
+            <button type="button" id="aiGenerateBtn" class="button ai-generate-btn" disabled data-i18n="ruleModalAiGenerate">
               Generate
             </button>
           </div>
           <div id="aiAssistStatus" class="ai-assist-status"></div>
-          <div class="help-text">Describe what you want to group and AI will suggest name, domains, and color</div>
+          <div class="help-text" data-i18n="ruleModalAiAssistHelp">Describe what you want to group and AI will suggest name, domains, and color</div>
         </div>
         <div id="patternModeToggle" class="form-group pattern-mode-toggle hidden">
-          <label>Pattern Mode</label>
+          <label data-i18n="ruleModalPatternModeLabel">Pattern Mode</label>
           <div class="toggle-buttons">
-            <button type="button" id="simpleModeBtn" class="toggle-btn active">
+            <button type="button" id="simpleModeBtn" class="toggle-btn active" data-i18n="ruleModalPatternModeSimple">
               Simple (domains)
             </button>
-            <button type="button" id="explicitModeBtn" class="toggle-btn">
+            <button type="button" id="explicitModeBtn" class="toggle-btn" data-i18n="ruleModalPatternModeExplicit">
               Explicit (full URLs)
             </button>
           </div>
-          <div id="modeHint" class="help-text">Groups all pages from these base domains</div>
+          <div id="modeHint" class="help-text" data-i18n="ruleModalSimpleModeHint">Groups all pages from these base domains</div>
         </div>
         <div class="form-group">
-          <label for="rulePatterns">URL Patterns (one per line)</label>
+          <label for="rulePatterns" data-i18n="ruleModalPatternsLabel">URL Patterns (one per line)</label>
           <textarea
             id="rulePatterns"
             rows="4"
@@ -53,46 +54,46 @@ example.com/admin/*
 192.168.1.*"
             required
           ></textarea>
-          <div class="help-text pattern-help">Supports: domains, wildcards (*.example.com), paths (example.com/api/*), IP addresses</div>
+          <div class="help-text pattern-help" data-i18n="ruleModalPatternsHelp">Supports: domains, wildcards (*.example.com), paths (example.com/api/*), IP addresses</div>
           <div id="patternFeedback" class="pattern-feedback"></div>
         </div>
         <div class="form-group" id="colorGroup">
-          <label>Group Color</label>
+          <label data-i18n="ruleModalColorLabel">Group Color</label>
           <div id="colorPicker" class="color-picker">
-            <button type="button" class="color-btn active" data-color="blue" title="Blue"></button>
-            <button type="button" class="color-btn" data-color="red" title="Red"></button>
-            <button type="button" class="color-btn" data-color="yellow" title="Yellow"></button>
-            <button type="button" class="color-btn" data-color="green" title="Green"></button>
-            <button type="button" class="color-btn" data-color="pink" title="Pink"></button>
-            <button type="button" class="color-btn" data-color="purple" title="Purple"></button>
-            <button type="button" class="color-btn" data-color="cyan" title="Cyan"></button>
-            <button type="button" class="color-btn" data-color="orange" title="Orange"></button>
-            <button type="button" class="color-btn" data-color="grey" title="Grey"></button>
+            <button type="button" class="color-btn active" data-color="blue" title="Blue" data-i18n-title="ruleModalColorBlue"></button>
+            <button type="button" class="color-btn" data-color="red" title="Red" data-i18n-title="ruleModalColorRed"></button>
+            <button type="button" class="color-btn" data-color="yellow" title="Yellow" data-i18n-title="ruleModalColorYellow"></button>
+            <button type="button" class="color-btn" data-color="green" title="Green" data-i18n-title="ruleModalColorGreen"></button>
+            <button type="button" class="color-btn" data-color="pink" title="Pink" data-i18n-title="ruleModalColorPink"></button>
+            <button type="button" class="color-btn" data-color="purple" title="Purple" data-i18n-title="ruleModalColorPurple"></button>
+            <button type="button" class="color-btn" data-color="cyan" title="Cyan" data-i18n-title="ruleModalColorCyan"></button>
+            <button type="button" class="color-btn" data-color="orange" title="Orange" data-i18n-title="ruleModalColorOrange"></button>
+            <button type="button" class="color-btn" data-color="grey" title="Grey" data-i18n-title="ruleModalColorGrey"></button>
           </div>
           <input type="hidden" id="ruleColor" value="blue" />
         </div>
         <div class="form-group checkbox-group">
           <label>
             <input type="checkbox" id="ruleEnabled" checked />
-            Enabled
+            <span data-i18n="ruleModalEnabledLabel">Enabled</span>
           </label>
         </div>
         <div class="button-group">
-          <button type="submit" class="button primary" id="saveButton">Save Rule</button>
-          <button type="button" class="button secondary" id="cancelButton">Cancel</button>
+          <button type="submit" class="button primary" id="saveButton" data-i18n="ruleModalSave">Save Rule</button>
+          <button type="button" class="button secondary" id="cancelButton" data-i18n="ruleModalCancel">Cancel</button>
         </div>
       </form>
       <div id="conflictWarning" class="conflict-warning hidden">
-        <h3>Pattern Conflicts Detected</h3>
-        <p class="conflict-subtitle">These patterns overlap with existing rules. Tabs matching both rules will only be assigned to one.</p>
+        <h3 data-i18n="ruleModalConflictTitle">Pattern Conflicts Detected</h3>
+        <p class="conflict-subtitle" data-i18n="ruleModalConflictSubtitle">These patterns overlap with existing rules. Tabs matching both rules will only be assigned to one.</p>
         <div id="conflictList" class="conflict-list"></div>
         <div id="conflictResolutions" class="conflict-resolutions hidden">
-          <h4>AI Suggestions</h4>
+          <h4 data-i18n="ruleModalAiSuggestions">AI Suggestions</h4>
           <ul id="resolutionList"></ul>
         </div>
         <div class="conflict-actions">
-          <button type="button" class="button primary" id="saveAnywayBtn">Save Anyway</button>
-          <button type="button" class="button secondary" id="goBackBtn">Go Back</button>
+          <button type="button" class="button primary" id="saveAnywayBtn" data-i18n="ruleModalSaveAnyway">Save Anyway</button>
+          <button type="button" class="button secondary" id="goBackBtn" data-i18n="ruleModalGoBack">Go Back</button>
         </div>
       </div>
     </div>

--- a/entrypoints/rules-modal.unlisted/main.ts
+++ b/entrypoints/rules-modal.unlisted/main.ts
@@ -1,6 +1,12 @@
 import "./style.css"
-import type { PatternConflict, RuleData, TabGroupColor } from "../../types"
-import { applyI18nToDom, t } from "../../utils/i18n"
+import type { PatternConflict, RuleData, TabGroupColor, UserLocale } from "../../types"
+import {
+  applyDirectionToDom,
+  applyI18nToDom,
+  initI18n,
+  resolveEffectiveLocale,
+  t
+} from "../../utils/i18n"
 import { urlPatternMatcher } from "../../utils/UrlPatternMatcher"
 
 // Get URL parameters
@@ -443,9 +449,15 @@ async function generateRuleFromDescription(): Promise<void> {
     aiGenerateBtn.classList.remove("generating")
   }
 }
-
-// Initialize
-applyI18nToDom()
+// Initialize — resolve locale from background, load override catalog if any,
+// then translate the DOM and set text direction.
+;(async () => {
+  const resp = await sendMessage<{ locale?: UserLocale }>({ action: "getUserLocale" })
+  const locale: UserLocale = resp?.locale ?? "auto"
+  await initI18n(locale)
+  applyI18nToDom()
+  applyDirectionToDom(resolveEffectiveLocale(locale))
+})()
 setupColorPicker()
 loadExistingRule()
 loadFromGroup()

--- a/entrypoints/rules-modal.unlisted/main.ts
+++ b/entrypoints/rules-modal.unlisted/main.ts
@@ -1,5 +1,6 @@
 import "./style.css"
 import type { PatternConflict, RuleData, TabGroupColor } from "../../types"
+import { applyI18nToDom, t } from "../../utils/i18n"
 import { urlPatternMatcher } from "../../utils/UrlPatternMatcher"
 
 // Get URL parameters
@@ -98,8 +99,8 @@ function sendMessage<T = Record<string, unknown>>(message: Record<string, unknow
 async function loadExistingRule(): Promise<void> {
   if (!isEditMode || !ruleId) return
 
-  modalTitle.textContent = "Edit Custom Rule"
-  saveButton.textContent = "Update Rule"
+  modalTitle.textContent = t("ruleModalEditTitle", "Edit Custom Rule")
+  saveButton.textContent = t("ruleModalUpdate", "Update Rule")
 
   try {
     const response = await sendMessage<{
@@ -117,7 +118,7 @@ async function loadExistingRule(): Promise<void> {
     }
   } catch (error) {
     console.error("Error loading rule:", error)
-    alert("Failed to load rule for editing")
+    alert(t("ruleModalFailedToLoad", "Failed to load rule for editing"))
   }
 }
 
@@ -131,13 +132,13 @@ function buildRuleData(): RuleData | null {
   const enabled = ruleEnabledCheckbox.checked
 
   if (patterns.length === 0) {
-    alert("Please enter at least one URL pattern")
+    alert(t("ruleModalEnterPattern", "Please enter at least one URL pattern"))
     return null
   }
 
   const name = isBlacklistMode ? "" : ruleNameInput.value.trim()
   if (!isBlacklistMode && !name) {
-    alert("Please enter a rule name")
+    alert(t("ruleModalEnterName", "Please enter a rule name"))
     return null
   }
 
@@ -164,7 +165,7 @@ async function persistRule(ruleData: RuleData): Promise<void> {
   if (response?.success) {
     window.close()
   } else {
-    alert(response?.error || "Failed to save rule")
+    alert(response?.error || t("ruleModalFailedToSave", "Failed to save rule"))
   }
 }
 
@@ -217,7 +218,7 @@ async function saveRule(event: Event): Promise<void> {
   if (!ruleData) return
 
   saveButton.disabled = true
-  saveButton.textContent = "Checking..."
+  saveButton.textContent = t("ruleModalChecking", "Checking...")
 
   try {
     const analysis = await sendMessage<{
@@ -264,7 +265,9 @@ async function saveRule(event: Event): Promise<void> {
     alert(`Failed to save rule: ${(error as Error).message}`)
   } finally {
     saveButton.disabled = false
-    saveButton.textContent = isEditMode ? "Update Rule" : "Save Rule"
+    saveButton.textContent = isEditMode
+      ? t("ruleModalUpdate", "Update Rule")
+      : t("ruleModalSave", "Save Rule")
   }
 }
 
@@ -277,8 +280,12 @@ function cancel(): void {
 // Apply blacklist mode UI adjustments
 function applyBlacklistMode(): void {
   if (!isBlacklistMode) return
-  modalTitle.textContent = isEditMode ? "Edit Blacklist Rule" : "Add to Blacklist"
-  saveButton.textContent = isEditMode ? "Update Rule" : "Save Blacklist Rule"
+  modalTitle.textContent = isEditMode
+    ? t("blacklistEditTitle", "Edit Blacklist Rule")
+    : t("blacklistAddButton", "Add to Blacklist")
+  saveButton.textContent = isEditMode
+    ? t("ruleModalUpdate", "Update Rule")
+    : t("ruleModalSave", "Save Rule")
   colorGroup.style.display = "none"
   ruleNameInput.required = false
   const ruleNameGroup = ruleNameInput.closest(".form-group")
@@ -314,7 +321,7 @@ function setupColorPicker(): void {
 function loadFromGroup(): void {
   if (!isFromGroup) return
 
-  modalTitle.textContent = "Create Rule from Group"
+  modalTitle.textContent = t("contextMenuCreateRuleFromGroup", "Create Rule from Group")
 
   // Pre-populate form fields
   ruleNameInput.value = groupName
@@ -336,7 +343,7 @@ function setupPatternModeToggle(): void {
     rulePatternsInput.value = simpleDomains.join("\n")
     simpleModeBtn.classList.add("active")
     explicitModeBtn.classList.remove("active")
-    modeHint.textContent = "Groups all pages from these base domains"
+    modeHint.textContent = t("ruleModalSimpleModeHint", "Groups all pages from these base domains")
     validatePatterns()
   })
 
@@ -344,7 +351,7 @@ function setupPatternModeToggle(): void {
     rulePatternsInput.value = explicitUrls.join("\n")
     explicitModeBtn.classList.add("active")
     simpleModeBtn.classList.remove("active")
-    modeHint.textContent = "Only matches these exact URLs"
+    modeHint.textContent = t("ruleModalExplicitModeHint", "Only matches these exact URLs")
     validatePatterns()
   })
 }
@@ -360,8 +367,10 @@ async function checkAiAvailability(): Promise<void> {
     aiGenerateBtn.disabled = !isReady
 
     if (!isReady) {
-      aiAssistStatus.textContent =
+      aiAssistStatus.textContent = t(
+        "ruleModalAiNeedsModel",
         "Load an AI model from the popup's AI Features section to use AI Assist"
+      )
       aiAssistStatus.className = "ai-assist-status info"
     } else {
       aiAssistStatus.textContent = ""
@@ -384,15 +393,15 @@ function getCurrentPatterns(): string[] {
 async function generateRuleFromDescription(): Promise<void> {
   const description = aiDescription.value.trim()
   if (!description) {
-    aiAssistStatus.textContent = "Please enter a description"
+    aiAssistStatus.textContent = t("ruleModalAiEnterDescription", "Please enter a description")
     aiAssistStatus.className = "ai-assist-status error"
     return
   }
 
   aiGenerateBtn.disabled = true
-  aiGenerateBtn.textContent = "Generating..."
+  aiGenerateBtn.textContent = t("ruleModalGenerating", "Generating...")
   aiGenerateBtn.classList.add("generating")
-  aiAssistStatus.textContent = "AI is thinking..."
+  aiAssistStatus.textContent = t("ruleModalAiThinking", "AI is thinking...")
   aiAssistStatus.className = "ai-assist-status info"
 
   try {
@@ -417,24 +426,26 @@ async function generateRuleFromDescription(): Promise<void> {
         response.warnings && response.warnings.length > 0
           ? ` (${response.warnings.join("; ")})`
           : ""
-      aiAssistStatus.textContent = `Rule generated! Review and edit below, then save.${warningText}`
+      aiAssistStatus.textContent = `${t("ruleModalAiGenerated", "Rule generated! Review and edit below, then save.")}${warningText}`
       aiAssistStatus.className = "ai-assist-status success"
     } else {
       aiAssistStatus.textContent =
-        response?.error || "Failed to generate rule. Try rephrasing your description."
+        response?.error ||
+        t("ruleModalAiGenerateError", "Failed to generate rule. Try rephrasing your description.")
       aiAssistStatus.className = "ai-assist-status error"
     }
   } catch (error) {
-    aiAssistStatus.textContent = `Generation failed: ${(error as Error).message}`
+    aiAssistStatus.textContent = `${t("ruleModalAiGenerateError", "Failed to generate rule")}: ${(error as Error).message}`
     aiAssistStatus.className = "ai-assist-status error"
   } finally {
     aiGenerateBtn.disabled = false
-    aiGenerateBtn.textContent = "Generate"
+    aiGenerateBtn.textContent = t("ruleModalAiGenerate", "Generate")
     aiGenerateBtn.classList.remove("generating")
   }
 }
 
 // Initialize
+applyI18nToDom()
 setupColorPicker()
 loadExistingRule()
 loadFromGroup()

--- a/entrypoints/rules-modal.unlisted/style.css
+++ b/entrypoints/rules-modal.unlisted/style.css
@@ -408,3 +408,12 @@ h1 {
   gap: 8px;
   justify-content: flex-end;
 }
+
+/* Pattern textarea always renders left-to-right regardless of the UI language.
+   Domains, URLs, regex — these are technical tokens that are authored in
+   English/ASCII and look broken when mirrored into RTL. The rule name and
+   AI description fields stay LTR/RTL-aware since the user may type Hebrew there. */
+[dir="rtl"] #rulePatterns {
+  direction: ltr;
+  text-align: left;
+}

--- a/entrypoints/sidebar/index.html
+++ b/entrypoints/sidebar/index.html
@@ -9,54 +9,56 @@
   </head>
   <body class="sidebar-container">
     <div class="popup-container">
-      <h1>Auto Tab Groups</h1>
+      <h1 data-i18n="popupTitle">Auto Tab Groups</h1>
       <main>
         <div class="button-group-row">
-          <button id="group" class="button primaryButton">Group Tabs</button>
-          <button id="ungroup" class="button primaryButton">Ungroup All</button>
+          <button id="group" class="button primaryButton" data-i18n="popupGroupTabs">Group Tabs</button>
+          <button id="ungroup" class="button primaryButton" data-i18n="popupUngroupAll">Ungroup All</button>
         </div>
         <button
           id="generateNewColors"
           class="button gradientButton"
+          data-i18n="popupGenerateNewColors"
+          data-i18n-title="popupGenerateNewColorsTitle"
           title="Randomize group colors. Colors are saved and restored automatically for each domain/rule."
         >
           Generate New Colors
         </button>
         <div class="button-group-row">
-          <button id="collapseAllButton" class="button secondaryButton collapse-all-button">
+          <button id="collapseAllButton" class="button secondaryButton collapse-all-button" data-i18n="popupCollapseAll">
             Collapse All
           </button>
-          <button id="expandAllButton" class="button secondaryButton expand-all-button">
+          <button id="expandAllButton" class="button secondaryButton expand-all-button" data-i18n="popupExpandAll">
             Expand All
           </button>
         </div>
         <div class="separator"></div>
         <div class="settings-container">
-          <h2>Settings</h2>
+          <h2 data-i18n="settingsHeading">Settings</h2>
           <div class="toggle-container">
-            <span>Auto-Group Mode</span>
+            <span data-i18n="settingAutoGroupMode">Auto-Group Mode</span>
             <label class="switch">
               <input type="checkbox" id="autoGroupToggle" />
               <span class="slider round"></span>
             </label>
           </div>
           <div class="toggle-container">
-            <span>Group by</span>
+            <span data-i18n="settingGroupBy">Group by</span>
             <div class="group-by-toggle-bar">
-              <button class="toggle-option" data-value="rules-only">Rules only</button>
-              <button class="toggle-option active" data-value="domain">Domain</button>
-              <button class="toggle-option" data-value="subdomain">Sub-domain</button>
+              <button class="toggle-option" data-value="rules-only" data-i18n="settingGroupByRulesOnly">Rules only</button>
+              <button class="toggle-option active" data-value="domain" data-i18n="settingGroupByDomain">Domain</button>
+              <button class="toggle-option" data-value="subdomain" data-i18n="settingGroupBySubdomain">Sub-domain</button>
             </div>
           </div>
           <div class="toggle-container">
-            <span>Group new empty tabs under "System"</span>
+            <span data-i18n="settingGroupNewEmptyTabs">Group new empty tabs under "System"</span>
             <label class="switch">
               <input type="checkbox" id="groupNewTabsToggle" />
               <span class="slider round"></span>
             </label>
           </div>
           <div class="toggle-container">
-            <span>Minimum tabs to form a group</span>
+            <span data-i18n="settingMinimumTabsForGroup">Minimum tabs to form a group</span>
             <div class="number-input-container">
               <input
                 type="number"
@@ -69,14 +71,14 @@
             </div>
           </div>
           <div class="toggle-container">
-            <span>Auto-collapse inactive groups</span>
+            <span data-i18n="settingAutoCollapseInactive">Auto-collapse inactive groups</span>
             <label class="switch">
               <input type="checkbox" id="autoCollapseToggle" />
               <span class="slider round"></span>
             </label>
           </div>
           <div class="toggle-container collapse-delay-container" id="collapseDelayContainer">
-            <span>Collapse delay</span>
+            <span data-i18n="settingCollapseDelay">Collapse delay</span>
             <div class="delay-input-group">
               <input
                 type="number"
@@ -90,11 +92,11 @@
               <span class="delay-unit">ms</span>
             </div>
           </div>
-          <div class="help-text collapse-help" id="collapseHelp">
+          <div class="help-text collapse-help" id="collapseHelp" data-i18n="settingCollapseDelayHelp">
             0 = immediate, or set delay (100-5000ms) before collapsing
           </div>
           <div class="toggle-container">
-            <span>Open new tabs next to current tab</span>
+            <span data-i18n="settingOpenNewTabsNextToCurrent">Open new tabs next to current tab</span>
             <label class="switch">
               <input type="checkbox" id="openTabNextToCurrentToggle" />
               <span class="slider round"></span>
@@ -102,14 +104,14 @@
           </div>
           <div class="settings-info">
             <span class="info-icon">&#128204;</span>
-            <span>Pinned tabs are never grouped automatically</span>
+            <span data-i18n="settingPinnedTabsNote">Pinned tabs are never grouped automatically</span>
           </div>
         </div>
 
         <!-- Sorting Section -->
         <div class="sorting-section">
           <button class="sorting-toggle">
-            <span class="noselect">Sorting</span>
+            <span class="noselect" data-i18n="sortingSectionTitle">Sorting</span>
             <span class="up-arrow">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
                 <path
@@ -122,20 +124,20 @@
           </button>
           <div class="sorting-content">
             <div class="toggle-container">
-              <span>Keep groups sorted A-Z</span>
+              <span data-i18n="settingSortGroupsAlphabetically">Keep groups sorted A-Z</span>
               <label class="switch">
                 <input type="checkbox" id="sortGroupsToggle" />
                 <span class="slider round"></span>
               </label>
             </div>
             <div class="toggle-container sorting-index-container" id="sortingIndexContainer">
-              <span>Number groups (1. AI, 2. Docs...)</span>
+              <span data-i18n="settingNumberGroups">Number groups (1. AI, 2. Docs...)</span>
               <label class="switch">
                 <input type="checkbox" id="indexGroupTitlesToggle" />
                 <span class="slider round"></span>
               </label>
             </div>
-            <div class="help-text sorting-help" id="sortingHelp">
+            <div class="help-text sorting-help" id="sortingHelp" data-i18n="settingNumberGroupsHelp">
               Adds position numbers to group titles for quick reference
             </div>
           </div>
@@ -144,8 +146,8 @@
         <!-- AI Features Section -->
         <div class="ai-section">
           <button class="ai-toggle">
-            <span class="noselect">AI Features <span class="ai-experimental">Experimental</span><span class="ai-help-icon" data-tooltip="AI-powered tab grouping suggestions. This feature is experimental. All processing runs locally in your browser — no data is sent to external servers.">?</span></span>
-            <span class="ai-badge" id="aiBadge">Off</span>
+            <span class="noselect"><span data-i18n="aiSectionTitle">AI Features</span> <span class="ai-experimental" data-i18n="aiExperimentalBadge">Experimental</span><span class="ai-help-icon" data-tooltip="AI-powered tab grouping suggestions. This feature is experimental. All processing runs locally in your browser — no data is sent to external servers." data-i18n-tooltip="aiHelpTooltip">?</span></span>
+            <span class="ai-badge" id="aiBadge" data-i18n="aiBadgeOff">Off</span>
             <span class="up-arrow">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
                 <path
@@ -158,7 +160,7 @@
           </button>
           <div class="ai-content">
             <div class="toggle-container">
-              <span>Enable AI</span>
+              <span data-i18n="aiEnable">Enable AI</span>
               <label class="switch">
                 <input type="checkbox" id="aiEnabledToggle" />
                 <span class="slider round"></span>
@@ -166,25 +168,25 @@
             </div>
             <div class="ai-settings" id="aiSettings">
               <div class="toggle-container">
-                <span>Model</span>
+                <span data-i18n="aiModelLabel">Model</span>
                 <select id="aiModelSelect" class="ai-select"></select>
               </div>
               <div class="ai-status-row">
-                <span class="ai-status-label">Status:</span>
-                <span class="ai-status-badge" id="aiStatusBadge">Idle</span>
+                <span class="ai-status-label" data-i18n="aiStatusLabel">Status:</span>
+                <span class="ai-status-badge" id="aiStatusBadge" data-i18n="aiStatusIdle">Idle</span>
               </div>
               <div class="ai-progress-bar" id="aiProgressBar">
                 <div class="ai-progress-fill" id="aiProgressFill"></div>
               </div>
-              <button id="aiLoadButton" class="button ai-load-button">Load Model</button>
-              <div class="ai-webgpu-warning" id="aiWebGpuWarning">
+              <button id="aiLoadButton" class="button ai-load-button" data-i18n="aiLoadModel">Load Model</button>
+              <div class="ai-webgpu-warning" id="aiWebGpuWarning" data-i18n="aiWebGpuUnavailable">
                 WebGPU is not available. AI features require a browser with WebGPU support.
               </div>
-              <div class="help-text ai-help-text">
+              <div class="help-text ai-help-text" data-i18n="aiDownloadNote">
                 Models run locally in your browser. First load downloads the model (~250MB-900MB).
               </div>
               <div class="ai-suggest-section" id="aiSuggestSection">
-                <button id="aiSuggestButton" class="button ai-suggest-button" disabled>
+                <button id="aiSuggestButton" class="button ai-suggest-button" disabled data-i18n="aiSuggestGroups">
                   Suggest Groups
                 </button>
                 <div class="ai-suggest-status" id="aiSuggestStatus"></div>
@@ -197,7 +199,7 @@
         <!-- Custom Rules Section -->
         <div class="rules-section">
           <button class="rules-toggle">
-            <span class="noselect">Custom Rules</span>
+            <span class="noselect" data-i18n="rulesSectionTitle">Custom Rules</span>
             <span class="rules-count" id="rulesCount">(0)</span>
             <span class="up-arrow">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
@@ -214,11 +216,13 @@
               <!-- Rules will be dynamically added here -->
             </div>
             <div class="rules-actions">
-              <button id="addRuleButton" class="button rules-button">Add New Rule</button>
+              <button id="addRuleButton" class="button rules-button" data-i18n="rulesAddNewRule">Add New Rule</button>
               <div class="rules-import-export">
                 <button
                   id="exportRulesButton"
                   class="button rules-button secondary"
+                  data-i18n="rulesExport"
+                  data-i18n-title="rulesExportTitle"
                   title="Export all rules to JSON file"
                 >
                   Export
@@ -226,13 +230,15 @@
                 <button
                   id="importRulesButton"
                   class="button rules-button secondary"
+                  data-i18n="rulesImport"
+                  data-i18n-title="rulesImportTitle"
                   title="Import rules from JSON file"
                 >
                   Import
                 </button>
                 <input type="file" id="importFileInput" accept=".json" style="display: none" />
               </div>
-              <div class="help-text export-import-help">
+              <div class="help-text export-import-help" data-i18n="rulesExportImportHelp">
                 Export/import rules as JSON files for backup or sharing
               </div>
             </div>
@@ -242,7 +248,7 @@
         <!-- Blacklist Section -->
         <div class="blacklist-section">
           <button class="blacklist-toggle">
-            <span class="noselect">Blacklist</span>
+            <span class="noselect" data-i18n="blacklistSectionTitle">Blacklist</span>
             <span class="blacklist-count" id="blacklistCount">(0)</span>
             <span class="up-arrow">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
@@ -259,10 +265,38 @@
               <!-- Blacklist rules will be dynamically added here -->
             </div>
             <div class="blacklist-actions">
-              <button id="addBlacklistButton" class="button blacklist-button">Add to Blacklist</button>
+              <button id="addBlacklistButton" class="button blacklist-button" data-i18n="blacklistAddButton">Add to Blacklist</button>
             </div>
-            <div class="help-text blacklist-help">
+            <div class="help-text blacklist-help" data-i18n="blacklistHelp">
               Blacklisted domains will never be grouped
+            </div>
+          </div>
+        </div>
+
+        <!-- Advanced Section -->
+        <div class="advanced-section">
+          <button class="advanced-toggle">
+            <span class="noselect" data-i18n="advancedSectionTitle">Advanced</span>
+            <span class="up-arrow">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+                <path
+                  d="m16.707 13.293-4-4a1 1 0 0 0-1.414 0l-4 4A1 1 0 0 0 8 15h8a1 1 0 0 0 .707-1.707z"
+                  style="fill: #6b7280"
+                  data-name="Up"
+                />
+              </svg>
+            </span>
+          </button>
+          <div class="advanced-content">
+            <div class="toggle-container">
+              <span data-i18n="advancedHideContextMenu">Hide right-click context menu</span>
+              <label class="switch">
+                <input type="checkbox" id="hideContextMenuToggle" />
+                <span class="slider round"></span>
+              </label>
+            </div>
+            <div class="help-text advanced-help" data-i18n="advancedHideContextMenuHelp">
+              When enabled, Auto Tab Groups will not add its items to the page right-click menu.
             </div>
           </div>
         </div>
@@ -270,21 +304,22 @@
       <footer class="footer-container">
         <div class="separator"></div>
         <div>
-          Made by
+          <span data-i18n="footerMadeBy">Made by</span>
           <a class="author selectable" href="https://github.com/nitzanpap" target="_blank"
             >Nitzan Papini</a
-          >, for <span id="browserName">Firefox</span>
+          >, <span data-i18n="footerFor">for</span> <span id="browserName">Firefox</span>
           <span id="browserEmoji"></span>
         </div>
         <div class="feedback-link">
           <a
             href="https://docs.google.com/forms/d/1ViwZsXRSlJqij4nGp84F4gT2f4vBhZkGDQU25F9ESPI"
             target="_blank"
-            >Feedback & Requests & Support</a
+            data-i18n="footerFeedback"
+            >Feedback &amp; Requests &amp; Support</a
           >
         </div>
         <div class="version">
-          <span>Version: <span id="versionNumber"></span></span>
+          <span><span data-i18n="footerVersion">Version:</span> <span id="versionNumber"></span></span>
         </div>
       </footer>
     </div>

--- a/entrypoints/sidebar/index.html
+++ b/entrypoints/sidebar/index.html
@@ -45,7 +45,12 @@
             >
               <option value="auto" data-i18n="settingLanguageAuto">Auto (browser default)</option>
               <option value="en">English</option>
+              <option value="ar">العربية</option>
+              <option value="es">Español</option>
               <option value="he">עברית</option>
+              <option value="hi">हिन्दी</option>
+              <option value="ru">Русский</option>
+              <option value="zh">中文</option>
             </select>
           </div>
           <div class="toggle-container">

--- a/entrypoints/sidebar/index.html
+++ b/entrypoints/sidebar/index.html
@@ -35,6 +35,19 @@
         <div class="separator"></div>
         <div class="settings-container">
           <h2 data-i18n="settingsHeading">Settings</h2>
+          <div class="toggle-container language-row">
+            <span data-i18n="settingLanguage">Language</span>
+            <select
+              id="languageSelect"
+              class="language-select"
+              aria-label="Language"
+              data-i18n-aria-label="settingLanguage"
+            >
+              <option value="auto" data-i18n="settingLanguageAuto">Auto (browser default)</option>
+              <option value="en">English</option>
+              <option value="he">עברית</option>
+            </select>
+          </div>
           <div class="toggle-container">
             <span data-i18n="settingAutoGroupMode">Auto-Group Mode</span>
             <label class="switch">

--- a/entrypoints/sidebar/main.ts
+++ b/entrypoints/sidebar/main.ts
@@ -3,6 +3,7 @@ import "../popup/style.css"
 import type { CustomRule } from "../../types"
 import type { AiGroupSuggestion } from "../../types/ai-messages"
 import { extractDomain } from "../../utils/DomainUtils"
+import { applyI18nToDom, t } from "../../utils/i18n"
 import { cachedAiSuggestions } from "../../utils/storage"
 
 // DOM Elements
@@ -52,6 +53,11 @@ const blacklistCount = document.getElementById("blacklistCount") as HTMLSpanElem
 const blacklistList = document.getElementById("blacklistList") as HTMLDivElement
 const addBlacklistButton = document.getElementById("addBlacklistButton") as HTMLButtonElement
 
+// Advanced Elements
+const advancedToggle = document.querySelector(".advanced-toggle") as HTMLButtonElement
+const advancedContent = document.querySelector(".advanced-content") as HTMLDivElement
+const hideContextMenuToggle = document.getElementById("hideContextMenuToggle") as HTMLInputElement
+
 // AI Elements
 const aiToggle = document.querySelector(".ai-toggle") as HTMLButtonElement
 const aiContent = document.querySelector(".ai-content") as HTMLDivElement
@@ -76,6 +82,7 @@ let aiStatusPollingInterval: ReturnType<typeof setInterval> | null = null
 let sortingSectionExpanded = false
 let customRulesExpanded = false
 let blacklistExpanded = false
+let advancedExpanded = false
 let currentRules: Record<string, CustomRule> = {}
 
 // Color mapping for display
@@ -117,10 +124,10 @@ function updateBrowserDisplay(): void {
   // Check if Firefox
   const isFirefox = navigator.userAgent.includes("Firefox")
   if (isFirefox) {
-    browserNameElement.textContent = "Firefox"
+    browserNameElement.textContent = t("footerBrowserFirefox", "Firefox")
     browserEmojiElement.textContent = ""
   } else {
-    browserNameElement.textContent = "Chrome"
+    browserNameElement.textContent = t("footerBrowserChrome", "Chrome")
     browserEmojiElement.textContent = ""
   }
 }
@@ -149,7 +156,7 @@ function updateGroupByToggle(mode: string): void {
 // Format domains display
 function formatDomainsDisplay(domains: string[], maxLength = 40): string {
   if (!Array.isArray(domains) || domains.length === 0) {
-    return "No domains"
+    return t("rulesNoDomains", "No domains")
   }
 
   if (domains.length === 1) {
@@ -176,7 +183,7 @@ function formatDomainsDisplay(domains: string[], maxLength = 40): string {
   }
 
   const remaining = domains.length - count
-  return `${truncated}${remaining > 0 ? ` and ${remaining} more` : ""}`
+  return `${truncated}${remaining > 0 ? t("rulesDomainsSeparator", ` and ${remaining} more`, String(remaining)) : ""}`
 }
 
 // Load and display custom rules
@@ -193,7 +200,7 @@ async function loadCustomRules(): Promise<void> {
     }
   } catch (error) {
     console.error("Error loading custom rules:", error)
-    showRulesError("Failed to load custom rules")
+    showRulesError(t("rulesFailedToLoad", "Failed to load custom rules"))
   }
 }
 
@@ -208,7 +215,9 @@ function updateRulesDisplay(): void {
   if (exportRulesButton) {
     exportRulesButton.disabled = allRules.length === 0
     exportRulesButton.title =
-      allRules.length === 0 ? "No rules to export" : "Export all rules to JSON file"
+      allRules.length === 0
+        ? t("rulesNoExport", "No rules to export")
+        : t("rulesExportTitle", "Export all rules to JSON file")
   }
 
   while (rulesList.firstChild) rulesList.removeChild(rulesList.firstChild)
@@ -216,8 +225,10 @@ function updateRulesDisplay(): void {
   if (groupingRules.length === 0) {
     const emptyDiv = document.createElement("div")
     emptyDiv.className = "empty-rules"
-    emptyDiv.textContent =
+    emptyDiv.textContent = t(
+      "rulesEmptyState",
       "No custom rules yet. Create your first rule to group tabs by your preferences!"
+    )
     rulesList.appendChild(emptyDiv)
   } else {
     groupingRules.sort((a, b) => {
@@ -249,7 +260,7 @@ function updateBlacklistDisplay(): void {
   if (blacklistRules.length === 0) {
     const emptyDiv = document.createElement("div")
     emptyDiv.className = "empty-rules"
-    emptyDiv.textContent = "No blacklisted domains yet."
+    emptyDiv.textContent = t("blacklistEmpty", "No blacklisted domains yet.")
     blacklistList.appendChild(emptyDiv)
     return
   }
@@ -286,15 +297,15 @@ function createBlacklistElement(rule: CustomRule): HTMLDivElement {
 
   const editBtn = document.createElement("button")
   editBtn.className = "rule-action-btn edit"
-  editBtn.title = "Edit blacklist rule"
+  editBtn.title = t("blacklistEditTitle", "Edit blacklist rule")
   editBtn.setAttribute("data-rule-id", rule.id)
-  editBtn.textContent = "Edit"
+  editBtn.textContent = t("rulesEdit", "Edit")
 
   const deleteBtn = document.createElement("button")
   deleteBtn.className = "rule-action-btn delete"
-  deleteBtn.title = "Delete blacklist rule"
+  deleteBtn.title = t("blacklistDeleteTitle", "Delete blacklist rule")
   deleteBtn.setAttribute("data-rule-id", rule.id)
-  deleteBtn.textContent = "Delete"
+  deleteBtn.textContent = t("rulesDelete", "Delete")
 
   ruleActions.appendChild(editBtn)
   ruleActions.appendChild(deleteBtn)
@@ -340,21 +351,21 @@ function createRuleElement(rule: CustomRule): HTMLDivElement {
 
   const addTabBtn = document.createElement("button")
   addTabBtn.className = "rule-action-btn add-tab"
-  addTabBtn.title = "Add Tab to Existing Rule"
+  addTabBtn.title = t("rulesAddTabTitle", "Add Tab to Existing Rule")
   addTabBtn.setAttribute("data-rule-id", rule.id)
   addTabBtn.textContent = "+"
 
   const editBtn = document.createElement("button")
   editBtn.className = "rule-action-btn edit"
-  editBtn.title = "Edit rule"
+  editBtn.title = t("rulesEditTitle", "Edit rule")
   editBtn.setAttribute("data-rule-id", rule.id)
-  editBtn.textContent = "Edit"
+  editBtn.textContent = t("rulesEdit", "Edit")
 
   const deleteBtn = document.createElement("button")
   deleteBtn.className = "rule-action-btn delete"
-  deleteBtn.title = "Delete rule"
+  deleteBtn.title = t("rulesDeleteTitle", "Delete rule")
   deleteBtn.setAttribute("data-rule-id", rule.id)
-  deleteBtn.textContent = "Delete"
+  deleteBtn.textContent = t("rulesDelete", "Delete")
 
   ruleActions.appendChild(addTabBtn)
   ruleActions.appendChild(editBtn)
@@ -429,7 +440,7 @@ async function addCurrentTabToRule(ruleId: string, button: HTMLButtonElement): P
     const [activeTab] = await browser.tabs.query({ active: true, currentWindow: true })
     if (!activeTab?.url) {
       button.textContent = "!"
-      button.title = "No active tab found"
+      button.title = t("rulesAddTabNoTab", "No active tab found")
       setTimeout(resetButton, 1500)
       return
     }
@@ -437,7 +448,7 @@ async function addCurrentTabToRule(ruleId: string, button: HTMLButtonElement): P
     const domain = extractDomain(activeTab.url)
     if (!domain || domain === "system") {
       button.textContent = "!"
-      button.title = "Cannot extract domain from this tab"
+      button.title = t("rulesAddTabCantExtract", "Cannot extract domain from this tab")
       setTimeout(resetButton, 1500)
       return
     }
@@ -455,19 +466,19 @@ async function addCurrentTabToRule(ruleId: string, button: HTMLButtonElement): P
     if (response?.success) {
       if (response.alreadyExists) {
         button.textContent = "="
-        button.title = "Domain already in this rule"
+        button.title = t("rulesAddTabAlreadyExists", "Domain already in this rule")
       } else {
         button.textContent = "\u2713"
-        button.title = "Added!"
+        button.title = t("rulesAddTabAdded", "Added!")
         await loadCustomRules()
       }
     } else {
       button.textContent = "!"
-      button.title = response?.error || "Failed to add domain"
+      button.title = response?.error || t("rulesAddTabFailed", "Failed to add domain")
     }
   } catch {
     button.textContent = "!"
-    button.title = "Failed to add domain"
+    button.title = t("rulesAddTabFailed", "Failed to add domain")
   }
 
   setTimeout(resetButton, 1500)
@@ -530,7 +541,12 @@ function toggleBlacklistSection(): void {
 }
 
 async function deleteRule(ruleId: string, ruleName: string): Promise<void> {
-  if (!confirm(`Are you sure you want to delete the rule "${ruleName}"?`)) {
+  const prompt = t(
+    "rulesDeleteConfirm",
+    `Are you sure you want to delete the rule "${ruleName}"?`,
+    ruleName
+  )
+  if (!confirm(prompt)) {
     return
   }
 
@@ -544,11 +560,11 @@ async function deleteRule(ruleId: string, ruleName: string): Promise<void> {
       delete currentRules[ruleId]
       updateRulesDisplay()
     } else {
-      alert(response?.error || "Failed to delete rule")
+      alert(response?.error || t("rulesFailedToDelete", "Failed to delete rule"))
     }
   } catch (error) {
     console.error("Error deleting rule:", error)
-    alert("Failed to delete rule")
+    alert(t("rulesFailedToDelete", "Failed to delete rule"))
   }
 }
 
@@ -573,13 +589,13 @@ async function exportRules(): Promise<void> {
       a.click()
       document.body.removeChild(a)
       URL.revokeObjectURL(url)
-      showRulesMessage("Rules exported successfully!", "success")
+      showRulesMessage(t("rulesExportSuccess", "Rules exported successfully!"), "success")
     } else {
-      alert(response?.error || "Failed to export rules")
+      alert(response?.error || t("rulesFailedToExport", "Failed to export rules"))
     }
   } catch (error) {
     console.error("Error exporting rules:", error)
-    alert("Failed to export rules")
+    alert(t("rulesFailedToExport", "Failed to export rules"))
   }
 }
 
@@ -600,9 +616,12 @@ async function handleFileImport(event: Event): Promise<void> {
     const text = await file.text()
 
     const replaceExisting = confirm(
-      "Do you want to replace all existing rules?\n\n" +
-        "Click OK to REPLACE all existing rules with imported ones\n" +
-        "Click Cancel to MERGE imported rules with existing ones"
+      t(
+        "rulesImportReplacePrompt",
+        "Do you want to replace all existing rules?\n\n" +
+          "Click OK to REPLACE all existing rules with imported ones\n" +
+          "Click Cancel to MERGE imported rules with existing ones"
+      )
     )
 
     const response = await sendMessage<{
@@ -620,23 +639,27 @@ async function handleFileImport(event: Event): Promise<void> {
     if (response?.success) {
       await loadCustomRules()
 
-      const message =
-        `Import successful!\n` +
-        `Imported: ${response.imported} rules\n` +
-        `Skipped: ${response.skipped} rules`
+      const imported = String(response.imported ?? 0)
+      const skipped = String(response.skipped ?? 0)
+      const message = t(
+        "rulesImportSummary",
+        `Import successful!\nImported: ${imported} rules\nSkipped: ${skipped} rules`,
+        [imported, skipped]
+      )
 
-      showRulesMessage("Rules imported successfully!", "success")
+      showRulesMessage(t("rulesImportSuccess", "Rules imported successfully!"), "success")
       alert(message)
     } else {
-      alert(response?.error || "Failed to import rules")
+      alert(response?.error || t("rulesFailedToImport", "Failed to import rules"))
     }
   } catch (error) {
     console.error("Error importing rules:", error)
-    alert(`Failed to import rules: ${(error as Error).message}`)
+    alert(`${t("rulesFailedToImport", "Failed to import rules")}: ${(error as Error).message}`)
   }
 }
 
 // Initialize
+applyI18nToDom()
 updateVersionDisplay()
 updateBrowserDisplay()
 
@@ -831,8 +854,13 @@ async function initializeAiSection(): Promise<void> {
   try {
     // AI features are Chrome-only for now (WebLLM's tokenizer exceeds Firefox store limits)
     if (navigator.userAgent.includes("Firefox")) {
-      aiContent.innerHTML =
-        '<div class="ai-firefox-notice">AI features are currently available on Chrome only. Firefox support is coming soon.</div>'
+      const notice = document.createElement("div")
+      notice.className = "ai-firefox-notice"
+      notice.textContent = t(
+        "aiFirefoxNotice",
+        "AI features are currently available on Chrome only. Firefox support is coming soon."
+      )
+      aiContent.replaceChildren(notice)
       return
     }
 
@@ -868,7 +896,8 @@ async function initializeAiSection(): Promise<void> {
 
     if (webGpuResponse?.webGpu && !webGpuResponse.webGpu.available) {
       aiWebGpuWarning.classList.add("visible")
-      aiWebGpuWarning.textContent = webGpuResponse.webGpu.reason || "WebGPU is not available"
+      aiWebGpuWarning.textContent =
+        webGpuResponse.webGpu.reason || t("aiWebGpuUnavailable", "WebGPU is not available")
       aiLoadButton.disabled = true
     }
   } catch (error) {
@@ -886,7 +915,7 @@ function updateAiSettingsVisibility(enabled: boolean): void {
 }
 
 function updateAiBadge(enabled: boolean): void {
-  aiBadge.textContent = enabled ? "On" : "Off"
+  aiBadge.textContent = enabled ? t("aiBadgeOn", "On") : t("aiBadgeOff", "Off")
   aiBadge.classList.toggle("enabled", enabled)
 }
 
@@ -899,12 +928,12 @@ function updateAiModelStatus(modelStatus: {
 
   aiStatusBadge.textContent =
     status === "idle"
-      ? "Idle"
+      ? t("aiStatusIdle", "Idle")
       : status === "loading"
-        ? `Loading ${progress}%`
+        ? t("aiStatusLoading", `Loading ${progress}%`, String(progress))
         : status === "ready"
-          ? "Ready"
-          : "Error"
+          ? t("aiStatusReady", "Ready")
+          : t("aiStatusError", "Error")
 
   aiStatusBadge.className = "ai-status-badge"
   if (status !== "idle") {
@@ -919,20 +948,20 @@ function updateAiModelStatus(modelStatus: {
   }
 
   if (status === "ready") {
-    aiLoadButton.textContent = "Unload Model"
+    aiLoadButton.textContent = t("aiUnloadModel", "Unload Model")
     aiLoadButton.classList.add("unload")
     aiLoadButton.disabled = false
     aiModelSelect.disabled = true
     aiSuggestButton.disabled = false
     stopAiStatusPolling()
   } else if (status === "loading") {
-    aiLoadButton.textContent = "Loading..."
+    aiLoadButton.textContent = t("aiLoadingButton", "Loading...")
     aiLoadButton.disabled = true
     aiModelSelect.disabled = true
     aiSuggestButton.disabled = true
     startAiStatusPolling()
   } else if (status === "error") {
-    aiLoadButton.textContent = "Retry Load"
+    aiLoadButton.textContent = t("aiRetryLoad", "Retry Load")
     aiLoadButton.classList.remove("unload")
     aiLoadButton.disabled = false
     aiModelSelect.disabled = false
@@ -942,7 +971,7 @@ function updateAiModelStatus(modelStatus: {
       console.error("AI model error:", error)
     }
   } else {
-    aiLoadButton.textContent = "Load Model"
+    aiLoadButton.textContent = t("aiLoadModel", "Load Model")
     aiLoadButton.classList.remove("unload")
     aiLoadButton.disabled = false
     aiModelSelect.disabled = false
@@ -977,7 +1006,7 @@ function stopAiStatusPolling(): void {
 
 async function handleSuggestGroups(): Promise<void> {
   aiSuggestButton.disabled = true
-  aiSuggestStatus.textContent = "Analyzing your tabs..."
+  aiSuggestStatus.textContent = t("aiAnalyzing", "Analyzing your tabs...")
   aiSuggestStatus.className = "ai-suggest-status loading"
   aiSuggestionsContainer.innerHTML = ""
 
@@ -994,12 +1023,13 @@ async function handleSuggestGroups(): Promise<void> {
       aiSuggestStatus.className = "ai-suggest-status"
       renderSuggestions(response.suggestions, [])
     } else {
-      aiSuggestStatus.textContent = response?.error || "Failed to get suggestions"
+      aiSuggestStatus.textContent =
+        response?.error || t("aiFailedToGetSuggestions", "Failed to get suggestions")
       aiSuggestStatus.className = "ai-suggest-status error"
     }
   } catch (error) {
     console.error("Error suggesting groups:", error)
-    aiSuggestStatus.textContent = "Failed to get suggestions"
+    aiSuggestStatus.textContent = t("aiFailedToGetSuggestions", "Failed to get suggestions")
     aiSuggestStatus.className = "ai-suggest-status error"
   } finally {
     aiSuggestButton.disabled = false
@@ -1013,14 +1043,14 @@ function renderSuggestions(
   aiSuggestionsContainer.innerHTML = ""
 
   if (suggestions.length === 0) {
-    aiSuggestStatus.textContent = "No suggestions found"
+    aiSuggestStatus.textContent = t("aiNoSuggestions", "No suggestions found")
     aiSuggestStatus.className = "ai-suggest-status"
     return
   }
 
   const dismissBtn = document.createElement("button")
   dismissBtn.className = "suggestion-dismiss-btn"
-  dismissBtn.textContent = "Dismiss"
+  dismissBtn.textContent = t("aiDismiss", "Dismiss")
   dismissBtn.addEventListener("click", async () => {
     await cachedAiSuggestions.setValue(null)
     aiSuggestionsContainer.innerHTML = ""
@@ -1047,7 +1077,11 @@ function renderSuggestions(
 
     const tabCount = document.createElement("span")
     tabCount.className = "suggestion-tab-count"
-    tabCount.textContent = `${suggestion.tabs.length} tab${suggestion.tabs.length !== 1 ? "s" : ""}`
+    const plural = suggestion.tabs.length !== 1 ? "s" : ""
+    tabCount.textContent = t("aiTabsCount", `${suggestion.tabs.length} tab${plural}`, [
+      String(suggestion.tabs.length),
+      plural
+    ])
 
     header.appendChild(colorDot)
     header.appendChild(name)
@@ -1069,7 +1103,7 @@ function renderSuggestions(
 
     const applyBtn = document.createElement("button")
     applyBtn.className = `suggestion-apply-btn${isApplied ? " applied" : ""}`
-    applyBtn.textContent = isApplied ? "Applied!" : "Apply"
+    applyBtn.textContent = isApplied ? t("aiApplied", "Applied!") : t("aiApply", "Apply")
     applyBtn.disabled = isApplied
     if (!isApplied) {
       applyBtn.addEventListener("click", () => handleApplySuggestion(suggestion, applyBtn))
@@ -1077,7 +1111,7 @@ function renderSuggestions(
 
     const ruleBtn = document.createElement("button")
     ruleBtn.className = "suggestion-rule-btn"
-    ruleBtn.textContent = "Create Rule"
+    ruleBtn.textContent = t("aiCreateRule", "Create Rule")
     ruleBtn.addEventListener("click", () => createRuleFromSuggestion(suggestion))
 
     actions.appendChild(applyBtn)
@@ -1095,7 +1129,7 @@ async function handleApplySuggestion(
   button: HTMLButtonElement
 ): Promise<void> {
   button.disabled = true
-  button.textContent = "Applying..."
+  button.textContent = t("aiApplying", "Applying...")
 
   try {
     const response = await sendMessage<{
@@ -1109,19 +1143,24 @@ async function handleApplySuggestion(
     })
 
     if (response?.success) {
-      button.textContent = "Applied!"
+      button.textContent = t("aiApplied", "Applied!")
       button.classList.add("applied")
       if (response.staleTabIds && response.staleTabIds.length > 0) {
-        button.textContent = `Applied (${response.staleTabIds.length} tab${response.staleTabIds.length !== 1 ? "s" : ""} closed)`
+        const count = response.staleTabIds.length
+        const plural = count !== 1 ? "s" : ""
+        button.textContent = t("aiAppliedWithStale", `Applied (${count} tab${plural} closed)`, [
+          String(count),
+          plural
+        ])
       }
     } else {
-      button.textContent = "Failed"
+      button.textContent = t("aiFailed", "Failed")
       button.disabled = false
       console.error("Failed to apply suggestion:", response?.error)
     }
   } catch (error) {
     console.error("Error applying suggestion:", error)
-    button.textContent = "Failed"
+    button.textContent = t("aiFailed", "Failed")
     button.disabled = false
   }
 }
@@ -1210,6 +1249,28 @@ importFileInput?.addEventListener("change", handleFileImport)
 // Blacklist event listeners
 blacklistToggle?.addEventListener("click", toggleBlacklistSection)
 addBlacklistButton?.addEventListener("click", addBlacklistRule)
+
+// Advanced section toggle
+function toggleAdvancedSection(): void {
+  advancedExpanded = !advancedExpanded
+  advancedToggle.classList.toggle("expanded", advancedExpanded)
+  advancedContent.classList.toggle("expanded", advancedExpanded)
+}
+
+advancedToggle?.addEventListener("click", toggleAdvancedSection)
+
+// Initialize hide context menu state
+sendMessage<{ enabled?: boolean }>({ action: "getHideContextMenu" }).then(response => {
+  hideContextMenuToggle.checked = response?.enabled ?? false
+})
+
+// Hide context menu event listener
+hideContextMenuToggle?.addEventListener("change", event => {
+  sendMessage({
+    action: "toggleHideContextMenu",
+    enabled: (event.target as HTMLInputElement).checked
+  })
+})
 
 // Initialize AI badge on sidebar open
 sendMessage<{

--- a/entrypoints/sidebar/main.ts
+++ b/entrypoints/sidebar/main.ts
@@ -671,8 +671,10 @@ async function handleFileImport(event: Event): Promise<void> {
   }
 }
 // Initialize — resolve locale from background, load override catalog if any,
-// then translate the DOM and set text direction.
-;(async () => {
+// then translate the DOM and set text direction. Dynamic lists (rules, blacklist,
+// cached AI suggestions) are loaded AFTER i18n is ready so their dynamically
+// rendered strings (Edit/Delete buttons, empty states) pick up the right locale.
+const i18nReady: Promise<void> = (async () => {
   const resp = await sendMessage<{ locale?: UserLocale }>({ action: "getUserLocale" })
   const locale: UserLocale = resp?.locale ?? "auto"
   languageSelect.value = locale
@@ -683,13 +685,17 @@ async function handleFileImport(event: Event): Promise<void> {
 updateVersionDisplay()
 updateBrowserDisplay()
 
-// Language picker change handler
+// Language picker change handler — also re-renders dynamic lists so their
+// JS-rendered strings (Edit/Delete buttons, truncation suffix, empty states)
+// switch along with the static DOM.
 languageSelect.addEventListener("change", async () => {
   const locale = languageSelect.value as UserLocale
   await sendMessage({ action: "setUserLocale", locale })
   await initI18n(locale)
   applyI18nToDom()
   applyDirectionToDom(resolveEffectiveLocale(locale))
+  updateRulesDisplay()
+  updateBlacklistDisplay()
 })
 
 // Button event listeners
@@ -1346,7 +1352,12 @@ async function loadCachedSuggestions(): Promise<void> {
 
   renderSuggestions(cached.suggestions, cached.appliedIndices)
 }
-loadCachedSuggestions()
 
-// Load custom rules on sidebar open
-loadCustomRules()
+// Gate initial dynamic loads on i18n readiness so JS-rendered strings
+// (Edit/Delete buttons, empty state, truncation suffix, etc.) render in the
+// user's chosen locale on first paint. Subsequent calls (from event handlers)
+// already run after i18nReady has resolved.
+i18nReady.then(() => {
+  loadCachedSuggestions()
+  loadCustomRules()
+})

--- a/entrypoints/sidebar/main.ts
+++ b/entrypoints/sidebar/main.ts
@@ -1,9 +1,15 @@
 // Sidebar shares the same logic and styles as popup
 import "../popup/style.css"
-import type { CustomRule } from "../../types"
+import type { CustomRule, UserLocale } from "../../types"
 import type { AiGroupSuggestion } from "../../types/ai-messages"
 import { extractDomain } from "../../utils/DomainUtils"
-import { applyI18nToDom, t } from "../../utils/i18n"
+import {
+  applyDirectionToDom,
+  applyI18nToDom,
+  initI18n,
+  resolveEffectiveLocale,
+  t
+} from "../../utils/i18n"
 import { cachedAiSuggestions } from "../../utils/storage"
 
 // DOM Elements
@@ -61,6 +67,9 @@ const addBlacklistButton = document.getElementById("addBlacklistButton") as HTML
 const advancedToggle = document.querySelector(".advanced-toggle") as HTMLButtonElement
 const advancedContent = document.querySelector(".advanced-content") as HTMLDivElement
 const hideContextMenuToggle = document.getElementById("hideContextMenuToggle") as HTMLInputElement
+
+// Language picker
+const languageSelect = document.getElementById("languageSelect") as HTMLSelectElement
 
 // AI Elements
 const aiToggle = document.querySelector(".ai-toggle") as HTMLButtonElement
@@ -661,11 +670,27 @@ async function handleFileImport(event: Event): Promise<void> {
     alert(`${t("rulesFailedToImport", "Failed to import rules")}: ${(error as Error).message}`)
   }
 }
-
-// Initialize
-applyI18nToDom()
+// Initialize — resolve locale from background, load override catalog if any,
+// then translate the DOM and set text direction.
+;(async () => {
+  const resp = await sendMessage<{ locale?: UserLocale }>({ action: "getUserLocale" })
+  const locale: UserLocale = resp?.locale ?? "auto"
+  languageSelect.value = locale
+  await initI18n(locale)
+  applyI18nToDom()
+  applyDirectionToDom(resolveEffectiveLocale(locale))
+})()
 updateVersionDisplay()
 updateBrowserDisplay()
+
+// Language picker change handler
+languageSelect.addEventListener("change", async () => {
+  const locale = languageSelect.value as UserLocale
+  await sendMessage({ action: "setUserLocale", locale })
+  await initI18n(locale)
+  applyI18nToDom()
+  applyDirectionToDom(resolveEffectiveLocale(locale))
+})
 
 // Button event listeners
 groupButton.addEventListener("click", () => sendMessage({ action: "group" }))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.4.2",
+  "version": "3.5.0",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/public/_locales/ar/messages.json
+++ b/public/_locales/ar/messages.json
@@ -1,0 +1,748 @@
+{
+  "extensionName": {
+    "message": "Auto Tab Groups",
+    "description": "The name of the extension as it appears in the browser store and toolbar."
+  },
+  "extensionDescription": {
+    "message": "يجمّع علامات التبويب تلقائياً حسب النطاق.",
+    "description": "Short description shown in the extensions list."
+  },
+
+  "popupTitle": {
+    "message": "Auto Tab Groups",
+    "description": "Heading shown at the top of the popup/sidebar."
+  },
+  "popupGroupTabs": {
+    "message": "تجميع علامات التبويب",
+    "description": "Button that groups all open tabs immediately."
+  },
+  "popupUngroupAll": {
+    "message": "إلغاء تجميع الكل",
+    "description": "Button that removes every tab group."
+  },
+  "popupGenerateNewColors": {
+    "message": "إنشاء ألوان جديدة",
+    "description": "Button that randomizes the colors of all groups."
+  },
+  "popupGenerateNewColorsTitle": {
+    "message": "اختيار ألوان عشوائية للمجموعات. تُحفظ الألوان وتُستعاد تلقائياً لكل نطاق أو قاعدة.",
+    "description": "Tooltip for the Generate New Colors button."
+  },
+  "popupCollapseAll": {
+    "message": "طي الكل",
+    "description": "Button that collapses every group."
+  },
+  "popupExpandAll": {
+    "message": "توسيع الكل",
+    "description": "Button that expands every group."
+  },
+
+  "settingsHeading": {
+    "message": "الإعدادات",
+    "description": "Heading for the main settings section."
+  },
+  "settingLanguage": {
+    "message": "اللغة",
+    "description": "Label for the UI language picker."
+  },
+  "settingLanguageAuto": {
+    "message": "تلقائي (الافتراضي للمتصفح)",
+    "description": "Picker option that defers to the browser's UI language."
+  },
+  "settingAutoGroupMode": {
+    "message": "وضع التجميع التلقائي",
+    "description": "Label for the toggle that enables automatic grouping."
+  },
+  "settingGroupBy": {
+    "message": "التجميع حسب",
+    "description": "Label for the group-by mode selector."
+  },
+  "settingGroupByRulesOnly": {
+    "message": "القواعد فقط",
+    "description": "Option that groups only by custom rules."
+  },
+  "settingGroupByRulesAndDomain": {
+    "message": "القواعد والنطاق",
+    "description": "Option that groups by rules plus base domain (popup)."
+  },
+  "settingGroupByRulesAndSubdomain": {
+    "message": "القواعد والنطاق الفرعي",
+    "description": "Option that groups by rules plus subdomain (popup)."
+  },
+  "settingGroupByDomain": {
+    "message": "النطاق",
+    "description": "Option that groups by base domain (sidebar)."
+  },
+  "settingGroupBySubdomain": {
+    "message": "النطاق الفرعي",
+    "description": "Option that groups by subdomain (sidebar)."
+  },
+  "settingGroupNewEmptyTabs": {
+    "message": "تجميع علامات التبويب الفارغة الجديدة تحت «System»",
+    "description": "Label for the toggle that groups blank/new tabs under a System group."
+  },
+  "settingMinimumTabsForGroup": {
+    "message": "الحد الأدنى لعلامات التبويب لتكوين مجموعة",
+    "description": "Label for the numeric input that sets the minimum tab count required to create a group."
+  },
+  "settingAutoCollapseInactive": {
+    "message": "طي المجموعات غير النشطة تلقائياً",
+    "description": "Label for the toggle that auto-collapses groups the user isn't looking at."
+  },
+  "settingCollapseDelay": {
+    "message": "تأخير الطي",
+    "description": "Label for the numeric input that sets the auto-collapse delay."
+  },
+  "settingCollapseDelayHelp": {
+    "message": "0 = فوري، أو حدّد التأخير (100-5000 مللي ثانية) قبل الطي",
+    "description": "Help text under the collapse-delay input."
+  },
+  "settingOpenNewTabsNextToCurrent": {
+    "message": "فتح علامات التبويب الجديدة بجوار علامة التبويب الحالية",
+    "description": "Label for the toggle that opens new tabs adjacent to the active tab."
+  },
+  "settingPinnedTabsNote": {
+    "message": "لا تُجمَّع علامات التبويب المثبَّتة تلقائياً أبداً",
+    "description": "Informational note about pinned tabs."
+  },
+
+  "sortingSectionTitle": {
+    "message": "الترتيب",
+    "description": "Title for the collapsible sorting section."
+  },
+  "settingSortGroupsAlphabetically": {
+    "message": "إبقاء المجموعات مرتَّبة أبجدياً",
+    "description": "Toggle that keeps tab groups sorted alphabetically."
+  },
+  "settingSortDirection": {
+    "message": "الاتجاه",
+    "description": "Label for the sort direction toggle (A-Z vs Z-A)."
+  },
+  "settingSortDirectionAsc": {
+    "message": "A - Z",
+    "description": "Ascending alphabetical sort direction option."
+  },
+  "settingSortDirectionDesc": {
+    "message": "Z - A",
+    "description": "Descending alphabetical sort direction option."
+  },
+  "settingNumberGroups": {
+    "message": "ترقيم المجموعات (1. AI، 2. Docs...)",
+    "description": "Toggle that prefixes group titles with their sort index."
+  },
+  "settingNumberGroupsHelp": {
+    "message": "يضيف أرقام المواضع إلى عناوين المجموعات للرجوع السريع",
+    "description": "Help text describing the Number Groups toggle."
+  },
+
+  "aiSectionTitle": {
+    "message": "ميزات الذكاء الاصطناعي",
+    "description": "Title for the AI features section."
+  },
+  "aiExperimentalBadge": {
+    "message": "تجريبي",
+    "description": "Badge shown next to the AI Features title."
+  },
+  "aiHelpTooltip": {
+    "message": "اقتراحات تجميع علامات التبويب المدعومة بالذكاء الاصطناعي. هذه الميزة تجريبية. تجري جميع المعالجة محلياً داخل متصفحك — لا تُرسَل أي بيانات إلى خوادم خارجية.",
+    "description": "Tooltip explaining the AI Features."
+  },
+  "aiBadgeOn": {
+    "message": "مُفعَّل",
+    "description": "Status badge shown when AI is enabled."
+  },
+  "aiBadgeOff": {
+    "message": "مُعطَّل",
+    "description": "Status badge shown when AI is disabled."
+  },
+  "aiEnable": {
+    "message": "تفعيل الذكاء الاصطناعي",
+    "description": "Toggle that enables or disables AI features."
+  },
+  "aiModelLabel": {
+    "message": "النموذج",
+    "description": "Label for the AI model selector."
+  },
+  "aiStatusLabel": {
+    "message": "الحالة:",
+    "description": "Label for the AI model status."
+  },
+  "aiStatusIdle": {
+    "message": "خامل",
+    "description": "AI model status: idle."
+  },
+  "aiStatusReady": {
+    "message": "جاهز",
+    "description": "AI model status: ready."
+  },
+  "aiStatusLoading": {
+    "message": "جارٍ التحميل $progress$٪",
+    "description": "AI model status while loading, with a progress percentage.",
+    "placeholders": {
+      "progress": { "content": "$1", "example": "42" }
+    }
+  },
+  "aiStatusError": {
+    "message": "خطأ",
+    "description": "AI model status: error."
+  },
+  "aiLoadModel": {
+    "message": "تحميل النموذج",
+    "description": "Button that starts loading the AI model."
+  },
+  "aiUnloadModel": {
+    "message": "تفريغ النموذج",
+    "description": "Button that unloads the AI model."
+  },
+  "aiLoadingButton": {
+    "message": "جارٍ التحميل...",
+    "description": "Label shown on the load button while loading."
+  },
+  "aiRetryLoad": {
+    "message": "إعادة المحاولة",
+    "description": "Button shown after an AI model load error."
+  },
+  "aiWebGpuUnavailable": {
+    "message": "WebGPU غير متاح. تتطلب ميزات الذكاء الاصطناعي متصفحاً يدعم WebGPU.",
+    "description": "Warning shown when WebGPU is not supported."
+  },
+  "aiDownloadNote": {
+    "message": "تعمل النماذج محلياً داخل متصفحك. يُنزِّل التحميل الأول النموذج (~250MB-900MB).",
+    "description": "Help text beneath the load model button."
+  },
+  "aiSuggestGroups": {
+    "message": "اقتراح مجموعات",
+    "description": "Button that asks the AI to suggest tab groups."
+  },
+  "aiAnalyzing": {
+    "message": "جارٍ تحليل علامات التبويب الخاصة بك...",
+    "description": "Status text while the AI analyzes open tabs."
+  },
+  "aiNoSuggestions": {
+    "message": "لا توجد اقتراحات",
+    "description": "Status text shown when the AI returns zero suggestions."
+  },
+  "aiFailedToGetSuggestions": {
+    "message": "فشل الحصول على اقتراحات",
+    "description": "Error shown when AI suggestion fails."
+  },
+  "aiDismiss": {
+    "message": "رفض",
+    "description": "Button that dismisses AI suggestions."
+  },
+  "aiApply": {
+    "message": "تطبيق",
+    "description": "Button that applies an AI suggestion."
+  },
+  "aiApplying": {
+    "message": "جارٍ التطبيق...",
+    "description": "Button label while applying a suggestion."
+  },
+  "aiApplied": {
+    "message": "تم التطبيق!",
+    "description": "Button label after applying a suggestion."
+  },
+  "aiFailed": {
+    "message": "فشل",
+    "description": "Button label after a suggestion fails."
+  },
+  "aiCreateRule": {
+    "message": "إنشاء قاعدة",
+    "description": "Button that creates a rule from a suggestion."
+  },
+  "aiTabsCount": {
+    "message": "$count$ علامة تبويب",
+    "description": "Tab count label for a suggestion.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "plural": { "content": "$2" }
+    }
+  },
+  "aiAppliedWithStale": {
+    "message": "تم التطبيق (أُغلقت $count$ علامة تبويب)",
+    "description": "Shown when a suggestion is applied but some tabs were closed.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "plural": { "content": "$2" }
+    }
+  },
+  "aiFirefoxNotice": {
+    "message": "ميزات الذكاء الاصطناعي متاحة حالياً على Chrome فقط. دعم Firefox قريباً.",
+    "description": "Notice shown to Firefox users."
+  },
+
+  "rulesSectionTitle": {
+    "message": "القواعد المخصَّصة",
+    "description": "Title for the custom rules section."
+  },
+  "rulesAddNewRule": {
+    "message": "إضافة قاعدة جديدة",
+    "description": "Button that opens the new rule dialog."
+  },
+  "rulesExport": {
+    "message": "تصدير",
+    "description": "Button that exports rules to JSON."
+  },
+  "rulesImport": {
+    "message": "استيراد",
+    "description": "Button that imports rules from JSON."
+  },
+  "rulesExportTitle": {
+    "message": "تصدير جميع القواعد إلى ملف JSON",
+    "description": "Tooltip on the Export button."
+  },
+  "rulesImportTitle": {
+    "message": "استيراد القواعد من ملف JSON",
+    "description": "Tooltip on the Import button."
+  },
+  "rulesExportImportHelp": {
+    "message": "تصدير/استيراد القواعد كملفات JSON للنسخ الاحتياطي أو المشاركة",
+    "description": "Help text under the export/import buttons."
+  },
+  "rulesEmptyState": {
+    "message": "لا توجد قواعد مخصَّصة بعد. أنشئ قاعدتك الأولى لتجميع علامات التبويب حسب تفضيلاتك!",
+    "description": "Shown when there are no custom rules."
+  },
+  "rulesEdit": {
+    "message": "تحرير",
+    "description": "Edit button on a rule row."
+  },
+  "rulesDelete": {
+    "message": "حذف",
+    "description": "Delete button on a rule row."
+  },
+  "rulesEditTitle": {
+    "message": "تحرير القاعدة",
+    "description": "Tooltip for the edit button."
+  },
+  "rulesDeleteTitle": {
+    "message": "حذف القاعدة",
+    "description": "Tooltip for the delete button."
+  },
+  "rulesAddTabTitle": {
+    "message": "إضافة علامة التبويب إلى قاعدة موجودة",
+    "description": "Tooltip for the + button that adds the current tab to a rule."
+  },
+  "rulesDeleteConfirm": {
+    "message": "هل أنت متأكد أنك تريد حذف القاعدة «$name$»؟",
+    "description": "Confirmation prompt before deleting a rule.",
+    "placeholders": {
+      "name": { "content": "$1" }
+    }
+  },
+  "rulesFailedToLoad": {
+    "message": "فشل تحميل القواعد المخصَّصة",
+    "description": "Error when loading rules fails."
+  },
+  "rulesFailedToDelete": {
+    "message": "فشل حذف القاعدة",
+    "description": "Error when deleting a rule fails."
+  },
+  "rulesExportSuccess": {
+    "message": "تم تصدير القواعد بنجاح!",
+    "description": "Confirmation after exporting rules."
+  },
+  "rulesFailedToExport": {
+    "message": "فشل تصدير القواعد",
+    "description": "Error when export fails."
+  },
+  "rulesImportSuccess": {
+    "message": "تم استيراد القواعد بنجاح!",
+    "description": "Confirmation after importing rules."
+  },
+  "rulesImportSummary": {
+    "message": "نجح الاستيراد!\nتم الاستيراد: $imported$ قاعدة\nتم التخطي: $skipped$ قاعدة",
+    "description": "Summary shown after rules are imported.",
+    "placeholders": {
+      "imported": { "content": "$1" },
+      "skipped": { "content": "$2" }
+    }
+  },
+  "rulesFailedToImport": {
+    "message": "فشل استيراد القواعد",
+    "description": "Error when import fails."
+  },
+  "rulesImportReplacePrompt": {
+    "message": "هل تريد استبدال جميع القواعد الموجودة؟\n\nاضغط «موافق» لاستبدال جميع القواعد الموجودة بالقواعد المستوردة\nاضغط «إلغاء» لدمج القواعد المستوردة مع القواعد الموجودة",
+    "description": "Prompt that asks whether to merge or replace on import."
+  },
+  "rulesNoExport": {
+    "message": "لا توجد قواعد لتصديرها",
+    "description": "Tooltip shown on a disabled export button when there are no rules."
+  },
+  "rulesNoDomains": {
+    "message": "لا توجد نطاقات",
+    "description": "Shown when a rule has no configured domains."
+  },
+  "rulesDomainsSeparator": {
+    "message": " و $count$ أخرى",
+    "description": "Appended to truncated domain lists.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "rulesAddTabNoTab": {
+    "message": "لم يتم العثور على علامة تبويب نشطة",
+    "description": "Tooltip shown on the add-tab button when no active tab is available."
+  },
+  "rulesAddTabCantExtract": {
+    "message": "لا يمكن استخراج النطاق من علامة التبويب هذه",
+    "description": "Tooltip when the current tab's URL has no domain."
+  },
+  "rulesAddTabAlreadyExists": {
+    "message": "النطاق موجود بالفعل في هذه القاعدة",
+    "description": "Tooltip when the tab's domain is already part of the rule."
+  },
+  "rulesAddTabAdded": {
+    "message": "تمت الإضافة!",
+    "description": "Tooltip shown briefly after adding a tab to a rule."
+  },
+  "rulesAddTabFailed": {
+    "message": "فشل إضافة النطاق",
+    "description": "Tooltip when adding a domain fails."
+  },
+
+  "blacklistSectionTitle": {
+    "message": "القائمة السوداء",
+    "description": "Title for the blacklist section."
+  },
+  "blacklistAddButton": {
+    "message": "إضافة إلى القائمة السوداء",
+    "description": "Button to add a domain to the blacklist."
+  },
+  "blacklistHelp": {
+    "message": "لن يتم تجميع النطاقات الموجودة في القائمة السوداء أبداً",
+    "description": "Help text under the blacklist section."
+  },
+  "blacklistEmpty": {
+    "message": "لا توجد نطاقات في القائمة السوداء بعد.",
+    "description": "Shown when the blacklist is empty."
+  },
+  "blacklistEditTitle": {
+    "message": "تحرير قاعدة القائمة السوداء",
+    "description": "Tooltip for the blacklist edit button."
+  },
+  "blacklistDeleteTitle": {
+    "message": "حذف قاعدة القائمة السوداء",
+    "description": "Tooltip for the blacklist delete button."
+  },
+
+  "advancedSectionTitle": {
+    "message": "متقدم",
+    "description": "Title for the advanced settings section."
+  },
+  "advancedHideContextMenu": {
+    "message": "إخفاء قائمة النقر بالزر الأيمن",
+    "description": "Toggle that hides the extension's context menu items."
+  },
+  "advancedHideContextMenuHelp": {
+    "message": "عند التفعيل، لن يُضيف Auto Tab Groups عناصره إلى قائمة النقر بالزر الأيمن للصفحة.",
+    "description": "Help text for the hide context menu toggle."
+  },
+
+  "footerMadeBy": {
+    "message": "من إنشاء",
+    "description": "Prefix for the author attribution in the footer."
+  },
+  "footerFor": {
+    "message": "لـ",
+    "description": "Connector text: 'Made by X, for Chrome'."
+  },
+  "footerBrowserChrome": {
+    "message": "Chrome",
+    "description": "Name of the Chrome browser in the footer."
+  },
+  "footerBrowserFirefox": {
+    "message": "Firefox",
+    "description": "Name of the Firefox browser in the footer."
+  },
+  "footerFeedback": {
+    "message": "الملاحظات والطلبات والدعم",
+    "description": "Text of the feedback link."
+  },
+  "footerVersion": {
+    "message": "الإصدار:",
+    "description": "Prefix before the version number."
+  },
+
+  "contextMenuCreateRuleFromGroup": {
+    "message": "إنشاء قاعدة من المجموعة",
+    "description": "Right-click menu: create a custom rule from the clicked tab's group."
+  },
+  "contextMenuAddTabToExistingRule": {
+    "message": "إضافة علامة التبويب إلى قاعدة موجودة",
+    "description": "Right-click menu: submenu to add the current tab's domain to an existing rule."
+  },
+  "contextMenuAddToBlacklist": {
+    "message": "إضافة إلى القائمة السوداء",
+    "description": "Right-click menu: add the current tab's domain to the blacklist."
+  },
+  "contextMenuNoRulesYet": {
+    "message": "لا توجد قواعد بعد",
+    "description": "Disabled placeholder shown when the Add Tab submenu has no rules."
+  },
+
+  "ruleModalCreateTitle": {
+    "message": "إنشاء قاعدة مخصَّصة",
+    "description": "Title shown when creating a new rule."
+  },
+  "ruleModalEditTitle": {
+    "message": "تحرير قاعدة مخصَّصة",
+    "description": "Title shown when editing an existing rule."
+  },
+  "ruleModalNameLabel": {
+    "message": "اسم القاعدة",
+    "description": "Label for the rule name input."
+  },
+  "ruleModalNamePlaceholder": {
+    "message": "مثلاً: تطبيقات العمل",
+    "description": "Placeholder for the rule name input."
+  },
+  "ruleModalNameHelp": {
+    "message": "يدعم أي لغة بما في ذلك الصينية واليابانية والكورية والرموز التعبيرية",
+    "description": "Help text under the rule name input."
+  },
+  "ruleModalAiAssistLabel": {
+    "message": "المساعدة بالذكاء الاصطناعي",
+    "description": "Label for the AI assist section."
+  },
+  "ruleModalAiAssistPlaceholder": {
+    "message": "صِف قاعدتك، مثلاً: «جمِّع كل خدمات Google» أو «جمِّع علامات التبويب الخاصة بـ AWS console»",
+    "description": "Placeholder for the AI assist input."
+  },
+  "ruleModalAiGenerate": {
+    "message": "إنشاء",
+    "description": "Button that asks the AI to generate a rule."
+  },
+  "ruleModalAiAssistHelp": {
+    "message": "صِف ما تريد تجميعه وسيقترح الذكاء الاصطناعي الاسم والنطاقات واللون",
+    "description": "Help text under the AI assist input."
+  },
+  "ruleModalPatternModeLabel": {
+    "message": "وضع النمط",
+    "description": "Label for the pattern mode toggle."
+  },
+  "ruleModalPatternModeSimple": {
+    "message": "بسيط (نطاقات)",
+    "description": "Simple pattern mode: matches whole domains."
+  },
+  "ruleModalPatternModeExplicit": {
+    "message": "صريح (روابط كاملة)",
+    "description": "Explicit pattern mode: matches full URLs."
+  },
+  "ruleModalSimpleModeHint": {
+    "message": "يجمّع جميع الصفحات من هذه النطاقات الأساسية",
+    "description": "Hint shown in simple pattern mode."
+  },
+  "ruleModalExplicitModeHint": {
+    "message": "يجمّع فقط الصفحات التي تطابق هذه الأنماط الكاملة للروابط",
+    "description": "Hint shown in explicit pattern mode."
+  },
+  "ruleModalPatternsLabel": {
+    "message": "أنماط الروابط (نمط واحد لكل سطر)",
+    "description": "Label for the patterns textarea."
+  },
+  "ruleModalPatternsHelp": {
+    "message": "يدعم: النطاقات، الرموز البدل (*.example.com)، المسارات (example.com/api/*)، عناوين IP",
+    "description": "Help text for the patterns textarea."
+  },
+  "ruleModalColorLabel": {
+    "message": "لون المجموعة",
+    "description": "Label for the color picker."
+  },
+  "ruleModalColorBlue": { "message": "أزرق", "description": "Color option: blue." },
+  "ruleModalColorRed": { "message": "أحمر", "description": "Color option: red." },
+  "ruleModalColorYellow": { "message": "أصفر", "description": "Color option: yellow." },
+  "ruleModalColorGreen": { "message": "أخضر", "description": "Color option: green." },
+  "ruleModalColorPink": { "message": "وردي", "description": "Color option: pink." },
+  "ruleModalColorPurple": { "message": "بنفسجي", "description": "Color option: purple." },
+  "ruleModalColorCyan": { "message": "سماوي", "description": "Color option: cyan." },
+  "ruleModalColorOrange": { "message": "برتقالي", "description": "Color option: orange." },
+  "ruleModalColorGrey": { "message": "رمادي", "description": "Color option: grey." },
+  "ruleModalEnabledLabel": {
+    "message": "مُفعَّلة",
+    "description": "Checkbox: whether the rule is enabled."
+  },
+  "ruleModalSave": {
+    "message": "حفظ القاعدة",
+    "description": "Submit button for the rule form."
+  },
+  "ruleModalUpdate": {
+    "message": "تحديث القاعدة",
+    "description": "Submit button when editing an existing rule."
+  },
+  "ruleModalCancel": {
+    "message": "إلغاء",
+    "description": "Cancel button for the rule form."
+  },
+  "ruleModalConflictTitle": {
+    "message": "تم اكتشاف تعارضات في الأنماط",
+    "description": "Heading of the conflict warning box."
+  },
+  "ruleModalConflictSubtitle": {
+    "message": "تتداخل هذه الأنماط مع قواعد موجودة. ستُخصَّص علامات التبويب التي تطابق القاعدتين لواحدة فقط.",
+    "description": "Subtitle of the conflict warning."
+  },
+  "ruleModalAiSuggestions": {
+    "message": "اقتراحات الذكاء الاصطناعي",
+    "description": "Heading for the AI-generated resolution suggestions."
+  },
+  "ruleModalSaveAnyway": {
+    "message": "احفظ على أي حال",
+    "description": "Button that saves the rule despite conflicts."
+  },
+  "ruleModalGoBack": {
+    "message": "رجوع",
+    "description": "Button that returns to editing after a conflict warning."
+  },
+  "ruleModalChecking": {
+    "message": "جارٍ التحقق...",
+    "description": "Label shown on the save button while checking for conflicts."
+  },
+  "ruleModalGenerating": {
+    "message": "جارٍ الإنشاء...",
+    "description": "Label shown on the AI generate button while generating a rule."
+  },
+  "ruleModalAiThinking": {
+    "message": "الذكاء الاصطناعي يفكر...",
+    "description": "Status text while the AI generates a rule."
+  },
+  "ruleModalAiNeedsModel": {
+    "message": "حمّل نموذج ذكاء اصطناعي من قسم ميزات الذكاء الاصطناعي في النافذة المنبثقة لاستخدام المساعدة بالذكاء الاصطناعي",
+    "description": "Status shown when AI Assist is invoked but no model is loaded."
+  },
+  "ruleModalAiGenerated": {
+    "message": "تم إنشاء القاعدة! راجعها وعدّلها أدناه ثم احفظ.",
+    "description": "Status after the AI generates a rule."
+  },
+  "ruleModalAiGenerateError": {
+    "message": "فشل إنشاء القاعدة. حاول إعادة صياغة وصفك.",
+    "description": "Error shown when AI rule generation fails."
+  },
+  "ruleModalAiEnterDescription": {
+    "message": "يرجى إدخال وصف",
+    "description": "Error shown when AI Assist is triggered with no description."
+  },
+  "ruleModalEnterPattern": {
+    "message": "يرجى إدخال نمط رابط واحد على الأقل",
+    "description": "Alert shown when submitting with no patterns."
+  },
+  "ruleModalEnterName": {
+    "message": "يرجى إدخال اسم للقاعدة",
+    "description": "Alert shown when submitting a rule with no name."
+  },
+  "ruleModalFailedToLoad": {
+    "message": "فشل تحميل القاعدة للتحرير",
+    "description": "Alert when the rule modal can't load the rule."
+  },
+  "ruleModalFailedToSave": {
+    "message": "فشل حفظ القاعدة",
+    "description": "Alert when saving a rule fails."
+  },
+
+  "importPageTitle": {
+    "message": "استيراد القواعد",
+    "description": "Title for the import rules page."
+  },
+  "importDropInstruction": {
+    "message": "اسحب ملف JSON وأفلته هنا",
+    "description": "Instruction shown in the import drop zone."
+  },
+  "importOr": {
+    "message": "أو",
+    "description": "Separator between drag-drop and button."
+  },
+  "importBrowseFiles": {
+    "message": "تصفُّح الملفات",
+    "description": "Button that opens the file picker."
+  },
+  "importPreviewHeading": {
+    "message": "معاينة",
+    "description": "Heading above the import preview."
+  },
+  "importModeLabel": {
+    "message": "وضع الاستيراد",
+    "description": "Label above the import mode radio buttons."
+  },
+  "importMerge": {
+    "message": "دمج مع القواعد الموجودة",
+    "description": "Radio option: merge on import."
+  },
+  "importReplace": {
+    "message": "استبدال جميع القواعد الموجودة",
+    "description": "Radio option: replace on import."
+  },
+  "importButton": {
+    "message": "استيراد القواعد",
+    "description": "Button that performs the import."
+  },
+  "importCancel": {
+    "message": "إلغاء",
+    "description": "Cancel button on the import page."
+  },
+  "importStatValid": {
+    "message": "قواعد صالحة",
+    "description": "Label for the valid rule count in the import preview."
+  },
+  "importStatInvalid": {
+    "message": "غير صالحة (سيتم تخطيها)",
+    "description": "Label for the invalid rule count in the import preview."
+  },
+  "importPatternsSuffix": {
+    "message": "$count$ أنماط",
+    "description": "Label showing pattern count for an imported rule.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importMoreRules": {
+    "message": "...و $count$ قواعد أخرى",
+    "description": "Shown when more rules exist beyond the preview slice.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importUnnamed": {
+    "message": "بلا اسم",
+    "description": "Placeholder name for rules with no name."
+  },
+  "importImporting": {
+    "message": "جارٍ الاستيراد...",
+    "description": "Label on the import button while importing."
+  },
+  "importSuccess": {
+    "message": "تم استيراد $count$ قواعد بنجاح",
+    "description": "Success message after import.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importSuccessWithSkipped": {
+    "message": "تم استيراد $count$ قواعد بنجاح (تم تخطي $skipped$)",
+    "description": "Success message when some rules are skipped.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "skipped": { "content": "$2" }
+    }
+  },
+  "importFailed": {
+    "message": "فشل الاستيراد",
+    "description": "Generic import failure message."
+  },
+  "importInvalidJson": {
+    "message": "JSON غير صالح",
+    "description": "Error when file is not valid JSON."
+  },
+  "importInvalidFormat": {
+    "message": "تنسيق الملف غير صالح: خاصية «rules» مفقودة",
+    "description": "Error when file has no 'rules' key."
+  },
+  "importNoRules": {
+    "message": "لم يتم العثور على قواعد في الملف",
+    "description": "Error when file has no rules."
+  },
+  "importSelectJson": {
+    "message": "يرجى اختيار ملف JSON",
+    "description": "Error when a non-JSON file is selected."
+  }
+}

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1,0 +1,728 @@
+{
+  "extensionName": {
+    "message": "Auto Tab Groups",
+    "description": "The name of the extension as it appears in the browser store and toolbar."
+  },
+  "extensionDescription": {
+    "message": "Automatically groups tabs by domain.",
+    "description": "Short description shown in the extensions list."
+  },
+
+  "popupTitle": {
+    "message": "Auto Tab Groups",
+    "description": "Heading shown at the top of the popup/sidebar."
+  },
+  "popupGroupTabs": {
+    "message": "Group Tabs",
+    "description": "Button that groups all open tabs immediately."
+  },
+  "popupUngroupAll": {
+    "message": "Ungroup All",
+    "description": "Button that removes every tab group."
+  },
+  "popupGenerateNewColors": {
+    "message": "Generate New Colors",
+    "description": "Button that randomizes the colors of all groups."
+  },
+  "popupGenerateNewColorsTitle": {
+    "message": "Randomize group colors. Colors are saved and restored automatically for each domain/rule.",
+    "description": "Tooltip for the Generate New Colors button."
+  },
+  "popupCollapseAll": {
+    "message": "Collapse All",
+    "description": "Button that collapses every group."
+  },
+  "popupExpandAll": {
+    "message": "Expand All",
+    "description": "Button that expands every group."
+  },
+
+  "settingsHeading": {
+    "message": "Settings",
+    "description": "Heading for the main settings section."
+  },
+  "settingAutoGroupMode": {
+    "message": "Auto-Group Mode",
+    "description": "Label for the toggle that enables automatic grouping."
+  },
+  "settingGroupBy": {
+    "message": "Group by",
+    "description": "Label for the group-by mode selector."
+  },
+  "settingGroupByRulesOnly": {
+    "message": "Rules only",
+    "description": "Option that groups only by custom rules."
+  },
+  "settingGroupByRulesAndDomain": {
+    "message": "Rules & Domain",
+    "description": "Option that groups by rules plus base domain (popup)."
+  },
+  "settingGroupByRulesAndSubdomain": {
+    "message": "Rules & Sub-domain",
+    "description": "Option that groups by rules plus subdomain (popup)."
+  },
+  "settingGroupByDomain": {
+    "message": "Domain",
+    "description": "Option that groups by base domain (sidebar)."
+  },
+  "settingGroupBySubdomain": {
+    "message": "Sub-domain",
+    "description": "Option that groups by subdomain (sidebar)."
+  },
+  "settingGroupNewEmptyTabs": {
+    "message": "Group new empty tabs under \"System\"",
+    "description": "Label for the toggle that groups blank/new tabs under a System group."
+  },
+  "settingMinimumTabsForGroup": {
+    "message": "Minimum tabs to form a group",
+    "description": "Label for the numeric input that sets the minimum tab count required to create a group."
+  },
+  "settingAutoCollapseInactive": {
+    "message": "Auto-collapse inactive groups",
+    "description": "Label for the toggle that auto-collapses groups the user isn't looking at."
+  },
+  "settingCollapseDelay": {
+    "message": "Collapse delay",
+    "description": "Label for the numeric input that sets the auto-collapse delay."
+  },
+  "settingCollapseDelayHelp": {
+    "message": "0 = immediate, or set delay (100-5000ms) before collapsing",
+    "description": "Help text under the collapse-delay input."
+  },
+  "settingOpenNewTabsNextToCurrent": {
+    "message": "Open new tabs next to current tab",
+    "description": "Label for the toggle that opens new tabs adjacent to the active tab."
+  },
+  "settingPinnedTabsNote": {
+    "message": "Pinned tabs are never grouped automatically",
+    "description": "Informational note about pinned tabs."
+  },
+
+  "sortingSectionTitle": {
+    "message": "Sorting",
+    "description": "Title for the collapsible sorting section."
+  },
+  "settingSortGroupsAlphabetically": {
+    "message": "Keep groups sorted A-Z",
+    "description": "Toggle that keeps tab groups sorted alphabetically."
+  },
+  "settingNumberGroups": {
+    "message": "Number groups (1. AI, 2. Docs...)",
+    "description": "Toggle that prefixes group titles with their sort index."
+  },
+  "settingNumberGroupsHelp": {
+    "message": "Adds position numbers to group titles for quick reference",
+    "description": "Help text describing the Number Groups toggle."
+  },
+
+  "aiSectionTitle": {
+    "message": "AI Features",
+    "description": "Title for the AI features section."
+  },
+  "aiExperimentalBadge": {
+    "message": "Experimental",
+    "description": "Badge shown next to the AI Features title."
+  },
+  "aiHelpTooltip": {
+    "message": "AI-powered tab grouping suggestions. This feature is experimental. All processing runs locally in your browser — no data is sent to external servers.",
+    "description": "Tooltip explaining the AI Features."
+  },
+  "aiBadgeOn": {
+    "message": "On",
+    "description": "Status badge shown when AI is enabled."
+  },
+  "aiBadgeOff": {
+    "message": "Off",
+    "description": "Status badge shown when AI is disabled."
+  },
+  "aiEnable": {
+    "message": "Enable AI",
+    "description": "Toggle that enables or disables AI features."
+  },
+  "aiModelLabel": {
+    "message": "Model",
+    "description": "Label for the AI model selector."
+  },
+  "aiStatusLabel": {
+    "message": "Status:",
+    "description": "Label for the AI model status."
+  },
+  "aiStatusIdle": {
+    "message": "Idle",
+    "description": "AI model status: idle."
+  },
+  "aiStatusReady": {
+    "message": "Ready",
+    "description": "AI model status: ready."
+  },
+  "aiStatusLoading": {
+    "message": "Loading $progress$%",
+    "description": "AI model status while loading, with a progress percentage.",
+    "placeholders": {
+      "progress": { "content": "$1", "example": "42" }
+    }
+  },
+  "aiStatusError": {
+    "message": "Error",
+    "description": "AI model status: error."
+  },
+  "aiLoadModel": {
+    "message": "Load Model",
+    "description": "Button that starts loading the AI model."
+  },
+  "aiUnloadModel": {
+    "message": "Unload Model",
+    "description": "Button that unloads the AI model."
+  },
+  "aiLoadingButton": {
+    "message": "Loading...",
+    "description": "Label shown on the load button while loading."
+  },
+  "aiRetryLoad": {
+    "message": "Retry Load",
+    "description": "Button shown after an AI model load error."
+  },
+  "aiWebGpuUnavailable": {
+    "message": "WebGPU is not available. AI features require a browser with WebGPU support.",
+    "description": "Warning shown when WebGPU is not supported."
+  },
+  "aiDownloadNote": {
+    "message": "Models run locally in your browser. First load downloads the model (~250MB-900MB).",
+    "description": "Help text beneath the load model button."
+  },
+  "aiSuggestGroups": {
+    "message": "Suggest Groups",
+    "description": "Button that asks the AI to suggest tab groups."
+  },
+  "aiAnalyzing": {
+    "message": "Analyzing your tabs...",
+    "description": "Status text while the AI analyzes open tabs."
+  },
+  "aiNoSuggestions": {
+    "message": "No suggestions found",
+    "description": "Status text shown when the AI returns zero suggestions."
+  },
+  "aiFailedToGetSuggestions": {
+    "message": "Failed to get suggestions",
+    "description": "Error shown when AI suggestion fails."
+  },
+  "aiDismiss": {
+    "message": "Dismiss",
+    "description": "Button that dismisses AI suggestions."
+  },
+  "aiApply": {
+    "message": "Apply",
+    "description": "Button that applies an AI suggestion."
+  },
+  "aiApplying": {
+    "message": "Applying...",
+    "description": "Button label while applying a suggestion."
+  },
+  "aiApplied": {
+    "message": "Applied!",
+    "description": "Button label after applying a suggestion."
+  },
+  "aiFailed": {
+    "message": "Failed",
+    "description": "Button label after a suggestion fails."
+  },
+  "aiCreateRule": {
+    "message": "Create Rule",
+    "description": "Button that creates a rule from a suggestion."
+  },
+  "aiTabsCount": {
+    "message": "$count$ tab$plural$",
+    "description": "Tab count label for a suggestion.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "plural": { "content": "$2" }
+    }
+  },
+  "aiAppliedWithStale": {
+    "message": "Applied ($count$ tab$plural$ closed)",
+    "description": "Shown when a suggestion is applied but some tabs were closed.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "plural": { "content": "$2" }
+    }
+  },
+  "aiFirefoxNotice": {
+    "message": "AI features are currently available on Chrome only. Firefox support is coming soon.",
+    "description": "Notice shown to Firefox users."
+  },
+
+  "rulesSectionTitle": {
+    "message": "Custom Rules",
+    "description": "Title for the custom rules section."
+  },
+  "rulesAddNewRule": {
+    "message": "Add New Rule",
+    "description": "Button that opens the new rule dialog."
+  },
+  "rulesExport": {
+    "message": "Export",
+    "description": "Button that exports rules to JSON."
+  },
+  "rulesImport": {
+    "message": "Import",
+    "description": "Button that imports rules from JSON."
+  },
+  "rulesExportTitle": {
+    "message": "Export all rules to JSON file",
+    "description": "Tooltip on the Export button."
+  },
+  "rulesImportTitle": {
+    "message": "Import rules from JSON file",
+    "description": "Tooltip on the Import button."
+  },
+  "rulesExportImportHelp": {
+    "message": "Export/import rules as JSON files for backup or sharing",
+    "description": "Help text under the export/import buttons."
+  },
+  "rulesEmptyState": {
+    "message": "No custom rules yet. Create your first rule to group tabs by your preferences!",
+    "description": "Shown when there are no custom rules."
+  },
+  "rulesEdit": {
+    "message": "Edit",
+    "description": "Edit button on a rule row."
+  },
+  "rulesDelete": {
+    "message": "Delete",
+    "description": "Delete button on a rule row."
+  },
+  "rulesEditTitle": {
+    "message": "Edit rule",
+    "description": "Tooltip for the edit button."
+  },
+  "rulesDeleteTitle": {
+    "message": "Delete rule",
+    "description": "Tooltip for the delete button."
+  },
+  "rulesAddTabTitle": {
+    "message": "Add Tab to Existing Rule",
+    "description": "Tooltip for the + button that adds the current tab to a rule."
+  },
+  "rulesDeleteConfirm": {
+    "message": "Are you sure you want to delete the rule \"$name$\"?",
+    "description": "Confirmation prompt before deleting a rule.",
+    "placeholders": {
+      "name": { "content": "$1" }
+    }
+  },
+  "rulesFailedToLoad": {
+    "message": "Failed to load custom rules",
+    "description": "Error when loading rules fails."
+  },
+  "rulesFailedToDelete": {
+    "message": "Failed to delete rule",
+    "description": "Error when deleting a rule fails."
+  },
+  "rulesExportSuccess": {
+    "message": "Rules exported successfully!",
+    "description": "Confirmation after exporting rules."
+  },
+  "rulesFailedToExport": {
+    "message": "Failed to export rules",
+    "description": "Error when export fails."
+  },
+  "rulesImportSuccess": {
+    "message": "Rules imported successfully!",
+    "description": "Confirmation after importing rules."
+  },
+  "rulesImportSummary": {
+    "message": "Import successful!\nImported: $imported$ rules\nSkipped: $skipped$ rules",
+    "description": "Summary shown after rules are imported.",
+    "placeholders": {
+      "imported": { "content": "$1" },
+      "skipped": { "content": "$2" }
+    }
+  },
+  "rulesFailedToImport": {
+    "message": "Failed to import rules",
+    "description": "Error when import fails."
+  },
+  "rulesImportReplacePrompt": {
+    "message": "Do you want to replace all existing rules?\n\nClick OK to REPLACE all existing rules with imported ones\nClick Cancel to MERGE imported rules with existing ones",
+    "description": "Prompt that asks whether to merge or replace on import."
+  },
+  "rulesNoExport": {
+    "message": "No rules to export",
+    "description": "Tooltip shown on a disabled export button when there are no rules."
+  },
+  "rulesNoDomains": {
+    "message": "No domains",
+    "description": "Shown when a rule has no configured domains."
+  },
+  "rulesDomainsSeparator": {
+    "message": " and $count$ more",
+    "description": "Appended to truncated domain lists.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "rulesAddTabNoTab": {
+    "message": "No active tab found",
+    "description": "Tooltip shown on the add-tab button when no active tab is available."
+  },
+  "rulesAddTabCantExtract": {
+    "message": "Cannot extract domain from this tab",
+    "description": "Tooltip when the current tab's URL has no domain."
+  },
+  "rulesAddTabAlreadyExists": {
+    "message": "Domain already in this rule",
+    "description": "Tooltip when the tab's domain is already part of the rule."
+  },
+  "rulesAddTabAdded": {
+    "message": "Added!",
+    "description": "Tooltip shown briefly after adding a tab to a rule."
+  },
+  "rulesAddTabFailed": {
+    "message": "Failed to add domain",
+    "description": "Tooltip when adding a domain fails."
+  },
+
+  "blacklistSectionTitle": {
+    "message": "Blacklist",
+    "description": "Title for the blacklist section."
+  },
+  "blacklistAddButton": {
+    "message": "Add to Blacklist",
+    "description": "Button to add a domain to the blacklist."
+  },
+  "blacklistHelp": {
+    "message": "Blacklisted domains will never be grouped",
+    "description": "Help text under the blacklist section."
+  },
+  "blacklistEmpty": {
+    "message": "No blacklisted domains yet.",
+    "description": "Shown when the blacklist is empty."
+  },
+  "blacklistEditTitle": {
+    "message": "Edit blacklist rule",
+    "description": "Tooltip for the blacklist edit button."
+  },
+  "blacklistDeleteTitle": {
+    "message": "Delete blacklist rule",
+    "description": "Tooltip for the blacklist delete button."
+  },
+
+  "advancedSectionTitle": {
+    "message": "Advanced",
+    "description": "Title for the advanced settings section."
+  },
+  "advancedHideContextMenu": {
+    "message": "Hide right-click context menu",
+    "description": "Toggle that hides the extension's context menu items."
+  },
+  "advancedHideContextMenuHelp": {
+    "message": "When enabled, Auto Tab Groups will not add its items to the page right-click menu.",
+    "description": "Help text for the hide context menu toggle."
+  },
+
+  "footerMadeBy": {
+    "message": "Made by",
+    "description": "Prefix for the author attribution in the footer."
+  },
+  "footerFor": {
+    "message": "for",
+    "description": "Connector text: 'Made by X, for Chrome'."
+  },
+  "footerBrowserChrome": {
+    "message": "Chrome",
+    "description": "Name of the Chrome browser in the footer."
+  },
+  "footerBrowserFirefox": {
+    "message": "Firefox",
+    "description": "Name of the Firefox browser in the footer."
+  },
+  "footerFeedback": {
+    "message": "Feedback & Requests & Support",
+    "description": "Text of the feedback link."
+  },
+  "footerVersion": {
+    "message": "Version:",
+    "description": "Prefix before the version number."
+  },
+
+  "contextMenuCreateRuleFromGroup": {
+    "message": "Create Rule from Group",
+    "description": "Right-click menu: create a custom rule from the clicked tab's group."
+  },
+  "contextMenuAddTabToExistingRule": {
+    "message": "Add Tab to Existing Rule",
+    "description": "Right-click menu: submenu to add the current tab's domain to an existing rule."
+  },
+  "contextMenuAddToBlacklist": {
+    "message": "Add to Blacklist",
+    "description": "Right-click menu: add the current tab's domain to the blacklist."
+  },
+  "contextMenuNoRulesYet": {
+    "message": "No rules yet",
+    "description": "Disabled placeholder shown when the Add Tab submenu has no rules."
+  },
+
+  "ruleModalCreateTitle": {
+    "message": "Create Custom Rule",
+    "description": "Title shown when creating a new rule."
+  },
+  "ruleModalEditTitle": {
+    "message": "Edit Custom Rule",
+    "description": "Title shown when editing an existing rule."
+  },
+  "ruleModalNameLabel": {
+    "message": "Rule Name",
+    "description": "Label for the rule name input."
+  },
+  "ruleModalNamePlaceholder": {
+    "message": "e.g., Work Apps",
+    "description": "Placeholder for the rule name input."
+  },
+  "ruleModalNameHelp": {
+    "message": "Supports any language including Chinese, Japanese, Korean, and emojis",
+    "description": "Help text under the rule name input."
+  },
+  "ruleModalAiAssistLabel": {
+    "message": "AI Assist",
+    "description": "Label for the AI assist section."
+  },
+  "ruleModalAiAssistPlaceholder": {
+    "message": "Describe your rule, e.g., 'Group all Google services' or 'Group AWS console tabs'",
+    "description": "Placeholder for the AI assist input."
+  },
+  "ruleModalAiGenerate": {
+    "message": "Generate",
+    "description": "Button that asks the AI to generate a rule."
+  },
+  "ruleModalAiAssistHelp": {
+    "message": "Describe what you want to group and AI will suggest name, domains, and color",
+    "description": "Help text under the AI assist input."
+  },
+  "ruleModalPatternModeLabel": {
+    "message": "Pattern Mode",
+    "description": "Label for the pattern mode toggle."
+  },
+  "ruleModalPatternModeSimple": {
+    "message": "Simple (domains)",
+    "description": "Simple pattern mode: matches whole domains."
+  },
+  "ruleModalPatternModeExplicit": {
+    "message": "Explicit (full URLs)",
+    "description": "Explicit pattern mode: matches full URLs."
+  },
+  "ruleModalSimpleModeHint": {
+    "message": "Groups all pages from these base domains",
+    "description": "Hint shown in simple pattern mode."
+  },
+  "ruleModalExplicitModeHint": {
+    "message": "Groups only pages matching these full URL patterns",
+    "description": "Hint shown in explicit pattern mode."
+  },
+  "ruleModalPatternsLabel": {
+    "message": "URL Patterns (one per line)",
+    "description": "Label for the patterns textarea."
+  },
+  "ruleModalPatternsHelp": {
+    "message": "Supports: domains, wildcards (*.example.com), paths (example.com/api/*), IP addresses",
+    "description": "Help text for the patterns textarea."
+  },
+  "ruleModalColorLabel": {
+    "message": "Group Color",
+    "description": "Label for the color picker."
+  },
+  "ruleModalColorBlue": { "message": "Blue", "description": "Color option: blue." },
+  "ruleModalColorRed": { "message": "Red", "description": "Color option: red." },
+  "ruleModalColorYellow": { "message": "Yellow", "description": "Color option: yellow." },
+  "ruleModalColorGreen": { "message": "Green", "description": "Color option: green." },
+  "ruleModalColorPink": { "message": "Pink", "description": "Color option: pink." },
+  "ruleModalColorPurple": { "message": "Purple", "description": "Color option: purple." },
+  "ruleModalColorCyan": { "message": "Cyan", "description": "Color option: cyan." },
+  "ruleModalColorOrange": { "message": "Orange", "description": "Color option: orange." },
+  "ruleModalColorGrey": { "message": "Grey", "description": "Color option: grey." },
+  "ruleModalEnabledLabel": {
+    "message": "Enabled",
+    "description": "Checkbox: whether the rule is enabled."
+  },
+  "ruleModalSave": {
+    "message": "Save Rule",
+    "description": "Submit button for the rule form."
+  },
+  "ruleModalUpdate": {
+    "message": "Update Rule",
+    "description": "Submit button when editing an existing rule."
+  },
+  "ruleModalCancel": {
+    "message": "Cancel",
+    "description": "Cancel button for the rule form."
+  },
+  "ruleModalConflictTitle": {
+    "message": "Pattern Conflicts Detected",
+    "description": "Heading of the conflict warning box."
+  },
+  "ruleModalConflictSubtitle": {
+    "message": "These patterns overlap with existing rules. Tabs matching both rules will only be assigned to one.",
+    "description": "Subtitle of the conflict warning."
+  },
+  "ruleModalAiSuggestions": {
+    "message": "AI Suggestions",
+    "description": "Heading for the AI-generated resolution suggestions."
+  },
+  "ruleModalSaveAnyway": {
+    "message": "Save Anyway",
+    "description": "Button that saves the rule despite conflicts."
+  },
+  "ruleModalGoBack": {
+    "message": "Go Back",
+    "description": "Button that returns to editing after a conflict warning."
+  },
+  "ruleModalChecking": {
+    "message": "Checking...",
+    "description": "Label shown on the save button while checking for conflicts."
+  },
+  "ruleModalGenerating": {
+    "message": "Generating...",
+    "description": "Label shown on the AI generate button while generating a rule."
+  },
+  "ruleModalAiThinking": {
+    "message": "AI is thinking...",
+    "description": "Status text while the AI generates a rule."
+  },
+  "ruleModalAiNeedsModel": {
+    "message": "Load an AI model from the popup's AI Features section to use AI Assist",
+    "description": "Status shown when AI Assist is invoked but no model is loaded."
+  },
+  "ruleModalAiGenerated": {
+    "message": "Rule generated! Review and edit below, then save.",
+    "description": "Status after the AI generates a rule."
+  },
+  "ruleModalAiGenerateError": {
+    "message": "Failed to generate rule. Try rephrasing your description.",
+    "description": "Error shown when AI rule generation fails."
+  },
+  "ruleModalAiEnterDescription": {
+    "message": "Please enter a description",
+    "description": "Error shown when AI Assist is triggered with no description."
+  },
+  "ruleModalEnterPattern": {
+    "message": "Please enter at least one URL pattern",
+    "description": "Alert shown when submitting with no patterns."
+  },
+  "ruleModalEnterName": {
+    "message": "Please enter a rule name",
+    "description": "Alert shown when submitting a rule with no name."
+  },
+  "ruleModalFailedToLoad": {
+    "message": "Failed to load rule for editing",
+    "description": "Alert when the rule modal can't load the rule."
+  },
+  "ruleModalFailedToSave": {
+    "message": "Failed to save rule",
+    "description": "Alert when saving a rule fails."
+  },
+
+  "importPageTitle": {
+    "message": "Import Rules",
+    "description": "Title for the import rules page."
+  },
+  "importDropInstruction": {
+    "message": "Drag & drop a JSON file here",
+    "description": "Instruction shown in the import drop zone."
+  },
+  "importOr": {
+    "message": "or",
+    "description": "Separator between drag-drop and button."
+  },
+  "importBrowseFiles": {
+    "message": "Browse Files",
+    "description": "Button that opens the file picker."
+  },
+  "importPreviewHeading": {
+    "message": "Preview",
+    "description": "Heading above the import preview."
+  },
+  "importModeLabel": {
+    "message": "Import Mode",
+    "description": "Label above the import mode radio buttons."
+  },
+  "importMerge": {
+    "message": "Merge with existing rules",
+    "description": "Radio option: merge on import."
+  },
+  "importReplace": {
+    "message": "Replace all existing rules",
+    "description": "Radio option: replace on import."
+  },
+  "importButton": {
+    "message": "Import Rules",
+    "description": "Button that performs the import."
+  },
+  "importCancel": {
+    "message": "Cancel",
+    "description": "Cancel button on the import page."
+  },
+  "importStatValid": {
+    "message": "Valid Rules",
+    "description": "Label for the valid rule count in the import preview."
+  },
+  "importStatInvalid": {
+    "message": "Invalid (will be skipped)",
+    "description": "Label for the invalid rule count in the import preview."
+  },
+  "importPatternsSuffix": {
+    "message": "$count$ patterns",
+    "description": "Label showing pattern count for an imported rule.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importMoreRules": {
+    "message": "...and $count$ more rules",
+    "description": "Shown when more rules exist beyond the preview slice.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importUnnamed": {
+    "message": "Unnamed",
+    "description": "Placeholder name for rules with no name."
+  },
+  "importImporting": {
+    "message": "Importing...",
+    "description": "Label on the import button while importing."
+  },
+  "importSuccess": {
+    "message": "Successfully imported $count$ rules",
+    "description": "Success message after import.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importSuccessWithSkipped": {
+    "message": "Successfully imported $count$ rules ($skipped$ skipped)",
+    "description": "Success message when some rules are skipped.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "skipped": { "content": "$2" }
+    }
+  },
+  "importFailed": {
+    "message": "Import failed",
+    "description": "Generic import failure message."
+  },
+  "importInvalidJson": {
+    "message": "Invalid JSON",
+    "description": "Error when file is not valid JSON."
+  },
+  "importInvalidFormat": {
+    "message": "Invalid file format: Missing 'rules' property",
+    "description": "Error when file has no 'rules' key."
+  },
+  "importNoRules": {
+    "message": "No rules found in file",
+    "description": "Error when file has no rules."
+  },
+  "importSelectJson": {
+    "message": "Please select a JSON file",
+    "description": "Error when a non-JSON file is selected."
+  }
+}

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -1,0 +1,748 @@
+{
+  "extensionName": {
+    "message": "Auto Tab Groups",
+    "description": "The name of the extension as it appears in the browser store and toolbar."
+  },
+  "extensionDescription": {
+    "message": "Agrupa automáticamente las pestañas por dominio.",
+    "description": "Short description shown in the extensions list."
+  },
+
+  "popupTitle": {
+    "message": "Auto Tab Groups",
+    "description": "Heading shown at the top of the popup/sidebar."
+  },
+  "popupGroupTabs": {
+    "message": "Agrupar pestañas",
+    "description": "Button that groups all open tabs immediately."
+  },
+  "popupUngroupAll": {
+    "message": "Desagrupar todo",
+    "description": "Button that removes every tab group."
+  },
+  "popupGenerateNewColors": {
+    "message": "Generar nuevos colores",
+    "description": "Button that randomizes the colors of all groups."
+  },
+  "popupGenerateNewColorsTitle": {
+    "message": "Aleatoriza los colores de los grupos. Los colores se guardan y restauran automáticamente para cada dominio o regla.",
+    "description": "Tooltip for the Generate New Colors button."
+  },
+  "popupCollapseAll": {
+    "message": "Contraer todo",
+    "description": "Button that collapses every group."
+  },
+  "popupExpandAll": {
+    "message": "Expandir todo",
+    "description": "Button that expands every group."
+  },
+
+  "settingsHeading": {
+    "message": "Ajustes",
+    "description": "Heading for the main settings section."
+  },
+  "settingLanguage": {
+    "message": "Idioma",
+    "description": "Label for the UI language picker."
+  },
+  "settingLanguageAuto": {
+    "message": "Automático (predeterminado del navegador)",
+    "description": "Picker option that defers to the browser's UI language."
+  },
+  "settingAutoGroupMode": {
+    "message": "Modo de agrupación automática",
+    "description": "Label for the toggle that enables automatic grouping."
+  },
+  "settingGroupBy": {
+    "message": "Agrupar por",
+    "description": "Label for the group-by mode selector."
+  },
+  "settingGroupByRulesOnly": {
+    "message": "Solo reglas",
+    "description": "Option that groups only by custom rules."
+  },
+  "settingGroupByRulesAndDomain": {
+    "message": "Reglas y dominio",
+    "description": "Option that groups by rules plus base domain (popup)."
+  },
+  "settingGroupByRulesAndSubdomain": {
+    "message": "Reglas y subdominio",
+    "description": "Option that groups by rules plus subdomain (popup)."
+  },
+  "settingGroupByDomain": {
+    "message": "Dominio",
+    "description": "Option that groups by base domain (sidebar)."
+  },
+  "settingGroupBySubdomain": {
+    "message": "Subdominio",
+    "description": "Option that groups by subdomain (sidebar)."
+  },
+  "settingGroupNewEmptyTabs": {
+    "message": "Agrupar nuevas pestañas vacías en «System»",
+    "description": "Label for the toggle that groups blank/new tabs under a System group."
+  },
+  "settingMinimumTabsForGroup": {
+    "message": "Mínimo de pestañas para formar un grupo",
+    "description": "Label for the numeric input that sets the minimum tab count required to create a group."
+  },
+  "settingAutoCollapseInactive": {
+    "message": "Contraer automáticamente los grupos inactivos",
+    "description": "Label for the toggle that auto-collapses groups the user isn't looking at."
+  },
+  "settingCollapseDelay": {
+    "message": "Retardo al contraer",
+    "description": "Label for the numeric input that sets the auto-collapse delay."
+  },
+  "settingCollapseDelayHelp": {
+    "message": "0 = inmediato, o establece el retardo (100-5000 ms) antes de contraer",
+    "description": "Help text under the collapse-delay input."
+  },
+  "settingOpenNewTabsNextToCurrent": {
+    "message": "Abrir pestañas nuevas junto a la pestaña actual",
+    "description": "Label for the toggle that opens new tabs adjacent to the active tab."
+  },
+  "settingPinnedTabsNote": {
+    "message": "Las pestañas ancladas nunca se agrupan automáticamente",
+    "description": "Informational note about pinned tabs."
+  },
+
+  "sortingSectionTitle": {
+    "message": "Ordenación",
+    "description": "Title for the collapsible sorting section."
+  },
+  "settingSortGroupsAlphabetically": {
+    "message": "Mantener los grupos ordenados alfabéticamente",
+    "description": "Toggle that keeps tab groups sorted alphabetically."
+  },
+  "settingSortDirection": {
+    "message": "Dirección",
+    "description": "Label for the sort direction toggle (A-Z vs Z-A)."
+  },
+  "settingSortDirectionAsc": {
+    "message": "A - Z",
+    "description": "Ascending alphabetical sort direction option."
+  },
+  "settingSortDirectionDesc": {
+    "message": "Z - A",
+    "description": "Descending alphabetical sort direction option."
+  },
+  "settingNumberGroups": {
+    "message": "Numerar grupos (1. AI, 2. Docs...)",
+    "description": "Toggle that prefixes group titles with their sort index."
+  },
+  "settingNumberGroupsHelp": {
+    "message": "Añade números de posición a los títulos de los grupos para una referencia rápida",
+    "description": "Help text describing the Number Groups toggle."
+  },
+
+  "aiSectionTitle": {
+    "message": "Funciones de IA",
+    "description": "Title for the AI features section."
+  },
+  "aiExperimentalBadge": {
+    "message": "Experimental",
+    "description": "Badge shown next to the AI Features title."
+  },
+  "aiHelpTooltip": {
+    "message": "Sugerencias de agrupación de pestañas con IA. Esta función es experimental. Todo el procesamiento se ejecuta localmente en tu navegador: no se envían datos a servidores externos.",
+    "description": "Tooltip explaining the AI Features."
+  },
+  "aiBadgeOn": {
+    "message": "Activado",
+    "description": "Status badge shown when AI is enabled."
+  },
+  "aiBadgeOff": {
+    "message": "Desactivado",
+    "description": "Status badge shown when AI is disabled."
+  },
+  "aiEnable": {
+    "message": "Activar IA",
+    "description": "Toggle that enables or disables AI features."
+  },
+  "aiModelLabel": {
+    "message": "Modelo",
+    "description": "Label for the AI model selector."
+  },
+  "aiStatusLabel": {
+    "message": "Estado:",
+    "description": "Label for the AI model status."
+  },
+  "aiStatusIdle": {
+    "message": "Inactivo",
+    "description": "AI model status: idle."
+  },
+  "aiStatusReady": {
+    "message": "Listo",
+    "description": "AI model status: ready."
+  },
+  "aiStatusLoading": {
+    "message": "Cargando $progress$%",
+    "description": "AI model status while loading, with a progress percentage.",
+    "placeholders": {
+      "progress": { "content": "$1", "example": "42" }
+    }
+  },
+  "aiStatusError": {
+    "message": "Error",
+    "description": "AI model status: error."
+  },
+  "aiLoadModel": {
+    "message": "Cargar modelo",
+    "description": "Button that starts loading the AI model."
+  },
+  "aiUnloadModel": {
+    "message": "Descargar modelo",
+    "description": "Button that unloads the AI model."
+  },
+  "aiLoadingButton": {
+    "message": "Cargando...",
+    "description": "Label shown on the load button while loading."
+  },
+  "aiRetryLoad": {
+    "message": "Reintentar carga",
+    "description": "Button shown after an AI model load error."
+  },
+  "aiWebGpuUnavailable": {
+    "message": "WebGPU no está disponible. Las funciones de IA requieren un navegador con soporte de WebGPU.",
+    "description": "Warning shown when WebGPU is not supported."
+  },
+  "aiDownloadNote": {
+    "message": "Los modelos se ejecutan localmente en tu navegador. La primera carga descarga el modelo (~250MB-900MB).",
+    "description": "Help text beneath the load model button."
+  },
+  "aiSuggestGroups": {
+    "message": "Sugerir grupos",
+    "description": "Button that asks the AI to suggest tab groups."
+  },
+  "aiAnalyzing": {
+    "message": "Analizando tus pestañas...",
+    "description": "Status text while the AI analyzes open tabs."
+  },
+  "aiNoSuggestions": {
+    "message": "No se encontraron sugerencias",
+    "description": "Status text shown when the AI returns zero suggestions."
+  },
+  "aiFailedToGetSuggestions": {
+    "message": "No se pudieron obtener sugerencias",
+    "description": "Error shown when AI suggestion fails."
+  },
+  "aiDismiss": {
+    "message": "Descartar",
+    "description": "Button that dismisses AI suggestions."
+  },
+  "aiApply": {
+    "message": "Aplicar",
+    "description": "Button that applies an AI suggestion."
+  },
+  "aiApplying": {
+    "message": "Aplicando...",
+    "description": "Button label while applying a suggestion."
+  },
+  "aiApplied": {
+    "message": "¡Aplicado!",
+    "description": "Button label after applying a suggestion."
+  },
+  "aiFailed": {
+    "message": "Falló",
+    "description": "Button label after a suggestion fails."
+  },
+  "aiCreateRule": {
+    "message": "Crear regla",
+    "description": "Button that creates a rule from a suggestion."
+  },
+  "aiTabsCount": {
+    "message": "$count$ pestaña$plural$",
+    "description": "Tab count label for a suggestion.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "plural": { "content": "$2" }
+    }
+  },
+  "aiAppliedWithStale": {
+    "message": "Aplicado ($count$ pestaña$plural$ cerrada)",
+    "description": "Shown when a suggestion is applied but some tabs were closed.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "plural": { "content": "$2" }
+    }
+  },
+  "aiFirefoxNotice": {
+    "message": "Las funciones de IA solo están disponibles actualmente en Chrome. El soporte para Firefox llegará pronto.",
+    "description": "Notice shown to Firefox users."
+  },
+
+  "rulesSectionTitle": {
+    "message": "Reglas personalizadas",
+    "description": "Title for the custom rules section."
+  },
+  "rulesAddNewRule": {
+    "message": "Añadir nueva regla",
+    "description": "Button that opens the new rule dialog."
+  },
+  "rulesExport": {
+    "message": "Exportar",
+    "description": "Button that exports rules to JSON."
+  },
+  "rulesImport": {
+    "message": "Importar",
+    "description": "Button that imports rules from JSON."
+  },
+  "rulesExportTitle": {
+    "message": "Exportar todas las reglas a un archivo JSON",
+    "description": "Tooltip on the Export button."
+  },
+  "rulesImportTitle": {
+    "message": "Importar reglas desde un archivo JSON",
+    "description": "Tooltip on the Import button."
+  },
+  "rulesExportImportHelp": {
+    "message": "Exporta/importa reglas como archivos JSON para respaldo o compartir",
+    "description": "Help text under the export/import buttons."
+  },
+  "rulesEmptyState": {
+    "message": "Aún no hay reglas personalizadas. ¡Crea tu primera regla para agrupar pestañas según tus preferencias!",
+    "description": "Shown when there are no custom rules."
+  },
+  "rulesEdit": {
+    "message": "Editar",
+    "description": "Edit button on a rule row."
+  },
+  "rulesDelete": {
+    "message": "Eliminar",
+    "description": "Delete button on a rule row."
+  },
+  "rulesEditTitle": {
+    "message": "Editar regla",
+    "description": "Tooltip for the edit button."
+  },
+  "rulesDeleteTitle": {
+    "message": "Eliminar regla",
+    "description": "Tooltip for the delete button."
+  },
+  "rulesAddTabTitle": {
+    "message": "Añadir pestaña a una regla existente",
+    "description": "Tooltip for the + button that adds the current tab to a rule."
+  },
+  "rulesDeleteConfirm": {
+    "message": "¿Seguro que quieres eliminar la regla «$name$»?",
+    "description": "Confirmation prompt before deleting a rule.",
+    "placeholders": {
+      "name": { "content": "$1" }
+    }
+  },
+  "rulesFailedToLoad": {
+    "message": "No se pudieron cargar las reglas personalizadas",
+    "description": "Error when loading rules fails."
+  },
+  "rulesFailedToDelete": {
+    "message": "No se pudo eliminar la regla",
+    "description": "Error when deleting a rule fails."
+  },
+  "rulesExportSuccess": {
+    "message": "¡Reglas exportadas correctamente!",
+    "description": "Confirmation after exporting rules."
+  },
+  "rulesFailedToExport": {
+    "message": "No se pudieron exportar las reglas",
+    "description": "Error when export fails."
+  },
+  "rulesImportSuccess": {
+    "message": "¡Reglas importadas correctamente!",
+    "description": "Confirmation after importing rules."
+  },
+  "rulesImportSummary": {
+    "message": "¡Importación exitosa!\nImportadas: $imported$ reglas\nOmitidas: $skipped$ reglas",
+    "description": "Summary shown after rules are imported.",
+    "placeholders": {
+      "imported": { "content": "$1" },
+      "skipped": { "content": "$2" }
+    }
+  },
+  "rulesFailedToImport": {
+    "message": "No se pudieron importar las reglas",
+    "description": "Error when import fails."
+  },
+  "rulesImportReplacePrompt": {
+    "message": "¿Quieres reemplazar todas las reglas existentes?\n\nPulsa Aceptar para REEMPLAZAR todas las reglas existentes por las importadas\nPulsa Cancelar para COMBINAR las reglas importadas con las existentes",
+    "description": "Prompt that asks whether to merge or replace on import."
+  },
+  "rulesNoExport": {
+    "message": "No hay reglas para exportar",
+    "description": "Tooltip shown on a disabled export button when there are no rules."
+  },
+  "rulesNoDomains": {
+    "message": "Sin dominios",
+    "description": "Shown when a rule has no configured domains."
+  },
+  "rulesDomainsSeparator": {
+    "message": " y $count$ más",
+    "description": "Appended to truncated domain lists.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "rulesAddTabNoTab": {
+    "message": "No se encontró ninguna pestaña activa",
+    "description": "Tooltip shown on the add-tab button when no active tab is available."
+  },
+  "rulesAddTabCantExtract": {
+    "message": "No se puede extraer el dominio de esta pestaña",
+    "description": "Tooltip when the current tab's URL has no domain."
+  },
+  "rulesAddTabAlreadyExists": {
+    "message": "El dominio ya está en esta regla",
+    "description": "Tooltip when the tab's domain is already part of the rule."
+  },
+  "rulesAddTabAdded": {
+    "message": "¡Añadido!",
+    "description": "Tooltip shown briefly after adding a tab to a rule."
+  },
+  "rulesAddTabFailed": {
+    "message": "No se pudo añadir el dominio",
+    "description": "Tooltip when adding a domain fails."
+  },
+
+  "blacklistSectionTitle": {
+    "message": "Lista negra",
+    "description": "Title for the blacklist section."
+  },
+  "blacklistAddButton": {
+    "message": "Añadir a la lista negra",
+    "description": "Button to add a domain to the blacklist."
+  },
+  "blacklistHelp": {
+    "message": "Los dominios en la lista negra nunca se agruparán",
+    "description": "Help text under the blacklist section."
+  },
+  "blacklistEmpty": {
+    "message": "Aún no hay dominios en la lista negra.",
+    "description": "Shown when the blacklist is empty."
+  },
+  "blacklistEditTitle": {
+    "message": "Editar regla de lista negra",
+    "description": "Tooltip for the blacklist edit button."
+  },
+  "blacklistDeleteTitle": {
+    "message": "Eliminar regla de lista negra",
+    "description": "Tooltip for the blacklist delete button."
+  },
+
+  "advancedSectionTitle": {
+    "message": "Avanzado",
+    "description": "Title for the advanced settings section."
+  },
+  "advancedHideContextMenu": {
+    "message": "Ocultar el menú contextual del clic derecho",
+    "description": "Toggle that hides the extension's context menu items."
+  },
+  "advancedHideContextMenuHelp": {
+    "message": "Cuando está activado, Auto Tab Groups no añadirá sus elementos al menú del clic derecho de la página.",
+    "description": "Help text for the hide context menu toggle."
+  },
+
+  "footerMadeBy": {
+    "message": "Creado por",
+    "description": "Prefix for the author attribution in the footer."
+  },
+  "footerFor": {
+    "message": "para",
+    "description": "Connector text: 'Made by X, for Chrome'."
+  },
+  "footerBrowserChrome": {
+    "message": "Chrome",
+    "description": "Name of the Chrome browser in the footer."
+  },
+  "footerBrowserFirefox": {
+    "message": "Firefox",
+    "description": "Name of the Firefox browser in the footer."
+  },
+  "footerFeedback": {
+    "message": "Comentarios, solicitudes y soporte",
+    "description": "Text of the feedback link."
+  },
+  "footerVersion": {
+    "message": "Versión:",
+    "description": "Prefix before the version number."
+  },
+
+  "contextMenuCreateRuleFromGroup": {
+    "message": "Crear regla a partir del grupo",
+    "description": "Right-click menu: create a custom rule from the clicked tab's group."
+  },
+  "contextMenuAddTabToExistingRule": {
+    "message": "Añadir pestaña a una regla existente",
+    "description": "Right-click menu: submenu to add the current tab's domain to an existing rule."
+  },
+  "contextMenuAddToBlacklist": {
+    "message": "Añadir a la lista negra",
+    "description": "Right-click menu: add the current tab's domain to the blacklist."
+  },
+  "contextMenuNoRulesYet": {
+    "message": "Aún no hay reglas",
+    "description": "Disabled placeholder shown when the Add Tab submenu has no rules."
+  },
+
+  "ruleModalCreateTitle": {
+    "message": "Crear regla personalizada",
+    "description": "Title shown when creating a new rule."
+  },
+  "ruleModalEditTitle": {
+    "message": "Editar regla personalizada",
+    "description": "Title shown when editing an existing rule."
+  },
+  "ruleModalNameLabel": {
+    "message": "Nombre de la regla",
+    "description": "Label for the rule name input."
+  },
+  "ruleModalNamePlaceholder": {
+    "message": "p. ej., Apps de trabajo",
+    "description": "Placeholder for the rule name input."
+  },
+  "ruleModalNameHelp": {
+    "message": "Admite cualquier idioma, incluidos chino, japonés, coreano y emojis",
+    "description": "Help text under the rule name input."
+  },
+  "ruleModalAiAssistLabel": {
+    "message": "Asistente de IA",
+    "description": "Label for the AI assist section."
+  },
+  "ruleModalAiAssistPlaceholder": {
+    "message": "Describe tu regla, p. ej., «Agrupa todos los servicios de Google» o «Agrupa las pestañas de la consola de AWS»",
+    "description": "Placeholder for the AI assist input."
+  },
+  "ruleModalAiGenerate": {
+    "message": "Generar",
+    "description": "Button that asks the AI to generate a rule."
+  },
+  "ruleModalAiAssistHelp": {
+    "message": "Describe qué quieres agrupar y la IA sugerirá nombre, dominios y color",
+    "description": "Help text under the AI assist input."
+  },
+  "ruleModalPatternModeLabel": {
+    "message": "Modo de patrón",
+    "description": "Label for the pattern mode toggle."
+  },
+  "ruleModalPatternModeSimple": {
+    "message": "Simple (dominios)",
+    "description": "Simple pattern mode: matches whole domains."
+  },
+  "ruleModalPatternModeExplicit": {
+    "message": "Explícito (URLs completas)",
+    "description": "Explicit pattern mode: matches full URLs."
+  },
+  "ruleModalSimpleModeHint": {
+    "message": "Agrupa todas las páginas de estos dominios base",
+    "description": "Hint shown in simple pattern mode."
+  },
+  "ruleModalExplicitModeHint": {
+    "message": "Agrupa solo las páginas que coincidan con estos patrones de URL completos",
+    "description": "Hint shown in explicit pattern mode."
+  },
+  "ruleModalPatternsLabel": {
+    "message": "Patrones de URL (uno por línea)",
+    "description": "Label for the patterns textarea."
+  },
+  "ruleModalPatternsHelp": {
+    "message": "Admite: dominios, comodines (*.example.com), rutas (example.com/api/*), direcciones IP",
+    "description": "Help text for the patterns textarea."
+  },
+  "ruleModalColorLabel": {
+    "message": "Color del grupo",
+    "description": "Label for the color picker."
+  },
+  "ruleModalColorBlue": { "message": "Azul", "description": "Color option: blue." },
+  "ruleModalColorRed": { "message": "Rojo", "description": "Color option: red." },
+  "ruleModalColorYellow": { "message": "Amarillo", "description": "Color option: yellow." },
+  "ruleModalColorGreen": { "message": "Verde", "description": "Color option: green." },
+  "ruleModalColorPink": { "message": "Rosa", "description": "Color option: pink." },
+  "ruleModalColorPurple": { "message": "Morado", "description": "Color option: purple." },
+  "ruleModalColorCyan": { "message": "Cian", "description": "Color option: cyan." },
+  "ruleModalColorOrange": { "message": "Naranja", "description": "Color option: orange." },
+  "ruleModalColorGrey": { "message": "Gris", "description": "Color option: grey." },
+  "ruleModalEnabledLabel": {
+    "message": "Activada",
+    "description": "Checkbox: whether the rule is enabled."
+  },
+  "ruleModalSave": {
+    "message": "Guardar regla",
+    "description": "Submit button for the rule form."
+  },
+  "ruleModalUpdate": {
+    "message": "Actualizar regla",
+    "description": "Submit button when editing an existing rule."
+  },
+  "ruleModalCancel": {
+    "message": "Cancelar",
+    "description": "Cancel button for the rule form."
+  },
+  "ruleModalConflictTitle": {
+    "message": "Conflictos de patrones detectados",
+    "description": "Heading of the conflict warning box."
+  },
+  "ruleModalConflictSubtitle": {
+    "message": "Estos patrones se solapan con reglas existentes. Las pestañas que coincidan con ambas reglas solo se asignarán a una.",
+    "description": "Subtitle of the conflict warning."
+  },
+  "ruleModalAiSuggestions": {
+    "message": "Sugerencias de IA",
+    "description": "Heading for the AI-generated resolution suggestions."
+  },
+  "ruleModalSaveAnyway": {
+    "message": "Guardar igualmente",
+    "description": "Button that saves the rule despite conflicts."
+  },
+  "ruleModalGoBack": {
+    "message": "Volver",
+    "description": "Button that returns to editing after a conflict warning."
+  },
+  "ruleModalChecking": {
+    "message": "Comprobando...",
+    "description": "Label shown on the save button while checking for conflicts."
+  },
+  "ruleModalGenerating": {
+    "message": "Generando...",
+    "description": "Label shown on the AI generate button while generating a rule."
+  },
+  "ruleModalAiThinking": {
+    "message": "La IA está pensando...",
+    "description": "Status text while the AI generates a rule."
+  },
+  "ruleModalAiNeedsModel": {
+    "message": "Carga un modelo de IA desde la sección de funciones de IA del popup para usar el asistente de IA",
+    "description": "Status shown when AI Assist is invoked but no model is loaded."
+  },
+  "ruleModalAiGenerated": {
+    "message": "¡Regla generada! Revísala y edítala abajo, y luego guarda.",
+    "description": "Status after the AI generates a rule."
+  },
+  "ruleModalAiGenerateError": {
+    "message": "No se pudo generar la regla. Intenta reformular tu descripción.",
+    "description": "Error shown when AI rule generation fails."
+  },
+  "ruleModalAiEnterDescription": {
+    "message": "Introduce una descripción",
+    "description": "Error shown when AI Assist is triggered with no description."
+  },
+  "ruleModalEnterPattern": {
+    "message": "Introduce al menos un patrón de URL",
+    "description": "Alert shown when submitting with no patterns."
+  },
+  "ruleModalEnterName": {
+    "message": "Introduce un nombre para la regla",
+    "description": "Alert shown when submitting a rule with no name."
+  },
+  "ruleModalFailedToLoad": {
+    "message": "No se pudo cargar la regla para editarla",
+    "description": "Alert when the rule modal can't load the rule."
+  },
+  "ruleModalFailedToSave": {
+    "message": "No se pudo guardar la regla",
+    "description": "Alert when saving a rule fails."
+  },
+
+  "importPageTitle": {
+    "message": "Importar reglas",
+    "description": "Title for the import rules page."
+  },
+  "importDropInstruction": {
+    "message": "Arrastra y suelta aquí un archivo JSON",
+    "description": "Instruction shown in the import drop zone."
+  },
+  "importOr": {
+    "message": "o",
+    "description": "Separator between drag-drop and button."
+  },
+  "importBrowseFiles": {
+    "message": "Explorar archivos",
+    "description": "Button that opens the file picker."
+  },
+  "importPreviewHeading": {
+    "message": "Vista previa",
+    "description": "Heading above the import preview."
+  },
+  "importModeLabel": {
+    "message": "Modo de importación",
+    "description": "Label above the import mode radio buttons."
+  },
+  "importMerge": {
+    "message": "Combinar con las reglas existentes",
+    "description": "Radio option: merge on import."
+  },
+  "importReplace": {
+    "message": "Reemplazar todas las reglas existentes",
+    "description": "Radio option: replace on import."
+  },
+  "importButton": {
+    "message": "Importar reglas",
+    "description": "Button that performs the import."
+  },
+  "importCancel": {
+    "message": "Cancelar",
+    "description": "Cancel button on the import page."
+  },
+  "importStatValid": {
+    "message": "Reglas válidas",
+    "description": "Label for the valid rule count in the import preview."
+  },
+  "importStatInvalid": {
+    "message": "Inválidas (se omitirán)",
+    "description": "Label for the invalid rule count in the import preview."
+  },
+  "importPatternsSuffix": {
+    "message": "$count$ patrones",
+    "description": "Label showing pattern count for an imported rule.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importMoreRules": {
+    "message": "...y $count$ reglas más",
+    "description": "Shown when more rules exist beyond the preview slice.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importUnnamed": {
+    "message": "Sin nombre",
+    "description": "Placeholder name for rules with no name."
+  },
+  "importImporting": {
+    "message": "Importando...",
+    "description": "Label on the import button while importing."
+  },
+  "importSuccess": {
+    "message": "Se importaron correctamente $count$ reglas",
+    "description": "Success message after import.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importSuccessWithSkipped": {
+    "message": "Se importaron correctamente $count$ reglas ($skipped$ omitidas)",
+    "description": "Success message when some rules are skipped.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "skipped": { "content": "$2" }
+    }
+  },
+  "importFailed": {
+    "message": "La importación falló",
+    "description": "Generic import failure message."
+  },
+  "importInvalidJson": {
+    "message": "JSON no válido",
+    "description": "Error when file is not valid JSON."
+  },
+  "importInvalidFormat": {
+    "message": "Formato de archivo no válido: falta la propiedad «rules»",
+    "description": "Error when file has no 'rules' key."
+  },
+  "importNoRules": {
+    "message": "No se encontraron reglas en el archivo",
+    "description": "Error when file has no rules."
+  },
+  "importSelectJson": {
+    "message": "Selecciona un archivo JSON",
+    "description": "Error when a non-JSON file is selected."
+  }
+}

--- a/public/_locales/he/messages.json
+++ b/public/_locales/he/messages.json
@@ -4,7 +4,7 @@
     "description": "The name of the extension as it appears in the browser store and toolbar."
   },
   "extensionDescription": {
-    "message": "Automatically groups tabs by domain.",
+    "message": "מקבץ לשוניות אוטומטית לפי דומיין.",
     "description": "Short description shown in the extensions list."
   },
 
@@ -13,109 +13,109 @@
     "description": "Heading shown at the top of the popup/sidebar."
   },
   "popupGroupTabs": {
-    "message": "Group Tabs",
+    "message": "קבץ לשוניות",
     "description": "Button that groups all open tabs immediately."
   },
   "popupUngroupAll": {
-    "message": "Ungroup All",
+    "message": "בטל את כל הקבוצות",
     "description": "Button that removes every tab group."
   },
   "popupGenerateNewColors": {
-    "message": "Generate New Colors",
+    "message": "צור צבעים חדשים",
     "description": "Button that randomizes the colors of all groups."
   },
   "popupGenerateNewColorsTitle": {
-    "message": "Randomize group colors. Colors are saved and restored automatically for each domain/rule.",
+    "message": "הגרל צבעים חדשים לקבוצות. הצבעים נשמרים ומשוחזרים אוטומטית לכל דומיין או חוק.",
     "description": "Tooltip for the Generate New Colors button."
   },
   "popupCollapseAll": {
-    "message": "Collapse All",
+    "message": "מזער הכל",
     "description": "Button that collapses every group."
   },
   "popupExpandAll": {
-    "message": "Expand All",
+    "message": "הרחב הכל",
     "description": "Button that expands every group."
   },
 
   "settingsHeading": {
-    "message": "Settings",
+    "message": "הגדרות",
     "description": "Heading for the main settings section."
   },
   "settingLanguage": {
-    "message": "Language",
+    "message": "שפה",
     "description": "Label for the UI language picker."
   },
   "settingLanguageAuto": {
-    "message": "Auto (browser default)",
+    "message": "אוטומטי (ברירת מחדל של הדפדפן)",
     "description": "Picker option that defers to the browser's UI language."
   },
   "settingAutoGroupMode": {
-    "message": "Auto-Group Mode",
+    "message": "מצב קיבוץ אוטומטי",
     "description": "Label for the toggle that enables automatic grouping."
   },
   "settingGroupBy": {
-    "message": "Group by",
+    "message": "קבץ לפי",
     "description": "Label for the group-by mode selector."
   },
   "settingGroupByRulesOnly": {
-    "message": "Rules only",
+    "message": "חוקים בלבד",
     "description": "Option that groups only by custom rules."
   },
   "settingGroupByRulesAndDomain": {
-    "message": "Rules & Domain",
+    "message": "חוקים ודומיין",
     "description": "Option that groups by rules plus base domain (popup)."
   },
   "settingGroupByRulesAndSubdomain": {
-    "message": "Rules & Sub-domain",
+    "message": "חוקים ותת-דומיין",
     "description": "Option that groups by rules plus subdomain (popup)."
   },
   "settingGroupByDomain": {
-    "message": "Domain",
+    "message": "דומיין",
     "description": "Option that groups by base domain (sidebar)."
   },
   "settingGroupBySubdomain": {
-    "message": "Sub-domain",
+    "message": "תת-דומיין",
     "description": "Option that groups by subdomain (sidebar)."
   },
   "settingGroupNewEmptyTabs": {
-    "message": "Group new empty tabs under \"System\"",
+    "message": "קבץ לשוניות ריקות חדשות תחת \"System\"",
     "description": "Label for the toggle that groups blank/new tabs under a System group."
   },
   "settingMinimumTabsForGroup": {
-    "message": "Minimum tabs to form a group",
+    "message": "מינימום לשוניות ליצירת קבוצה",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."
   },
   "settingAutoCollapseInactive": {
-    "message": "Auto-collapse inactive groups",
+    "message": "מזער אוטומטית קבוצות לא פעילות",
     "description": "Label for the toggle that auto-collapses groups the user isn't looking at."
   },
   "settingCollapseDelay": {
-    "message": "Collapse delay",
+    "message": "השהיית מזעור",
     "description": "Label for the numeric input that sets the auto-collapse delay."
   },
   "settingCollapseDelayHelp": {
-    "message": "0 = immediate, or set delay (100-5000ms) before collapsing",
+    "message": "0 = מיידי, או הגדר השהיה (100-5000ms) לפני מזעור",
     "description": "Help text under the collapse-delay input."
   },
   "settingOpenNewTabsNextToCurrent": {
-    "message": "Open new tabs next to current tab",
+    "message": "פתח לשוניות חדשות ליד הלשונית הנוכחית",
     "description": "Label for the toggle that opens new tabs adjacent to the active tab."
   },
   "settingPinnedTabsNote": {
-    "message": "Pinned tabs are never grouped automatically",
+    "message": "לשוניות נעוצות אינן מקובצות אוטומטית",
     "description": "Informational note about pinned tabs."
   },
 
   "sortingSectionTitle": {
-    "message": "Sorting",
+    "message": "מיון",
     "description": "Title for the collapsible sorting section."
   },
   "settingSortGroupsAlphabetically": {
-    "message": "Keep groups sorted alphabetically",
+    "message": "שמור על קבוצות ממוינות לפי א-ב",
     "description": "Toggle that keeps tab groups sorted alphabetically."
   },
   "settingSortDirection": {
-    "message": "Direction",
+    "message": "כיוון",
     "description": "Label for the sort direction toggle (A-Z vs Z-A)."
   },
   "settingSortDirectionAsc": {
@@ -127,131 +127,131 @@
     "description": "Descending alphabetical sort direction option."
   },
   "settingNumberGroups": {
-    "message": "Number groups (1. AI, 2. Docs...)",
+    "message": "מספר קבוצות (1. AI, 2. Docs...)",
     "description": "Toggle that prefixes group titles with their sort index."
   },
   "settingNumberGroupsHelp": {
-    "message": "Adds position numbers to group titles for quick reference",
+    "message": "מוסיף מספרי מיקום לכותרות הקבוצות להפניה מהירה",
     "description": "Help text describing the Number Groups toggle."
   },
 
   "aiSectionTitle": {
-    "message": "AI Features",
+    "message": "תכונות AI",
     "description": "Title for the AI features section."
   },
   "aiExperimentalBadge": {
-    "message": "Experimental",
+    "message": "ניסיוני",
     "description": "Badge shown next to the AI Features title."
   },
   "aiHelpTooltip": {
-    "message": "AI-powered tab grouping suggestions. This feature is experimental. All processing runs locally in your browser — no data is sent to external servers.",
+    "message": "הצעות קיבוץ לשוניות מבוססות בינה מלאכותית. תכונה זו ניסיונית. כל העיבוד מתבצע מקומית בדפדפן — לא נשלח מידע לשרתים חיצוניים.",
     "description": "Tooltip explaining the AI Features."
   },
   "aiBadgeOn": {
-    "message": "On",
+    "message": "פועל",
     "description": "Status badge shown when AI is enabled."
   },
   "aiBadgeOff": {
-    "message": "Off",
+    "message": "כבוי",
     "description": "Status badge shown when AI is disabled."
   },
   "aiEnable": {
-    "message": "Enable AI",
+    "message": "הפעל AI",
     "description": "Toggle that enables or disables AI features."
   },
   "aiModelLabel": {
-    "message": "Model",
+    "message": "מודל",
     "description": "Label for the AI model selector."
   },
   "aiStatusLabel": {
-    "message": "Status:",
+    "message": "סטטוס:",
     "description": "Label for the AI model status."
   },
   "aiStatusIdle": {
-    "message": "Idle",
+    "message": "במנוחה",
     "description": "AI model status: idle."
   },
   "aiStatusReady": {
-    "message": "Ready",
+    "message": "מוכן",
     "description": "AI model status: ready."
   },
   "aiStatusLoading": {
-    "message": "Loading $progress$%",
+    "message": "טוען $progress$%",
     "description": "AI model status while loading, with a progress percentage.",
     "placeholders": {
       "progress": { "content": "$1", "example": "42" }
     }
   },
   "aiStatusError": {
-    "message": "Error",
+    "message": "שגיאה",
     "description": "AI model status: error."
   },
   "aiLoadModel": {
-    "message": "Load Model",
+    "message": "טען מודל",
     "description": "Button that starts loading the AI model."
   },
   "aiUnloadModel": {
-    "message": "Unload Model",
+    "message": "פרוק מודל",
     "description": "Button that unloads the AI model."
   },
   "aiLoadingButton": {
-    "message": "Loading...",
+    "message": "טוען...",
     "description": "Label shown on the load button while loading."
   },
   "aiRetryLoad": {
-    "message": "Retry Load",
+    "message": "נסה שוב",
     "description": "Button shown after an AI model load error."
   },
   "aiWebGpuUnavailable": {
-    "message": "WebGPU is not available. AI features require a browser with WebGPU support.",
+    "message": "WebGPU אינו זמין. תכונות AI דורשות דפדפן שתומך ב-WebGPU.",
     "description": "Warning shown when WebGPU is not supported."
   },
   "aiDownloadNote": {
-    "message": "Models run locally in your browser. First load downloads the model (~250MB-900MB).",
+    "message": "המודלים פועלים מקומית בדפדפן שלך. הטעינה הראשונה מורידה את המודל (כ-250MB-900MB).",
     "description": "Help text beneath the load model button."
   },
   "aiSuggestGroups": {
-    "message": "Suggest Groups",
+    "message": "הצע קבוצות",
     "description": "Button that asks the AI to suggest tab groups."
   },
   "aiAnalyzing": {
-    "message": "Analyzing your tabs...",
+    "message": "מנתח את הלשוניות שלך...",
     "description": "Status text while the AI analyzes open tabs."
   },
   "aiNoSuggestions": {
-    "message": "No suggestions found",
+    "message": "לא נמצאו הצעות",
     "description": "Status text shown when the AI returns zero suggestions."
   },
   "aiFailedToGetSuggestions": {
-    "message": "Failed to get suggestions",
+    "message": "נכשל בקבלת הצעות",
     "description": "Error shown when AI suggestion fails."
   },
   "aiDismiss": {
-    "message": "Dismiss",
+    "message": "בטל",
     "description": "Button that dismisses AI suggestions."
   },
   "aiApply": {
-    "message": "Apply",
+    "message": "החל",
     "description": "Button that applies an AI suggestion."
   },
   "aiApplying": {
-    "message": "Applying...",
+    "message": "מחיל...",
     "description": "Button label while applying a suggestion."
   },
   "aiApplied": {
-    "message": "Applied!",
+    "message": "הוחל!",
     "description": "Button label after applying a suggestion."
   },
   "aiFailed": {
-    "message": "Failed",
+    "message": "נכשל",
     "description": "Button label after a suggestion fails."
   },
   "aiCreateRule": {
-    "message": "Create Rule",
+    "message": "צור חוק",
     "description": "Button that creates a rule from a suggestion."
   },
   "aiTabsCount": {
-    "message": "$count$ tab$plural$",
+    "message": "$count$ לשוניות",
     "description": "Tab count label for a suggestion.",
     "placeholders": {
       "count": { "content": "$1" },
@@ -259,7 +259,7 @@
     }
   },
   "aiAppliedWithStale": {
-    "message": "Applied ($count$ tab$plural$ closed)",
+    "message": "הוחל ($count$ לשוניות נסגרו)",
     "description": "Shown when a suggestion is applied but some tabs were closed.",
     "placeholders": {
       "count": { "content": "$1" },
@@ -267,91 +267,91 @@
     }
   },
   "aiFirefoxNotice": {
-    "message": "AI features are currently available on Chrome only. Firefox support is coming soon.",
+    "message": "תכונות AI זמינות כרגע רק בכרום. התמיכה ב-Firefox תגיע בקרוב.",
     "description": "Notice shown to Firefox users."
   },
 
   "rulesSectionTitle": {
-    "message": "Custom Rules",
+    "message": "חוקים מותאמים אישית",
     "description": "Title for the custom rules section."
   },
   "rulesAddNewRule": {
-    "message": "Add New Rule",
+    "message": "הוסף חוק חדש",
     "description": "Button that opens the new rule dialog."
   },
   "rulesExport": {
-    "message": "Export",
+    "message": "ייצא",
     "description": "Button that exports rules to JSON."
   },
   "rulesImport": {
-    "message": "Import",
+    "message": "ייבא",
     "description": "Button that imports rules from JSON."
   },
   "rulesExportTitle": {
-    "message": "Export all rules to JSON file",
+    "message": "ייצא את כל החוקים לקובץ JSON",
     "description": "Tooltip on the Export button."
   },
   "rulesImportTitle": {
-    "message": "Import rules from JSON file",
+    "message": "ייבא חוקים מקובץ JSON",
     "description": "Tooltip on the Import button."
   },
   "rulesExportImportHelp": {
-    "message": "Export/import rules as JSON files for backup or sharing",
+    "message": "ייצא/ייבא חוקים כקובצי JSON לגיבוי או שיתוף",
     "description": "Help text under the export/import buttons."
   },
   "rulesEmptyState": {
-    "message": "No custom rules yet. Create your first rule to group tabs by your preferences!",
+    "message": "אין עדיין חוקים מותאמים אישית. צור את החוק הראשון שלך לקיבוץ לשוניות לפי ההעדפות שלך!",
     "description": "Shown when there are no custom rules."
   },
   "rulesEdit": {
-    "message": "Edit",
+    "message": "ערוך",
     "description": "Edit button on a rule row."
   },
   "rulesDelete": {
-    "message": "Delete",
+    "message": "מחק",
     "description": "Delete button on a rule row."
   },
   "rulesEditTitle": {
-    "message": "Edit rule",
+    "message": "ערוך חוק",
     "description": "Tooltip for the edit button."
   },
   "rulesDeleteTitle": {
-    "message": "Delete rule",
+    "message": "מחק חוק",
     "description": "Tooltip for the delete button."
   },
   "rulesAddTabTitle": {
-    "message": "Add Tab to Existing Rule",
+    "message": "הוסף לשונית לחוק קיים",
     "description": "Tooltip for the + button that adds the current tab to a rule."
   },
   "rulesDeleteConfirm": {
-    "message": "Are you sure you want to delete the rule \"$name$\"?",
+    "message": "למחוק את החוק \"$name$\"?",
     "description": "Confirmation prompt before deleting a rule.",
     "placeholders": {
       "name": { "content": "$1" }
     }
   },
   "rulesFailedToLoad": {
-    "message": "Failed to load custom rules",
+    "message": "נכשל בטעינת חוקים מותאמים אישית",
     "description": "Error when loading rules fails."
   },
   "rulesFailedToDelete": {
-    "message": "Failed to delete rule",
+    "message": "נכשל במחיקת החוק",
     "description": "Error when deleting a rule fails."
   },
   "rulesExportSuccess": {
-    "message": "Rules exported successfully!",
+    "message": "החוקים יוצאו בהצלחה!",
     "description": "Confirmation after exporting rules."
   },
   "rulesFailedToExport": {
-    "message": "Failed to export rules",
+    "message": "נכשל בייצוא החוקים",
     "description": "Error when export fails."
   },
   "rulesImportSuccess": {
-    "message": "Rules imported successfully!",
+    "message": "החוקים יובאו בהצלחה!",
     "description": "Confirmation after importing rules."
   },
   "rulesImportSummary": {
-    "message": "Import successful!\nImported: $imported$ rules\nSkipped: $skipped$ rules",
+    "message": "הייבוא הצליח!\nיובאו: $imported$ חוקים\nדולגו: $skipped$ חוקים",
     "description": "Summary shown after rules are imported.",
     "placeholders": {
       "imported": { "content": "$1" },
@@ -359,93 +359,93 @@
     }
   },
   "rulesFailedToImport": {
-    "message": "Failed to import rules",
+    "message": "נכשל בייבוא החוקים",
     "description": "Error when import fails."
   },
   "rulesImportReplacePrompt": {
-    "message": "Do you want to replace all existing rules?\n\nClick OK to REPLACE all existing rules with imported ones\nClick Cancel to MERGE imported rules with existing ones",
+    "message": "להחליף את כל החוקים הקיימים?\n\nלחץ אישור כדי להחליף את כל החוקים הקיימים בחוקים המיובאים\nלחץ ביטול כדי למזג את החוקים המיובאים עם הקיימים",
     "description": "Prompt that asks whether to merge or replace on import."
   },
   "rulesNoExport": {
-    "message": "No rules to export",
+    "message": "אין חוקים לייצוא",
     "description": "Tooltip shown on a disabled export button when there are no rules."
   },
   "rulesNoDomains": {
-    "message": "No domains",
+    "message": "אין דומיינים",
     "description": "Shown when a rule has no configured domains."
   },
   "rulesDomainsSeparator": {
-    "message": " and $count$ more",
+    "message": " ועוד $count$",
     "description": "Appended to truncated domain lists.",
     "placeholders": {
       "count": { "content": "$1" }
     }
   },
   "rulesAddTabNoTab": {
-    "message": "No active tab found",
+    "message": "לא נמצאה לשונית פעילה",
     "description": "Tooltip shown on the add-tab button when no active tab is available."
   },
   "rulesAddTabCantExtract": {
-    "message": "Cannot extract domain from this tab",
+    "message": "לא ניתן לחלץ דומיין מהלשונית הזו",
     "description": "Tooltip when the current tab's URL has no domain."
   },
   "rulesAddTabAlreadyExists": {
-    "message": "Domain already in this rule",
+    "message": "הדומיין כבר קיים בחוק הזה",
     "description": "Tooltip when the tab's domain is already part of the rule."
   },
   "rulesAddTabAdded": {
-    "message": "Added!",
+    "message": "נוסף!",
     "description": "Tooltip shown briefly after adding a tab to a rule."
   },
   "rulesAddTabFailed": {
-    "message": "Failed to add domain",
+    "message": "נכשל בהוספת הדומיין",
     "description": "Tooltip when adding a domain fails."
   },
 
   "blacklistSectionTitle": {
-    "message": "Blacklist",
+    "message": "רשימה שחורה",
     "description": "Title for the blacklist section."
   },
   "blacklistAddButton": {
-    "message": "Add to Blacklist",
+    "message": "הוסף לרשימה השחורה",
     "description": "Button to add a domain to the blacklist."
   },
   "blacklistHelp": {
-    "message": "Blacklisted domains will never be grouped",
+    "message": "דומיינים ברשימה השחורה לעולם לא יקובצו",
     "description": "Help text under the blacklist section."
   },
   "blacklistEmpty": {
-    "message": "No blacklisted domains yet.",
+    "message": "אין עדיין דומיינים ברשימה השחורה.",
     "description": "Shown when the blacklist is empty."
   },
   "blacklistEditTitle": {
-    "message": "Edit blacklist rule",
+    "message": "ערוך חוק רשימה שחורה",
     "description": "Tooltip for the blacklist edit button."
   },
   "blacklistDeleteTitle": {
-    "message": "Delete blacklist rule",
+    "message": "מחק חוק רשימה שחורה",
     "description": "Tooltip for the blacklist delete button."
   },
 
   "advancedSectionTitle": {
-    "message": "Advanced",
+    "message": "מתקדם",
     "description": "Title for the advanced settings section."
   },
   "advancedHideContextMenu": {
-    "message": "Hide right-click context menu",
+    "message": "הסתר תפריט לחיצה ימנית",
     "description": "Toggle that hides the extension's context menu items."
   },
   "advancedHideContextMenuHelp": {
-    "message": "When enabled, Auto Tab Groups will not add its items to the page right-click menu.",
+    "message": "כשמופעל, Auto Tab Groups לא יוסיף פריטים לתפריט הלחיצה הימנית של העמוד.",
     "description": "Help text for the hide context menu toggle."
   },
 
   "footerMadeBy": {
-    "message": "Made by",
+    "message": "נבנה על ידי",
     "description": "Prefix for the author attribution in the footer."
   },
   "footerFor": {
-    "message": "for",
+    "message": "עבור",
     "description": "Connector text: 'Made by X, for Chrome'."
   },
   "footerBrowserChrome": {
@@ -457,268 +457,268 @@
     "description": "Name of the Firefox browser in the footer."
   },
   "footerFeedback": {
-    "message": "Feedback & Requests & Support",
+    "message": "משוב, בקשות ותמיכה",
     "description": "Text of the feedback link."
   },
   "footerVersion": {
-    "message": "Version:",
+    "message": "גרסה:",
     "description": "Prefix before the version number."
   },
 
   "contextMenuCreateRuleFromGroup": {
-    "message": "Create Rule from Group",
+    "message": "צור חוק מהקבוצה",
     "description": "Right-click menu: create a custom rule from the clicked tab's group."
   },
   "contextMenuAddTabToExistingRule": {
-    "message": "Add Tab to Existing Rule",
+    "message": "הוסף לשונית לחוק קיים",
     "description": "Right-click menu: submenu to add the current tab's domain to an existing rule."
   },
   "contextMenuAddToBlacklist": {
-    "message": "Add to Blacklist",
+    "message": "הוסף לרשימה השחורה",
     "description": "Right-click menu: add the current tab's domain to the blacklist."
   },
   "contextMenuNoRulesYet": {
-    "message": "No rules yet",
+    "message": "אין עדיין חוקים",
     "description": "Disabled placeholder shown when the Add Tab submenu has no rules."
   },
 
   "ruleModalCreateTitle": {
-    "message": "Create Custom Rule",
+    "message": "צור חוק מותאם אישית",
     "description": "Title shown when creating a new rule."
   },
   "ruleModalEditTitle": {
-    "message": "Edit Custom Rule",
+    "message": "ערוך חוק מותאם אישית",
     "description": "Title shown when editing an existing rule."
   },
   "ruleModalNameLabel": {
-    "message": "Rule Name",
+    "message": "שם החוק",
     "description": "Label for the rule name input."
   },
   "ruleModalNamePlaceholder": {
-    "message": "e.g., Work Apps",
+    "message": "למשל, אפליקציות עבודה",
     "description": "Placeholder for the rule name input."
   },
   "ruleModalNameHelp": {
-    "message": "Supports any language including Chinese, Japanese, Korean, and emojis",
+    "message": "תומך בכל שפה כולל סינית, יפנית, קוריאנית, ואימוג'ים",
     "description": "Help text under the rule name input."
   },
   "ruleModalAiAssistLabel": {
-    "message": "AI Assist",
+    "message": "סיוע AI",
     "description": "Label for the AI assist section."
   },
   "ruleModalAiAssistPlaceholder": {
-    "message": "Describe your rule, e.g., 'Group all Google services' or 'Group AWS console tabs'",
+    "message": "תאר את החוק שלך, למשל: 'קבץ את כל שירותי Google' או 'קבץ לשוניות של AWS console'",
     "description": "Placeholder for the AI assist input."
   },
   "ruleModalAiGenerate": {
-    "message": "Generate",
+    "message": "צור",
     "description": "Button that asks the AI to generate a rule."
   },
   "ruleModalAiAssistHelp": {
-    "message": "Describe what you want to group and AI will suggest name, domains, and color",
+    "message": "תאר מה ברצונך לקבץ וה-AI יציע שם, דומיינים וצבע",
     "description": "Help text under the AI assist input."
   },
   "ruleModalPatternModeLabel": {
-    "message": "Pattern Mode",
+    "message": "מצב התאמת דפוס",
     "description": "Label for the pattern mode toggle."
   },
   "ruleModalPatternModeSimple": {
-    "message": "Simple (domains)",
+    "message": "פשוט (דומיינים)",
     "description": "Simple pattern mode: matches whole domains."
   },
   "ruleModalPatternModeExplicit": {
-    "message": "Explicit (full URLs)",
+    "message": "מפורש (כתובות URL מלאות)",
     "description": "Explicit pattern mode: matches full URLs."
   },
   "ruleModalSimpleModeHint": {
-    "message": "Groups all pages from these base domains",
+    "message": "מקבץ את כל העמודים מהדומיינים הבסיסיים האלה",
     "description": "Hint shown in simple pattern mode."
   },
   "ruleModalExplicitModeHint": {
-    "message": "Groups only pages matching these full URL patterns",
+    "message": "מקבץ רק עמודים שמתאימים לדפוסי ה-URL המלאים האלה",
     "description": "Hint shown in explicit pattern mode."
   },
   "ruleModalPatternsLabel": {
-    "message": "URL Patterns (one per line)",
+    "message": "דפוסי URL (אחד בכל שורה)",
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "Supports: domains, wildcards (*.example.com), paths (example.com/api/*), IP addresses",
+    "message": "תומך ב: דומיינים, תווים כלליים (*.example.com), נתיבים (example.com/api/*), כתובות IP",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {
-    "message": "Group Color",
+    "message": "צבע הקבוצה",
     "description": "Label for the color picker."
   },
-  "ruleModalColorBlue": { "message": "Blue", "description": "Color option: blue." },
-  "ruleModalColorRed": { "message": "Red", "description": "Color option: red." },
-  "ruleModalColorYellow": { "message": "Yellow", "description": "Color option: yellow." },
-  "ruleModalColorGreen": { "message": "Green", "description": "Color option: green." },
-  "ruleModalColorPink": { "message": "Pink", "description": "Color option: pink." },
-  "ruleModalColorPurple": { "message": "Purple", "description": "Color option: purple." },
-  "ruleModalColorCyan": { "message": "Cyan", "description": "Color option: cyan." },
-  "ruleModalColorOrange": { "message": "Orange", "description": "Color option: orange." },
-  "ruleModalColorGrey": { "message": "Grey", "description": "Color option: grey." },
+  "ruleModalColorBlue": { "message": "כחול", "description": "Color option: blue." },
+  "ruleModalColorRed": { "message": "אדום", "description": "Color option: red." },
+  "ruleModalColorYellow": { "message": "צהוב", "description": "Color option: yellow." },
+  "ruleModalColorGreen": { "message": "ירוק", "description": "Color option: green." },
+  "ruleModalColorPink": { "message": "ורוד", "description": "Color option: pink." },
+  "ruleModalColorPurple": { "message": "סגול", "description": "Color option: purple." },
+  "ruleModalColorCyan": { "message": "טורקיז", "description": "Color option: cyan." },
+  "ruleModalColorOrange": { "message": "כתום", "description": "Color option: orange." },
+  "ruleModalColorGrey": { "message": "אפור", "description": "Color option: grey." },
   "ruleModalEnabledLabel": {
-    "message": "Enabled",
+    "message": "מופעל",
     "description": "Checkbox: whether the rule is enabled."
   },
   "ruleModalSave": {
-    "message": "Save Rule",
+    "message": "שמור חוק",
     "description": "Submit button for the rule form."
   },
   "ruleModalUpdate": {
-    "message": "Update Rule",
+    "message": "עדכן חוק",
     "description": "Submit button when editing an existing rule."
   },
   "ruleModalCancel": {
-    "message": "Cancel",
+    "message": "ביטול",
     "description": "Cancel button for the rule form."
   },
   "ruleModalConflictTitle": {
-    "message": "Pattern Conflicts Detected",
+    "message": "זוהו קונפליקטים בדפוסים",
     "description": "Heading of the conflict warning box."
   },
   "ruleModalConflictSubtitle": {
-    "message": "These patterns overlap with existing rules. Tabs matching both rules will only be assigned to one.",
+    "message": "הדפוסים האלה חופפים לחוקים קיימים. לשוניות שמתאימות לשני החוקים ישויכו רק לאחד.",
     "description": "Subtitle of the conflict warning."
   },
   "ruleModalAiSuggestions": {
-    "message": "AI Suggestions",
+    "message": "הצעות AI",
     "description": "Heading for the AI-generated resolution suggestions."
   },
   "ruleModalSaveAnyway": {
-    "message": "Save Anyway",
+    "message": "שמור בכל זאת",
     "description": "Button that saves the rule despite conflicts."
   },
   "ruleModalGoBack": {
-    "message": "Go Back",
+    "message": "חזור",
     "description": "Button that returns to editing after a conflict warning."
   },
   "ruleModalChecking": {
-    "message": "Checking...",
+    "message": "בודק...",
     "description": "Label shown on the save button while checking for conflicts."
   },
   "ruleModalGenerating": {
-    "message": "Generating...",
+    "message": "מייצר...",
     "description": "Label shown on the AI generate button while generating a rule."
   },
   "ruleModalAiThinking": {
-    "message": "AI is thinking...",
+    "message": "ה-AI חושב...",
     "description": "Status text while the AI generates a rule."
   },
   "ruleModalAiNeedsModel": {
-    "message": "Load an AI model from the popup's AI Features section to use AI Assist",
+    "message": "טען מודל AI מחלון התכונות של ה-AI בפופאפ כדי להשתמש בסיוע AI",
     "description": "Status shown when AI Assist is invoked but no model is loaded."
   },
   "ruleModalAiGenerated": {
-    "message": "Rule generated! Review and edit below, then save.",
+    "message": "החוק נוצר! בדוק וערוך למטה, ואז שמור.",
     "description": "Status after the AI generates a rule."
   },
   "ruleModalAiGenerateError": {
-    "message": "Failed to generate rule. Try rephrasing your description.",
+    "message": "נכשל ביצירת החוק. נסה לנסח מחדש את התיאור.",
     "description": "Error shown when AI rule generation fails."
   },
   "ruleModalAiEnterDescription": {
-    "message": "Please enter a description",
+    "message": "נא להזין תיאור",
     "description": "Error shown when AI Assist is triggered with no description."
   },
   "ruleModalEnterPattern": {
-    "message": "Please enter at least one URL pattern",
+    "message": "נא להזין לפחות דפוס URL אחד",
     "description": "Alert shown when submitting with no patterns."
   },
   "ruleModalEnterName": {
-    "message": "Please enter a rule name",
+    "message": "נא להזין שם לחוק",
     "description": "Alert shown when submitting a rule with no name."
   },
   "ruleModalFailedToLoad": {
-    "message": "Failed to load rule for editing",
+    "message": "נכשל בטעינת החוק לעריכה",
     "description": "Alert when the rule modal can't load the rule."
   },
   "ruleModalFailedToSave": {
-    "message": "Failed to save rule",
+    "message": "נכשל בשמירת החוק",
     "description": "Alert when saving a rule fails."
   },
 
   "importPageTitle": {
-    "message": "Import Rules",
+    "message": "ייבוא חוקים",
     "description": "Title for the import rules page."
   },
   "importDropInstruction": {
-    "message": "Drag & drop a JSON file here",
+    "message": "גרור ושחרר קובץ JSON כאן",
     "description": "Instruction shown in the import drop zone."
   },
   "importOr": {
-    "message": "or",
+    "message": "או",
     "description": "Separator between drag-drop and button."
   },
   "importBrowseFiles": {
-    "message": "Browse Files",
+    "message": "עיין בקבצים",
     "description": "Button that opens the file picker."
   },
   "importPreviewHeading": {
-    "message": "Preview",
+    "message": "תצוגה מקדימה",
     "description": "Heading above the import preview."
   },
   "importModeLabel": {
-    "message": "Import Mode",
+    "message": "מצב ייבוא",
     "description": "Label above the import mode radio buttons."
   },
   "importMerge": {
-    "message": "Merge with existing rules",
+    "message": "מזג עם חוקים קיימים",
     "description": "Radio option: merge on import."
   },
   "importReplace": {
-    "message": "Replace all existing rules",
+    "message": "החלף את כל החוקים הקיימים",
     "description": "Radio option: replace on import."
   },
   "importButton": {
-    "message": "Import Rules",
+    "message": "ייבא חוקים",
     "description": "Button that performs the import."
   },
   "importCancel": {
-    "message": "Cancel",
+    "message": "ביטול",
     "description": "Cancel button on the import page."
   },
   "importStatValid": {
-    "message": "Valid Rules",
+    "message": "חוקים תקינים",
     "description": "Label for the valid rule count in the import preview."
   },
   "importStatInvalid": {
-    "message": "Invalid (will be skipped)",
+    "message": "לא תקינים (ידולגו)",
     "description": "Label for the invalid rule count in the import preview."
   },
   "importPatternsSuffix": {
-    "message": "$count$ patterns",
+    "message": "$count$ דפוסים",
     "description": "Label showing pattern count for an imported rule.",
     "placeholders": {
       "count": { "content": "$1" }
     }
   },
   "importMoreRules": {
-    "message": "...and $count$ more rules",
+    "message": "...ועוד $count$ חוקים",
     "description": "Shown when more rules exist beyond the preview slice.",
     "placeholders": {
       "count": { "content": "$1" }
     }
   },
   "importUnnamed": {
-    "message": "Unnamed",
+    "message": "ללא שם",
     "description": "Placeholder name for rules with no name."
   },
   "importImporting": {
-    "message": "Importing...",
+    "message": "מייבא...",
     "description": "Label on the import button while importing."
   },
   "importSuccess": {
-    "message": "Successfully imported $count$ rules",
+    "message": "יובאו בהצלחה $count$ חוקים",
     "description": "Success message after import.",
     "placeholders": {
       "count": { "content": "$1" }
     }
   },
   "importSuccessWithSkipped": {
-    "message": "Successfully imported $count$ rules ($skipped$ skipped)",
+    "message": "יובאו בהצלחה $count$ חוקים ($skipped$ דולגו)",
     "description": "Success message when some rules are skipped.",
     "placeholders": {
       "count": { "content": "$1" },
@@ -726,23 +726,23 @@
     }
   },
   "importFailed": {
-    "message": "Import failed",
+    "message": "הייבוא נכשל",
     "description": "Generic import failure message."
   },
   "importInvalidJson": {
-    "message": "Invalid JSON",
+    "message": "JSON לא תקין",
     "description": "Error when file is not valid JSON."
   },
   "importInvalidFormat": {
-    "message": "Invalid file format: Missing 'rules' property",
+    "message": "פורמט קובץ לא תקין: חסר שדה 'rules'",
     "description": "Error when file has no 'rules' key."
   },
   "importNoRules": {
-    "message": "No rules found in file",
+    "message": "לא נמצאו חוקים בקובץ",
     "description": "Error when file has no rules."
   },
   "importSelectJson": {
-    "message": "Please select a JSON file",
+    "message": "נא לבחור קובץ JSON",
     "description": "Error when a non-JSON file is selected."
   }
 }

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -1,0 +1,748 @@
+{
+  "extensionName": {
+    "message": "Auto Tab Groups",
+    "description": "The name of the extension as it appears in the browser store and toolbar."
+  },
+  "extensionDescription": {
+    "message": "डोमेन के अनुसार टैब्स को स्वचालित रूप से समूहित करता है।",
+    "description": "Short description shown in the extensions list."
+  },
+
+  "popupTitle": {
+    "message": "Auto Tab Groups",
+    "description": "Heading shown at the top of the popup/sidebar."
+  },
+  "popupGroupTabs": {
+    "message": "टैब्स समूहित करें",
+    "description": "Button that groups all open tabs immediately."
+  },
+  "popupUngroupAll": {
+    "message": "सभी समूह हटाएँ",
+    "description": "Button that removes every tab group."
+  },
+  "popupGenerateNewColors": {
+    "message": "नए रंग बनाएँ",
+    "description": "Button that randomizes the colors of all groups."
+  },
+  "popupGenerateNewColorsTitle": {
+    "message": "समूह के रंगों को यादृच्छिक करें। रंग हर डोमेन/नियम के लिए स्वचालित रूप से सहेजे और पुनर्स्थापित किए जाते हैं।",
+    "description": "Tooltip for the Generate New Colors button."
+  },
+  "popupCollapseAll": {
+    "message": "सभी समेटें",
+    "description": "Button that collapses every group."
+  },
+  "popupExpandAll": {
+    "message": "सभी विस्तारित करें",
+    "description": "Button that expands every group."
+  },
+
+  "settingsHeading": {
+    "message": "सेटिंग्स",
+    "description": "Heading for the main settings section."
+  },
+  "settingLanguage": {
+    "message": "भाषा",
+    "description": "Label for the UI language picker."
+  },
+  "settingLanguageAuto": {
+    "message": "स्वचालित (ब्राउज़र की डिफ़ॉल्ट)",
+    "description": "Picker option that defers to the browser's UI language."
+  },
+  "settingAutoGroupMode": {
+    "message": "स्वचालित-समूह मोड",
+    "description": "Label for the toggle that enables automatic grouping."
+  },
+  "settingGroupBy": {
+    "message": "इसके अनुसार समूहित करें",
+    "description": "Label for the group-by mode selector."
+  },
+  "settingGroupByRulesOnly": {
+    "message": "केवल नियम",
+    "description": "Option that groups only by custom rules."
+  },
+  "settingGroupByRulesAndDomain": {
+    "message": "नियम और डोमेन",
+    "description": "Option that groups by rules plus base domain (popup)."
+  },
+  "settingGroupByRulesAndSubdomain": {
+    "message": "नियम और उप-डोमेन",
+    "description": "Option that groups by rules plus subdomain (popup)."
+  },
+  "settingGroupByDomain": {
+    "message": "डोमेन",
+    "description": "Option that groups by base domain (sidebar)."
+  },
+  "settingGroupBySubdomain": {
+    "message": "उप-डोमेन",
+    "description": "Option that groups by subdomain (sidebar)."
+  },
+  "settingGroupNewEmptyTabs": {
+    "message": "नए खाली टैब्स को \"System\" के अंतर्गत समूहित करें",
+    "description": "Label for the toggle that groups blank/new tabs under a System group."
+  },
+  "settingMinimumTabsForGroup": {
+    "message": "समूह बनाने के लिए न्यूनतम टैब्स",
+    "description": "Label for the numeric input that sets the minimum tab count required to create a group."
+  },
+  "settingAutoCollapseInactive": {
+    "message": "निष्क्रिय समूहों को स्वचालित रूप से समेटें",
+    "description": "Label for the toggle that auto-collapses groups the user isn't looking at."
+  },
+  "settingCollapseDelay": {
+    "message": "समेटने में विलंब",
+    "description": "Label for the numeric input that sets the auto-collapse delay."
+  },
+  "settingCollapseDelayHelp": {
+    "message": "0 = तुरंत, या समेटने से पहले विलंब सेट करें (100-5000 मिली सेकंड)",
+    "description": "Help text under the collapse-delay input."
+  },
+  "settingOpenNewTabsNextToCurrent": {
+    "message": "नए टैब्स को वर्तमान टैब के बगल में खोलें",
+    "description": "Label for the toggle that opens new tabs adjacent to the active tab."
+  },
+  "settingPinnedTabsNote": {
+    "message": "पिन किए गए टैब्स कभी भी स्वचालित रूप से समूहित नहीं होते",
+    "description": "Informational note about pinned tabs."
+  },
+
+  "sortingSectionTitle": {
+    "message": "क्रमण",
+    "description": "Title for the collapsible sorting section."
+  },
+  "settingSortGroupsAlphabetically": {
+    "message": "समूहों को वर्णानुक्रम में क्रमित रखें",
+    "description": "Toggle that keeps tab groups sorted alphabetically."
+  },
+  "settingSortDirection": {
+    "message": "दिशा",
+    "description": "Label for the sort direction toggle (A-Z vs Z-A)."
+  },
+  "settingSortDirectionAsc": {
+    "message": "A - Z",
+    "description": "Ascending alphabetical sort direction option."
+  },
+  "settingSortDirectionDesc": {
+    "message": "Z - A",
+    "description": "Descending alphabetical sort direction option."
+  },
+  "settingNumberGroups": {
+    "message": "समूहों को क्रमांकित करें (1. AI, 2. Docs...)",
+    "description": "Toggle that prefixes group titles with their sort index."
+  },
+  "settingNumberGroupsHelp": {
+    "message": "त्वरित संदर्भ के लिए समूह शीर्षकों में स्थिति क्रमांक जोड़ता है",
+    "description": "Help text describing the Number Groups toggle."
+  },
+
+  "aiSectionTitle": {
+    "message": "AI सुविधाएँ",
+    "description": "Title for the AI features section."
+  },
+  "aiExperimentalBadge": {
+    "message": "प्रायोगिक",
+    "description": "Badge shown next to the AI Features title."
+  },
+  "aiHelpTooltip": {
+    "message": "AI-संचालित टैब समूहीकरण सुझाव। यह सुविधा प्रायोगिक है। सारी प्रक्रिया आपके ब्राउज़र में स्थानीय रूप से चलती है — कोई डेटा बाहरी सर्वर पर नहीं भेजा जाता।",
+    "description": "Tooltip explaining the AI Features."
+  },
+  "aiBadgeOn": {
+    "message": "चालू",
+    "description": "Status badge shown when AI is enabled."
+  },
+  "aiBadgeOff": {
+    "message": "बंद",
+    "description": "Status badge shown when AI is disabled."
+  },
+  "aiEnable": {
+    "message": "AI सक्षम करें",
+    "description": "Toggle that enables or disables AI features."
+  },
+  "aiModelLabel": {
+    "message": "मॉडल",
+    "description": "Label for the AI model selector."
+  },
+  "aiStatusLabel": {
+    "message": "स्थिति:",
+    "description": "Label for the AI model status."
+  },
+  "aiStatusIdle": {
+    "message": "निष्क्रिय",
+    "description": "AI model status: idle."
+  },
+  "aiStatusReady": {
+    "message": "तैयार",
+    "description": "AI model status: ready."
+  },
+  "aiStatusLoading": {
+    "message": "लोड हो रहा है $progress$%",
+    "description": "AI model status while loading, with a progress percentage.",
+    "placeholders": {
+      "progress": { "content": "$1", "example": "42" }
+    }
+  },
+  "aiStatusError": {
+    "message": "त्रुटि",
+    "description": "AI model status: error."
+  },
+  "aiLoadModel": {
+    "message": "मॉडल लोड करें",
+    "description": "Button that starts loading the AI model."
+  },
+  "aiUnloadModel": {
+    "message": "मॉडल अनलोड करें",
+    "description": "Button that unloads the AI model."
+  },
+  "aiLoadingButton": {
+    "message": "लोड हो रहा है...",
+    "description": "Label shown on the load button while loading."
+  },
+  "aiRetryLoad": {
+    "message": "पुनः लोड करें",
+    "description": "Button shown after an AI model load error."
+  },
+  "aiWebGpuUnavailable": {
+    "message": "WebGPU उपलब्ध नहीं है। AI सुविधाओं के लिए WebGPU समर्थित ब्राउज़र आवश्यक है।",
+    "description": "Warning shown when WebGPU is not supported."
+  },
+  "aiDownloadNote": {
+    "message": "मॉडल आपके ब्राउज़र में स्थानीय रूप से चलते हैं। पहली बार लोड करने पर मॉडल डाउनलोड होता है (~250MB-900MB)।",
+    "description": "Help text beneath the load model button."
+  },
+  "aiSuggestGroups": {
+    "message": "समूह सुझाएँ",
+    "description": "Button that asks the AI to suggest tab groups."
+  },
+  "aiAnalyzing": {
+    "message": "आपके टैब्स का विश्लेषण किया जा रहा है...",
+    "description": "Status text while the AI analyzes open tabs."
+  },
+  "aiNoSuggestions": {
+    "message": "कोई सुझाव नहीं मिला",
+    "description": "Status text shown when the AI returns zero suggestions."
+  },
+  "aiFailedToGetSuggestions": {
+    "message": "सुझाव प्राप्त करने में विफल",
+    "description": "Error shown when AI suggestion fails."
+  },
+  "aiDismiss": {
+    "message": "खारिज करें",
+    "description": "Button that dismisses AI suggestions."
+  },
+  "aiApply": {
+    "message": "लागू करें",
+    "description": "Button that applies an AI suggestion."
+  },
+  "aiApplying": {
+    "message": "लागू कर रहे हैं...",
+    "description": "Button label while applying a suggestion."
+  },
+  "aiApplied": {
+    "message": "लागू कर दिया!",
+    "description": "Button label after applying a suggestion."
+  },
+  "aiFailed": {
+    "message": "विफल",
+    "description": "Button label after a suggestion fails."
+  },
+  "aiCreateRule": {
+    "message": "नियम बनाएँ",
+    "description": "Button that creates a rule from a suggestion."
+  },
+  "aiTabsCount": {
+    "message": "$count$ टैब",
+    "description": "Tab count label for a suggestion.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "plural": { "content": "$2" }
+    }
+  },
+  "aiAppliedWithStale": {
+    "message": "लागू कर दिया ($count$ टैब बंद किए गए)",
+    "description": "Shown when a suggestion is applied but some tabs were closed.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "plural": { "content": "$2" }
+    }
+  },
+  "aiFirefoxNotice": {
+    "message": "AI सुविधाएँ अभी केवल Chrome पर उपलब्ध हैं। Firefox का समर्थन जल्द आ रहा है।",
+    "description": "Notice shown to Firefox users."
+  },
+
+  "rulesSectionTitle": {
+    "message": "कस्टम नियम",
+    "description": "Title for the custom rules section."
+  },
+  "rulesAddNewRule": {
+    "message": "नया नियम जोड़ें",
+    "description": "Button that opens the new rule dialog."
+  },
+  "rulesExport": {
+    "message": "निर्यात",
+    "description": "Button that exports rules to JSON."
+  },
+  "rulesImport": {
+    "message": "आयात",
+    "description": "Button that imports rules from JSON."
+  },
+  "rulesExportTitle": {
+    "message": "सभी नियमों को JSON फ़ाइल में निर्यात करें",
+    "description": "Tooltip on the Export button."
+  },
+  "rulesImportTitle": {
+    "message": "JSON फ़ाइल से नियम आयात करें",
+    "description": "Tooltip on the Import button."
+  },
+  "rulesExportImportHelp": {
+    "message": "बैकअप या साझा करने के लिए नियमों को JSON फ़ाइलों के रूप में निर्यात/आयात करें",
+    "description": "Help text under the export/import buttons."
+  },
+  "rulesEmptyState": {
+    "message": "अभी तक कोई कस्टम नियम नहीं। अपनी पसंद के अनुसार टैब्स को समूहित करने के लिए अपना पहला नियम बनाएँ!",
+    "description": "Shown when there are no custom rules."
+  },
+  "rulesEdit": {
+    "message": "संपादित करें",
+    "description": "Edit button on a rule row."
+  },
+  "rulesDelete": {
+    "message": "हटाएँ",
+    "description": "Delete button on a rule row."
+  },
+  "rulesEditTitle": {
+    "message": "नियम संपादित करें",
+    "description": "Tooltip for the edit button."
+  },
+  "rulesDeleteTitle": {
+    "message": "नियम हटाएँ",
+    "description": "Tooltip for the delete button."
+  },
+  "rulesAddTabTitle": {
+    "message": "टैब को मौजूदा नियम में जोड़ें",
+    "description": "Tooltip for the + button that adds the current tab to a rule."
+  },
+  "rulesDeleteConfirm": {
+    "message": "क्या आप वाकई नियम \"$name$\" हटाना चाहते हैं?",
+    "description": "Confirmation prompt before deleting a rule.",
+    "placeholders": {
+      "name": { "content": "$1" }
+    }
+  },
+  "rulesFailedToLoad": {
+    "message": "कस्टम नियम लोड करने में विफल",
+    "description": "Error when loading rules fails."
+  },
+  "rulesFailedToDelete": {
+    "message": "नियम हटाने में विफल",
+    "description": "Error when deleting a rule fails."
+  },
+  "rulesExportSuccess": {
+    "message": "नियम सफलतापूर्वक निर्यात किए गए!",
+    "description": "Confirmation after exporting rules."
+  },
+  "rulesFailedToExport": {
+    "message": "नियम निर्यात करने में विफल",
+    "description": "Error when export fails."
+  },
+  "rulesImportSuccess": {
+    "message": "नियम सफलतापूर्वक आयात किए गए!",
+    "description": "Confirmation after importing rules."
+  },
+  "rulesImportSummary": {
+    "message": "आयात सफल!\nआयातित: $imported$ नियम\nछोड़े गए: $skipped$ नियम",
+    "description": "Summary shown after rules are imported.",
+    "placeholders": {
+      "imported": { "content": "$1" },
+      "skipped": { "content": "$2" }
+    }
+  },
+  "rulesFailedToImport": {
+    "message": "नियम आयात करने में विफल",
+    "description": "Error when import fails."
+  },
+  "rulesImportReplacePrompt": {
+    "message": "क्या आप सभी मौजूदा नियमों को बदलना चाहते हैं?\n\nसभी मौजूदा नियमों को आयातित नियमों से बदलने के लिए OK पर क्लिक करें\nआयातित नियमों को मौजूदा नियमों के साथ विलय करने के लिए Cancel पर क्लिक करें",
+    "description": "Prompt that asks whether to merge or replace on import."
+  },
+  "rulesNoExport": {
+    "message": "निर्यात के लिए कोई नियम नहीं",
+    "description": "Tooltip shown on a disabled export button when there are no rules."
+  },
+  "rulesNoDomains": {
+    "message": "कोई डोमेन नहीं",
+    "description": "Shown when a rule has no configured domains."
+  },
+  "rulesDomainsSeparator": {
+    "message": " और $count$ अधिक",
+    "description": "Appended to truncated domain lists.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "rulesAddTabNoTab": {
+    "message": "कोई सक्रिय टैब नहीं मिला",
+    "description": "Tooltip shown on the add-tab button when no active tab is available."
+  },
+  "rulesAddTabCantExtract": {
+    "message": "इस टैब से डोमेन नहीं निकाला जा सकता",
+    "description": "Tooltip when the current tab's URL has no domain."
+  },
+  "rulesAddTabAlreadyExists": {
+    "message": "डोमेन पहले से ही इस नियम में है",
+    "description": "Tooltip when the tab's domain is already part of the rule."
+  },
+  "rulesAddTabAdded": {
+    "message": "जोड़ दिया!",
+    "description": "Tooltip shown briefly after adding a tab to a rule."
+  },
+  "rulesAddTabFailed": {
+    "message": "डोमेन जोड़ने में विफल",
+    "description": "Tooltip when adding a domain fails."
+  },
+
+  "blacklistSectionTitle": {
+    "message": "ब्लैकलिस्ट",
+    "description": "Title for the blacklist section."
+  },
+  "blacklistAddButton": {
+    "message": "ब्लैकलिस्ट में जोड़ें",
+    "description": "Button to add a domain to the blacklist."
+  },
+  "blacklistHelp": {
+    "message": "ब्लैकलिस्टेड डोमेन कभी समूहित नहीं होंगे",
+    "description": "Help text under the blacklist section."
+  },
+  "blacklistEmpty": {
+    "message": "अभी तक कोई ब्लैकलिस्टेड डोमेन नहीं।",
+    "description": "Shown when the blacklist is empty."
+  },
+  "blacklistEditTitle": {
+    "message": "ब्लैकलिस्ट नियम संपादित करें",
+    "description": "Tooltip for the blacklist edit button."
+  },
+  "blacklistDeleteTitle": {
+    "message": "ब्लैकलिस्ट नियम हटाएँ",
+    "description": "Tooltip for the blacklist delete button."
+  },
+
+  "advancedSectionTitle": {
+    "message": "उन्नत",
+    "description": "Title for the advanced settings section."
+  },
+  "advancedHideContextMenu": {
+    "message": "राइट-क्लिक कॉन्टेक्स्ट मेनू छिपाएँ",
+    "description": "Toggle that hides the extension's context menu items."
+  },
+  "advancedHideContextMenuHelp": {
+    "message": "सक्षम होने पर, Auto Tab Groups अपने आइटम पेज के राइट-क्लिक मेनू में नहीं जोड़ेगा।",
+    "description": "Help text for the hide context menu toggle."
+  },
+
+  "footerMadeBy": {
+    "message": "द्वारा निर्मित",
+    "description": "Prefix for the author attribution in the footer."
+  },
+  "footerFor": {
+    "message": "के लिए",
+    "description": "Connector text: 'Made by X, for Chrome'."
+  },
+  "footerBrowserChrome": {
+    "message": "Chrome",
+    "description": "Name of the Chrome browser in the footer."
+  },
+  "footerBrowserFirefox": {
+    "message": "Firefox",
+    "description": "Name of the Firefox browser in the footer."
+  },
+  "footerFeedback": {
+    "message": "प्रतिक्रिया, अनुरोध और सहायता",
+    "description": "Text of the feedback link."
+  },
+  "footerVersion": {
+    "message": "संस्करण:",
+    "description": "Prefix before the version number."
+  },
+
+  "contextMenuCreateRuleFromGroup": {
+    "message": "समूह से नियम बनाएँ",
+    "description": "Right-click menu: create a custom rule from the clicked tab's group."
+  },
+  "contextMenuAddTabToExistingRule": {
+    "message": "टैब को मौजूदा नियम में जोड़ें",
+    "description": "Right-click menu: submenu to add the current tab's domain to an existing rule."
+  },
+  "contextMenuAddToBlacklist": {
+    "message": "ब्लैकलिस्ट में जोड़ें",
+    "description": "Right-click menu: add the current tab's domain to the blacklist."
+  },
+  "contextMenuNoRulesYet": {
+    "message": "अभी तक कोई नियम नहीं",
+    "description": "Disabled placeholder shown when the Add Tab submenu has no rules."
+  },
+
+  "ruleModalCreateTitle": {
+    "message": "कस्टम नियम बनाएँ",
+    "description": "Title shown when creating a new rule."
+  },
+  "ruleModalEditTitle": {
+    "message": "कस्टम नियम संपादित करें",
+    "description": "Title shown when editing an existing rule."
+  },
+  "ruleModalNameLabel": {
+    "message": "नियम का नाम",
+    "description": "Label for the rule name input."
+  },
+  "ruleModalNamePlaceholder": {
+    "message": "उदा., कार्य ऐप्स",
+    "description": "Placeholder for the rule name input."
+  },
+  "ruleModalNameHelp": {
+    "message": "चीनी, जापानी, कोरियाई और इमोजी सहित किसी भी भाषा का समर्थन करता है",
+    "description": "Help text under the rule name input."
+  },
+  "ruleModalAiAssistLabel": {
+    "message": "AI सहायक",
+    "description": "Label for the AI assist section."
+  },
+  "ruleModalAiAssistPlaceholder": {
+    "message": "अपने नियम का वर्णन करें, उदा., 'सभी Google सेवाओं को समूहित करें' या 'AWS कंसोल टैब्स को समूहित करें'",
+    "description": "Placeholder for the AI assist input."
+  },
+  "ruleModalAiGenerate": {
+    "message": "उत्पन्न करें",
+    "description": "Button that asks the AI to generate a rule."
+  },
+  "ruleModalAiAssistHelp": {
+    "message": "वर्णन करें कि आप क्या समूहित करना चाहते हैं और AI नाम, डोमेन और रंग सुझाएगा",
+    "description": "Help text under the AI assist input."
+  },
+  "ruleModalPatternModeLabel": {
+    "message": "पैटर्न मोड",
+    "description": "Label for the pattern mode toggle."
+  },
+  "ruleModalPatternModeSimple": {
+    "message": "सरल (डोमेन)",
+    "description": "Simple pattern mode: matches whole domains."
+  },
+  "ruleModalPatternModeExplicit": {
+    "message": "स्पष्ट (पूर्ण URL)",
+    "description": "Explicit pattern mode: matches full URLs."
+  },
+  "ruleModalSimpleModeHint": {
+    "message": "इन आधार डोमेनों के सभी पृष्ठों को समूहित करता है",
+    "description": "Hint shown in simple pattern mode."
+  },
+  "ruleModalExplicitModeHint": {
+    "message": "केवल इन पूर्ण URL पैटर्नों से मेल खाने वाले पृष्ठों को समूहित करता है",
+    "description": "Hint shown in explicit pattern mode."
+  },
+  "ruleModalPatternsLabel": {
+    "message": "URL पैटर्न (प्रति पंक्ति एक)",
+    "description": "Label for the patterns textarea."
+  },
+  "ruleModalPatternsHelp": {
+    "message": "समर्थित है: डोमेन, वाइल्डकार्ड (*.example.com), पथ (example.com/api/*), IP पते",
+    "description": "Help text for the patterns textarea."
+  },
+  "ruleModalColorLabel": {
+    "message": "समूह का रंग",
+    "description": "Label for the color picker."
+  },
+  "ruleModalColorBlue": { "message": "नीला", "description": "Color option: blue." },
+  "ruleModalColorRed": { "message": "लाल", "description": "Color option: red." },
+  "ruleModalColorYellow": { "message": "पीला", "description": "Color option: yellow." },
+  "ruleModalColorGreen": { "message": "हरा", "description": "Color option: green." },
+  "ruleModalColorPink": { "message": "गुलाबी", "description": "Color option: pink." },
+  "ruleModalColorPurple": { "message": "बैंगनी", "description": "Color option: purple." },
+  "ruleModalColorCyan": { "message": "सियान", "description": "Color option: cyan." },
+  "ruleModalColorOrange": { "message": "नारंगी", "description": "Color option: orange." },
+  "ruleModalColorGrey": { "message": "स्लेटी", "description": "Color option: grey." },
+  "ruleModalEnabledLabel": {
+    "message": "सक्षम",
+    "description": "Checkbox: whether the rule is enabled."
+  },
+  "ruleModalSave": {
+    "message": "नियम सहेजें",
+    "description": "Submit button for the rule form."
+  },
+  "ruleModalUpdate": {
+    "message": "नियम अद्यतन करें",
+    "description": "Submit button when editing an existing rule."
+  },
+  "ruleModalCancel": {
+    "message": "रद्द करें",
+    "description": "Cancel button for the rule form."
+  },
+  "ruleModalConflictTitle": {
+    "message": "पैटर्न संघर्ष पाए गए",
+    "description": "Heading of the conflict warning box."
+  },
+  "ruleModalConflictSubtitle": {
+    "message": "ये पैटर्न मौजूदा नियमों के साथ ओवरलैप होते हैं। दोनों नियमों से मेल खाने वाले टैब्स केवल एक को ही सौंपे जाएँगे।",
+    "description": "Subtitle of the conflict warning."
+  },
+  "ruleModalAiSuggestions": {
+    "message": "AI सुझाव",
+    "description": "Heading for the AI-generated resolution suggestions."
+  },
+  "ruleModalSaveAnyway": {
+    "message": "फिर भी सहेजें",
+    "description": "Button that saves the rule despite conflicts."
+  },
+  "ruleModalGoBack": {
+    "message": "वापस जाएँ",
+    "description": "Button that returns to editing after a conflict warning."
+  },
+  "ruleModalChecking": {
+    "message": "जाँच हो रही है...",
+    "description": "Label shown on the save button while checking for conflicts."
+  },
+  "ruleModalGenerating": {
+    "message": "उत्पन्न कर रहे हैं...",
+    "description": "Label shown on the AI generate button while generating a rule."
+  },
+  "ruleModalAiThinking": {
+    "message": "AI सोच रहा है...",
+    "description": "Status text while the AI generates a rule."
+  },
+  "ruleModalAiNeedsModel": {
+    "message": "AI सहायक का उपयोग करने के लिए पॉपअप के AI सुविधाएँ अनुभाग से AI मॉडल लोड करें",
+    "description": "Status shown when AI Assist is invoked but no model is loaded."
+  },
+  "ruleModalAiGenerated": {
+    "message": "नियम उत्पन्न हो गया! नीचे समीक्षा और संपादन करें, फिर सहेजें।",
+    "description": "Status after the AI generates a rule."
+  },
+  "ruleModalAiGenerateError": {
+    "message": "नियम उत्पन्न करने में विफल। अपने विवरण को पुनः लिखने का प्रयास करें।",
+    "description": "Error shown when AI rule generation fails."
+  },
+  "ruleModalAiEnterDescription": {
+    "message": "कृपया एक विवरण दर्ज करें",
+    "description": "Error shown when AI Assist is triggered with no description."
+  },
+  "ruleModalEnterPattern": {
+    "message": "कृपया कम से कम एक URL पैटर्न दर्ज करें",
+    "description": "Alert shown when submitting with no patterns."
+  },
+  "ruleModalEnterName": {
+    "message": "कृपया नियम का नाम दर्ज करें",
+    "description": "Alert shown when submitting a rule with no name."
+  },
+  "ruleModalFailedToLoad": {
+    "message": "संपादन के लिए नियम लोड करने में विफल",
+    "description": "Alert when the rule modal can't load the rule."
+  },
+  "ruleModalFailedToSave": {
+    "message": "नियम सहेजने में विफल",
+    "description": "Alert when saving a rule fails."
+  },
+
+  "importPageTitle": {
+    "message": "नियम आयात करें",
+    "description": "Title for the import rules page."
+  },
+  "importDropInstruction": {
+    "message": "यहाँ JSON फ़ाइल खींचें और छोड़ें",
+    "description": "Instruction shown in the import drop zone."
+  },
+  "importOr": {
+    "message": "या",
+    "description": "Separator between drag-drop and button."
+  },
+  "importBrowseFiles": {
+    "message": "फ़ाइलें ब्राउज़ करें",
+    "description": "Button that opens the file picker."
+  },
+  "importPreviewHeading": {
+    "message": "पूर्वावलोकन",
+    "description": "Heading above the import preview."
+  },
+  "importModeLabel": {
+    "message": "आयात मोड",
+    "description": "Label above the import mode radio buttons."
+  },
+  "importMerge": {
+    "message": "मौजूदा नियमों के साथ विलय करें",
+    "description": "Radio option: merge on import."
+  },
+  "importReplace": {
+    "message": "सभी मौजूदा नियमों को बदलें",
+    "description": "Radio option: replace on import."
+  },
+  "importButton": {
+    "message": "नियम आयात करें",
+    "description": "Button that performs the import."
+  },
+  "importCancel": {
+    "message": "रद्द करें",
+    "description": "Cancel button on the import page."
+  },
+  "importStatValid": {
+    "message": "मान्य नियम",
+    "description": "Label for the valid rule count in the import preview."
+  },
+  "importStatInvalid": {
+    "message": "अमान्य (छोड़े जाएँगे)",
+    "description": "Label for the invalid rule count in the import preview."
+  },
+  "importPatternsSuffix": {
+    "message": "$count$ पैटर्न",
+    "description": "Label showing pattern count for an imported rule.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importMoreRules": {
+    "message": "...और $count$ अधिक नियम",
+    "description": "Shown when more rules exist beyond the preview slice.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importUnnamed": {
+    "message": "अनाम",
+    "description": "Placeholder name for rules with no name."
+  },
+  "importImporting": {
+    "message": "आयात कर रहे हैं...",
+    "description": "Label on the import button while importing."
+  },
+  "importSuccess": {
+    "message": "सफलतापूर्वक $count$ नियम आयात किए गए",
+    "description": "Success message after import.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importSuccessWithSkipped": {
+    "message": "सफलतापूर्वक $count$ नियम आयात किए गए ($skipped$ छोड़े गए)",
+    "description": "Success message when some rules are skipped.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "skipped": { "content": "$2" }
+    }
+  },
+  "importFailed": {
+    "message": "आयात विफल",
+    "description": "Generic import failure message."
+  },
+  "importInvalidJson": {
+    "message": "अमान्य JSON",
+    "description": "Error when file is not valid JSON."
+  },
+  "importInvalidFormat": {
+    "message": "अमान्य फ़ाइल स्वरूप: 'rules' गुण गायब है",
+    "description": "Error when file has no 'rules' key."
+  },
+  "importNoRules": {
+    "message": "फ़ाइल में कोई नियम नहीं मिला",
+    "description": "Error when file has no rules."
+  },
+  "importSelectJson": {
+    "message": "कृपया एक JSON फ़ाइल चुनें",
+    "description": "Error when a non-JSON file is selected."
+  }
+}

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -1,0 +1,748 @@
+{
+  "extensionName": {
+    "message": "Auto Tab Groups",
+    "description": "The name of the extension as it appears in the browser store and toolbar."
+  },
+  "extensionDescription": {
+    "message": "Автоматически группирует вкладки по домену.",
+    "description": "Short description shown in the extensions list."
+  },
+
+  "popupTitle": {
+    "message": "Auto Tab Groups",
+    "description": "Heading shown at the top of the popup/sidebar."
+  },
+  "popupGroupTabs": {
+    "message": "Сгруппировать вкладки",
+    "description": "Button that groups all open tabs immediately."
+  },
+  "popupUngroupAll": {
+    "message": "Разгруппировать всё",
+    "description": "Button that removes every tab group."
+  },
+  "popupGenerateNewColors": {
+    "message": "Сгенерировать новые цвета",
+    "description": "Button that randomizes the colors of all groups."
+  },
+  "popupGenerateNewColorsTitle": {
+    "message": "Случайный выбор цветов групп. Цвета автоматически сохраняются и восстанавливаются для каждого домена или правила.",
+    "description": "Tooltip for the Generate New Colors button."
+  },
+  "popupCollapseAll": {
+    "message": "Свернуть всё",
+    "description": "Button that collapses every group."
+  },
+  "popupExpandAll": {
+    "message": "Развернуть всё",
+    "description": "Button that expands every group."
+  },
+
+  "settingsHeading": {
+    "message": "Настройки",
+    "description": "Heading for the main settings section."
+  },
+  "settingLanguage": {
+    "message": "Язык",
+    "description": "Label for the UI language picker."
+  },
+  "settingLanguageAuto": {
+    "message": "Автоматически (язык браузера)",
+    "description": "Picker option that defers to the browser's UI language."
+  },
+  "settingAutoGroupMode": {
+    "message": "Режим автогруппировки",
+    "description": "Label for the toggle that enables automatic grouping."
+  },
+  "settingGroupBy": {
+    "message": "Группировать по",
+    "description": "Label for the group-by mode selector."
+  },
+  "settingGroupByRulesOnly": {
+    "message": "Только правила",
+    "description": "Option that groups only by custom rules."
+  },
+  "settingGroupByRulesAndDomain": {
+    "message": "Правила и домен",
+    "description": "Option that groups by rules plus base domain (popup)."
+  },
+  "settingGroupByRulesAndSubdomain": {
+    "message": "Правила и поддомен",
+    "description": "Option that groups by rules plus subdomain (popup)."
+  },
+  "settingGroupByDomain": {
+    "message": "Домен",
+    "description": "Option that groups by base domain (sidebar)."
+  },
+  "settingGroupBySubdomain": {
+    "message": "Поддомен",
+    "description": "Option that groups by subdomain (sidebar)."
+  },
+  "settingGroupNewEmptyTabs": {
+    "message": "Группировать новые пустые вкладки в «System»",
+    "description": "Label for the toggle that groups blank/new tabs under a System group."
+  },
+  "settingMinimumTabsForGroup": {
+    "message": "Минимальное число вкладок для создания группы",
+    "description": "Label for the numeric input that sets the minimum tab count required to create a group."
+  },
+  "settingAutoCollapseInactive": {
+    "message": "Автоматически сворачивать неактивные группы",
+    "description": "Label for the toggle that auto-collapses groups the user isn't looking at."
+  },
+  "settingCollapseDelay": {
+    "message": "Задержка сворачивания",
+    "description": "Label for the numeric input that sets the auto-collapse delay."
+  },
+  "settingCollapseDelayHelp": {
+    "message": "0 = немедленно, либо задайте задержку (100–5000 мс) перед сворачиванием",
+    "description": "Help text under the collapse-delay input."
+  },
+  "settingOpenNewTabsNextToCurrent": {
+    "message": "Открывать новые вкладки рядом с текущей",
+    "description": "Label for the toggle that opens new tabs adjacent to the active tab."
+  },
+  "settingPinnedTabsNote": {
+    "message": "Закреплённые вкладки никогда не группируются автоматически",
+    "description": "Informational note about pinned tabs."
+  },
+
+  "sortingSectionTitle": {
+    "message": "Сортировка",
+    "description": "Title for the collapsible sorting section."
+  },
+  "settingSortGroupsAlphabetically": {
+    "message": "Держать группы отсортированными по алфавиту",
+    "description": "Toggle that keeps tab groups sorted alphabetically."
+  },
+  "settingSortDirection": {
+    "message": "Направление",
+    "description": "Label for the sort direction toggle (A-Z vs Z-A)."
+  },
+  "settingSortDirectionAsc": {
+    "message": "A - Z",
+    "description": "Ascending alphabetical sort direction option."
+  },
+  "settingSortDirectionDesc": {
+    "message": "Z - A",
+    "description": "Descending alphabetical sort direction option."
+  },
+  "settingNumberGroups": {
+    "message": "Нумеровать группы (1. AI, 2. Docs...)",
+    "description": "Toggle that prefixes group titles with their sort index."
+  },
+  "settingNumberGroupsHelp": {
+    "message": "Добавляет номера позиций к заголовкам групп для быстрой ориентации",
+    "description": "Help text describing the Number Groups toggle."
+  },
+
+  "aiSectionTitle": {
+    "message": "Функции ИИ",
+    "description": "Title for the AI features section."
+  },
+  "aiExperimentalBadge": {
+    "message": "Экспериментально",
+    "description": "Badge shown next to the AI Features title."
+  },
+  "aiHelpTooltip": {
+    "message": "Предложения группировки вкладок на основе ИИ. Функция экспериментальная. Вся обработка выполняется локально в вашем браузере — данные не отправляются на внешние серверы.",
+    "description": "Tooltip explaining the AI Features."
+  },
+  "aiBadgeOn": {
+    "message": "Вкл",
+    "description": "Status badge shown when AI is enabled."
+  },
+  "aiBadgeOff": {
+    "message": "Выкл",
+    "description": "Status badge shown when AI is disabled."
+  },
+  "aiEnable": {
+    "message": "Включить ИИ",
+    "description": "Toggle that enables or disables AI features."
+  },
+  "aiModelLabel": {
+    "message": "Модель",
+    "description": "Label for the AI model selector."
+  },
+  "aiStatusLabel": {
+    "message": "Статус:",
+    "description": "Label for the AI model status."
+  },
+  "aiStatusIdle": {
+    "message": "Ожидание",
+    "description": "AI model status: idle."
+  },
+  "aiStatusReady": {
+    "message": "Готово",
+    "description": "AI model status: ready."
+  },
+  "aiStatusLoading": {
+    "message": "Загрузка $progress$%",
+    "description": "AI model status while loading, with a progress percentage.",
+    "placeholders": {
+      "progress": { "content": "$1", "example": "42" }
+    }
+  },
+  "aiStatusError": {
+    "message": "Ошибка",
+    "description": "AI model status: error."
+  },
+  "aiLoadModel": {
+    "message": "Загрузить модель",
+    "description": "Button that starts loading the AI model."
+  },
+  "aiUnloadModel": {
+    "message": "Выгрузить модель",
+    "description": "Button that unloads the AI model."
+  },
+  "aiLoadingButton": {
+    "message": "Загрузка...",
+    "description": "Label shown on the load button while loading."
+  },
+  "aiRetryLoad": {
+    "message": "Повторить загрузку",
+    "description": "Button shown after an AI model load error."
+  },
+  "aiWebGpuUnavailable": {
+    "message": "WebGPU недоступен. Функциям ИИ требуется браузер с поддержкой WebGPU.",
+    "description": "Warning shown when WebGPU is not supported."
+  },
+  "aiDownloadNote": {
+    "message": "Модели работают локально в вашем браузере. При первой загрузке скачивается модель (~250МБ–900МБ).",
+    "description": "Help text beneath the load model button."
+  },
+  "aiSuggestGroups": {
+    "message": "Предложить группы",
+    "description": "Button that asks the AI to suggest tab groups."
+  },
+  "aiAnalyzing": {
+    "message": "Анализируем ваши вкладки...",
+    "description": "Status text while the AI analyzes open tabs."
+  },
+  "aiNoSuggestions": {
+    "message": "Предложения не найдены",
+    "description": "Status text shown when the AI returns zero suggestions."
+  },
+  "aiFailedToGetSuggestions": {
+    "message": "Не удалось получить предложения",
+    "description": "Error shown when AI suggestion fails."
+  },
+  "aiDismiss": {
+    "message": "Отклонить",
+    "description": "Button that dismisses AI suggestions."
+  },
+  "aiApply": {
+    "message": "Применить",
+    "description": "Button that applies an AI suggestion."
+  },
+  "aiApplying": {
+    "message": "Применение...",
+    "description": "Button label while applying a suggestion."
+  },
+  "aiApplied": {
+    "message": "Применено!",
+    "description": "Button label after applying a suggestion."
+  },
+  "aiFailed": {
+    "message": "Не удалось",
+    "description": "Button label after a suggestion fails."
+  },
+  "aiCreateRule": {
+    "message": "Создать правило",
+    "description": "Button that creates a rule from a suggestion."
+  },
+  "aiTabsCount": {
+    "message": "$count$ вкладок",
+    "description": "Tab count label for a suggestion.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "plural": { "content": "$2" }
+    }
+  },
+  "aiAppliedWithStale": {
+    "message": "Применено (закрыто $count$ вкладок)",
+    "description": "Shown when a suggestion is applied but some tabs were closed.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "plural": { "content": "$2" }
+    }
+  },
+  "aiFirefoxNotice": {
+    "message": "Функции ИИ сейчас доступны только в Chrome. Поддержка Firefox появится позже.",
+    "description": "Notice shown to Firefox users."
+  },
+
+  "rulesSectionTitle": {
+    "message": "Пользовательские правила",
+    "description": "Title for the custom rules section."
+  },
+  "rulesAddNewRule": {
+    "message": "Добавить правило",
+    "description": "Button that opens the new rule dialog."
+  },
+  "rulesExport": {
+    "message": "Экспорт",
+    "description": "Button that exports rules to JSON."
+  },
+  "rulesImport": {
+    "message": "Импорт",
+    "description": "Button that imports rules from JSON."
+  },
+  "rulesExportTitle": {
+    "message": "Экспортировать все правила в файл JSON",
+    "description": "Tooltip on the Export button."
+  },
+  "rulesImportTitle": {
+    "message": "Импортировать правила из файла JSON",
+    "description": "Tooltip on the Import button."
+  },
+  "rulesExportImportHelp": {
+    "message": "Экспорт/импорт правил в файлах JSON для резервного копирования или обмена",
+    "description": "Help text under the export/import buttons."
+  },
+  "rulesEmptyState": {
+    "message": "Пока нет пользовательских правил. Создайте первое правило, чтобы группировать вкладки по вашим предпочтениям!",
+    "description": "Shown when there are no custom rules."
+  },
+  "rulesEdit": {
+    "message": "Изменить",
+    "description": "Edit button on a rule row."
+  },
+  "rulesDelete": {
+    "message": "Удалить",
+    "description": "Delete button on a rule row."
+  },
+  "rulesEditTitle": {
+    "message": "Изменить правило",
+    "description": "Tooltip for the edit button."
+  },
+  "rulesDeleteTitle": {
+    "message": "Удалить правило",
+    "description": "Tooltip for the delete button."
+  },
+  "rulesAddTabTitle": {
+    "message": "Добавить вкладку в существующее правило",
+    "description": "Tooltip for the + button that adds the current tab to a rule."
+  },
+  "rulesDeleteConfirm": {
+    "message": "Удалить правило «$name$»?",
+    "description": "Confirmation prompt before deleting a rule.",
+    "placeholders": {
+      "name": { "content": "$1" }
+    }
+  },
+  "rulesFailedToLoad": {
+    "message": "Не удалось загрузить пользовательские правила",
+    "description": "Error when loading rules fails."
+  },
+  "rulesFailedToDelete": {
+    "message": "Не удалось удалить правило",
+    "description": "Error when deleting a rule fails."
+  },
+  "rulesExportSuccess": {
+    "message": "Правила успешно экспортированы!",
+    "description": "Confirmation after exporting rules."
+  },
+  "rulesFailedToExport": {
+    "message": "Не удалось экспортировать правила",
+    "description": "Error when export fails."
+  },
+  "rulesImportSuccess": {
+    "message": "Правила успешно импортированы!",
+    "description": "Confirmation after importing rules."
+  },
+  "rulesImportSummary": {
+    "message": "Импорт успешен!\nИмпортировано: $imported$ правил\nПропущено: $skipped$ правил",
+    "description": "Summary shown after rules are imported.",
+    "placeholders": {
+      "imported": { "content": "$1" },
+      "skipped": { "content": "$2" }
+    }
+  },
+  "rulesFailedToImport": {
+    "message": "Не удалось импортировать правила",
+    "description": "Error when import fails."
+  },
+  "rulesImportReplacePrompt": {
+    "message": "Заменить все существующие правила?\n\nНажмите «ОК», чтобы ЗАМЕНИТЬ все существующие правила импортированными\nНажмите «Отмена», чтобы ОБЪЕДИНИТЬ импортированные правила с существующими",
+    "description": "Prompt that asks whether to merge or replace on import."
+  },
+  "rulesNoExport": {
+    "message": "Нет правил для экспорта",
+    "description": "Tooltip shown on a disabled export button when there are no rules."
+  },
+  "rulesNoDomains": {
+    "message": "Нет доменов",
+    "description": "Shown when a rule has no configured domains."
+  },
+  "rulesDomainsSeparator": {
+    "message": " и ещё $count$",
+    "description": "Appended to truncated domain lists.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "rulesAddTabNoTab": {
+    "message": "Активная вкладка не найдена",
+    "description": "Tooltip shown on the add-tab button when no active tab is available."
+  },
+  "rulesAddTabCantExtract": {
+    "message": "Не удаётся извлечь домен из этой вкладки",
+    "description": "Tooltip when the current tab's URL has no domain."
+  },
+  "rulesAddTabAlreadyExists": {
+    "message": "Домен уже есть в этом правиле",
+    "description": "Tooltip when the tab's domain is already part of the rule."
+  },
+  "rulesAddTabAdded": {
+    "message": "Добавлено!",
+    "description": "Tooltip shown briefly after adding a tab to a rule."
+  },
+  "rulesAddTabFailed": {
+    "message": "Не удалось добавить домен",
+    "description": "Tooltip when adding a domain fails."
+  },
+
+  "blacklistSectionTitle": {
+    "message": "Чёрный список",
+    "description": "Title for the blacklist section."
+  },
+  "blacklistAddButton": {
+    "message": "Добавить в чёрный список",
+    "description": "Button to add a domain to the blacklist."
+  },
+  "blacklistHelp": {
+    "message": "Домены из чёрного списка никогда не будут группироваться",
+    "description": "Help text under the blacklist section."
+  },
+  "blacklistEmpty": {
+    "message": "Пока нет доменов в чёрном списке.",
+    "description": "Shown when the blacklist is empty."
+  },
+  "blacklistEditTitle": {
+    "message": "Изменить правило чёрного списка",
+    "description": "Tooltip for the blacklist edit button."
+  },
+  "blacklistDeleteTitle": {
+    "message": "Удалить правило чёрного списка",
+    "description": "Tooltip for the blacklist delete button."
+  },
+
+  "advancedSectionTitle": {
+    "message": "Дополнительно",
+    "description": "Title for the advanced settings section."
+  },
+  "advancedHideContextMenu": {
+    "message": "Скрыть контекстное меню правой кнопкой",
+    "description": "Toggle that hides the extension's context menu items."
+  },
+  "advancedHideContextMenuHelp": {
+    "message": "Если включено, Auto Tab Groups не будет добавлять свои пункты в контекстное меню страницы.",
+    "description": "Help text for the hide context menu toggle."
+  },
+
+  "footerMadeBy": {
+    "message": "Создано",
+    "description": "Prefix for the author attribution in the footer."
+  },
+  "footerFor": {
+    "message": "для",
+    "description": "Connector text: 'Made by X, for Chrome'."
+  },
+  "footerBrowserChrome": {
+    "message": "Chrome",
+    "description": "Name of the Chrome browser in the footer."
+  },
+  "footerBrowserFirefox": {
+    "message": "Firefox",
+    "description": "Name of the Firefox browser in the footer."
+  },
+  "footerFeedback": {
+    "message": "Отзывы, запросы и поддержка",
+    "description": "Text of the feedback link."
+  },
+  "footerVersion": {
+    "message": "Версия:",
+    "description": "Prefix before the version number."
+  },
+
+  "contextMenuCreateRuleFromGroup": {
+    "message": "Создать правило из группы",
+    "description": "Right-click menu: create a custom rule from the clicked tab's group."
+  },
+  "contextMenuAddTabToExistingRule": {
+    "message": "Добавить вкладку в существующее правило",
+    "description": "Right-click menu: submenu to add the current tab's domain to an existing rule."
+  },
+  "contextMenuAddToBlacklist": {
+    "message": "Добавить в чёрный список",
+    "description": "Right-click menu: add the current tab's domain to the blacklist."
+  },
+  "contextMenuNoRulesYet": {
+    "message": "Правил пока нет",
+    "description": "Disabled placeholder shown when the Add Tab submenu has no rules."
+  },
+
+  "ruleModalCreateTitle": {
+    "message": "Создать пользовательское правило",
+    "description": "Title shown when creating a new rule."
+  },
+  "ruleModalEditTitle": {
+    "message": "Изменить пользовательское правило",
+    "description": "Title shown when editing an existing rule."
+  },
+  "ruleModalNameLabel": {
+    "message": "Название правила",
+    "description": "Label for the rule name input."
+  },
+  "ruleModalNamePlaceholder": {
+    "message": "например, Рабочие приложения",
+    "description": "Placeholder for the rule name input."
+  },
+  "ruleModalNameHelp": {
+    "message": "Поддерживает любые языки, включая китайский, японский, корейский и эмодзи",
+    "description": "Help text under the rule name input."
+  },
+  "ruleModalAiAssistLabel": {
+    "message": "Помощь ИИ",
+    "description": "Label for the AI assist section."
+  },
+  "ruleModalAiAssistPlaceholder": {
+    "message": "Опишите ваше правило, например: «Группировать все сервисы Google» или «Группировать вкладки AWS console»",
+    "description": "Placeholder for the AI assist input."
+  },
+  "ruleModalAiGenerate": {
+    "message": "Сгенерировать",
+    "description": "Button that asks the AI to generate a rule."
+  },
+  "ruleModalAiAssistHelp": {
+    "message": "Опишите, что вы хотите сгруппировать, и ИИ предложит название, домены и цвет",
+    "description": "Help text under the AI assist input."
+  },
+  "ruleModalPatternModeLabel": {
+    "message": "Режим шаблонов",
+    "description": "Label for the pattern mode toggle."
+  },
+  "ruleModalPatternModeSimple": {
+    "message": "Простой (домены)",
+    "description": "Simple pattern mode: matches whole domains."
+  },
+  "ruleModalPatternModeExplicit": {
+    "message": "Явный (полные URL)",
+    "description": "Explicit pattern mode: matches full URLs."
+  },
+  "ruleModalSimpleModeHint": {
+    "message": "Группирует все страницы с этих базовых доменов",
+    "description": "Hint shown in simple pattern mode."
+  },
+  "ruleModalExplicitModeHint": {
+    "message": "Группирует только страницы, совпадающие с этими полными шаблонами URL",
+    "description": "Hint shown in explicit pattern mode."
+  },
+  "ruleModalPatternsLabel": {
+    "message": "Шаблоны URL (по одному на строку)",
+    "description": "Label for the patterns textarea."
+  },
+  "ruleModalPatternsHelp": {
+    "message": "Поддерживаются: домены, подстановки (*.example.com), пути (example.com/api/*), IP-адреса",
+    "description": "Help text for the patterns textarea."
+  },
+  "ruleModalColorLabel": {
+    "message": "Цвет группы",
+    "description": "Label for the color picker."
+  },
+  "ruleModalColorBlue": { "message": "Синий", "description": "Color option: blue." },
+  "ruleModalColorRed": { "message": "Красный", "description": "Color option: red." },
+  "ruleModalColorYellow": { "message": "Жёлтый", "description": "Color option: yellow." },
+  "ruleModalColorGreen": { "message": "Зелёный", "description": "Color option: green." },
+  "ruleModalColorPink": { "message": "Розовый", "description": "Color option: pink." },
+  "ruleModalColorPurple": { "message": "Фиолетовый", "description": "Color option: purple." },
+  "ruleModalColorCyan": { "message": "Голубой", "description": "Color option: cyan." },
+  "ruleModalColorOrange": { "message": "Оранжевый", "description": "Color option: orange." },
+  "ruleModalColorGrey": { "message": "Серый", "description": "Color option: grey." },
+  "ruleModalEnabledLabel": {
+    "message": "Включено",
+    "description": "Checkbox: whether the rule is enabled."
+  },
+  "ruleModalSave": {
+    "message": "Сохранить правило",
+    "description": "Submit button for the rule form."
+  },
+  "ruleModalUpdate": {
+    "message": "Обновить правило",
+    "description": "Submit button when editing an existing rule."
+  },
+  "ruleModalCancel": {
+    "message": "Отмена",
+    "description": "Cancel button for the rule form."
+  },
+  "ruleModalConflictTitle": {
+    "message": "Обнаружены конфликты шаблонов",
+    "description": "Heading of the conflict warning box."
+  },
+  "ruleModalConflictSubtitle": {
+    "message": "Эти шаблоны пересекаются с существующими правилами. Вкладки, подходящие обоим правилам, будут отнесены только к одному.",
+    "description": "Subtitle of the conflict warning."
+  },
+  "ruleModalAiSuggestions": {
+    "message": "Предложения ИИ",
+    "description": "Heading for the AI-generated resolution suggestions."
+  },
+  "ruleModalSaveAnyway": {
+    "message": "Сохранить всё равно",
+    "description": "Button that saves the rule despite conflicts."
+  },
+  "ruleModalGoBack": {
+    "message": "Назад",
+    "description": "Button that returns to editing after a conflict warning."
+  },
+  "ruleModalChecking": {
+    "message": "Проверка...",
+    "description": "Label shown on the save button while checking for conflicts."
+  },
+  "ruleModalGenerating": {
+    "message": "Генерация...",
+    "description": "Label shown on the AI generate button while generating a rule."
+  },
+  "ruleModalAiThinking": {
+    "message": "ИИ думает...",
+    "description": "Status text while the AI generates a rule."
+  },
+  "ruleModalAiNeedsModel": {
+    "message": "Загрузите модель ИИ в разделе «Функции ИИ» всплывающего окна, чтобы использовать помощь ИИ",
+    "description": "Status shown when AI Assist is invoked but no model is loaded."
+  },
+  "ruleModalAiGenerated": {
+    "message": "Правило сгенерировано! Проверьте и отредактируйте ниже, затем сохраните.",
+    "description": "Status after the AI generates a rule."
+  },
+  "ruleModalAiGenerateError": {
+    "message": "Не удалось сгенерировать правило. Попробуйте переформулировать описание.",
+    "description": "Error shown when AI rule generation fails."
+  },
+  "ruleModalAiEnterDescription": {
+    "message": "Введите описание",
+    "description": "Error shown when AI Assist is triggered with no description."
+  },
+  "ruleModalEnterPattern": {
+    "message": "Введите хотя бы один шаблон URL",
+    "description": "Alert shown when submitting with no patterns."
+  },
+  "ruleModalEnterName": {
+    "message": "Введите название правила",
+    "description": "Alert shown when submitting a rule with no name."
+  },
+  "ruleModalFailedToLoad": {
+    "message": "Не удалось загрузить правило для редактирования",
+    "description": "Alert when the rule modal can't load the rule."
+  },
+  "ruleModalFailedToSave": {
+    "message": "Не удалось сохранить правило",
+    "description": "Alert when saving a rule fails."
+  },
+
+  "importPageTitle": {
+    "message": "Импорт правил",
+    "description": "Title for the import rules page."
+  },
+  "importDropInstruction": {
+    "message": "Перетащите сюда файл JSON",
+    "description": "Instruction shown in the import drop zone."
+  },
+  "importOr": {
+    "message": "или",
+    "description": "Separator between drag-drop and button."
+  },
+  "importBrowseFiles": {
+    "message": "Выбрать файл",
+    "description": "Button that opens the file picker."
+  },
+  "importPreviewHeading": {
+    "message": "Предпросмотр",
+    "description": "Heading above the import preview."
+  },
+  "importModeLabel": {
+    "message": "Режим импорта",
+    "description": "Label above the import mode radio buttons."
+  },
+  "importMerge": {
+    "message": "Объединить с существующими правилами",
+    "description": "Radio option: merge on import."
+  },
+  "importReplace": {
+    "message": "Заменить все существующие правила",
+    "description": "Radio option: replace on import."
+  },
+  "importButton": {
+    "message": "Импортировать правила",
+    "description": "Button that performs the import."
+  },
+  "importCancel": {
+    "message": "Отмена",
+    "description": "Cancel button on the import page."
+  },
+  "importStatValid": {
+    "message": "Допустимые правила",
+    "description": "Label for the valid rule count in the import preview."
+  },
+  "importStatInvalid": {
+    "message": "Недопустимые (будут пропущены)",
+    "description": "Label for the invalid rule count in the import preview."
+  },
+  "importPatternsSuffix": {
+    "message": "$count$ шаблонов",
+    "description": "Label showing pattern count for an imported rule.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importMoreRules": {
+    "message": "...и ещё $count$ правил",
+    "description": "Shown when more rules exist beyond the preview slice.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importUnnamed": {
+    "message": "Без названия",
+    "description": "Placeholder name for rules with no name."
+  },
+  "importImporting": {
+    "message": "Импорт...",
+    "description": "Label on the import button while importing."
+  },
+  "importSuccess": {
+    "message": "Успешно импортировано $count$ правил",
+    "description": "Success message after import.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importSuccessWithSkipped": {
+    "message": "Успешно импортировано $count$ правил ($skipped$ пропущено)",
+    "description": "Success message when some rules are skipped.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "skipped": { "content": "$2" }
+    }
+  },
+  "importFailed": {
+    "message": "Сбой импорта",
+    "description": "Generic import failure message."
+  },
+  "importInvalidJson": {
+    "message": "Недопустимый JSON",
+    "description": "Error when file is not valid JSON."
+  },
+  "importInvalidFormat": {
+    "message": "Неверный формат файла: отсутствует свойство «rules»",
+    "description": "Error when file has no 'rules' key."
+  },
+  "importNoRules": {
+    "message": "В файле нет правил",
+    "description": "Error when file has no rules."
+  },
+  "importSelectJson": {
+    "message": "Выберите файл JSON",
+    "description": "Error when a non-JSON file is selected."
+  }
+}

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -1,0 +1,748 @@
+{
+  "extensionName": {
+    "message": "Auto Tab Groups",
+    "description": "The name of the extension as it appears in the browser store and toolbar."
+  },
+  "extensionDescription": {
+    "message": "按域名自动分组标签页。",
+    "description": "Short description shown in the extensions list."
+  },
+
+  "popupTitle": {
+    "message": "Auto Tab Groups",
+    "description": "Heading shown at the top of the popup/sidebar."
+  },
+  "popupGroupTabs": {
+    "message": "分组标签页",
+    "description": "Button that groups all open tabs immediately."
+  },
+  "popupUngroupAll": {
+    "message": "取消全部分组",
+    "description": "Button that removes every tab group."
+  },
+  "popupGenerateNewColors": {
+    "message": "生成新颜色",
+    "description": "Button that randomizes the colors of all groups."
+  },
+  "popupGenerateNewColorsTitle": {
+    "message": "随机生成分组颜色。颜色会自动保存并为每个域名/规则恢复。",
+    "description": "Tooltip for the Generate New Colors button."
+  },
+  "popupCollapseAll": {
+    "message": "全部折叠",
+    "description": "Button that collapses every group."
+  },
+  "popupExpandAll": {
+    "message": "全部展开",
+    "description": "Button that expands every group."
+  },
+
+  "settingsHeading": {
+    "message": "设置",
+    "description": "Heading for the main settings section."
+  },
+  "settingLanguage": {
+    "message": "语言",
+    "description": "Label for the UI language picker."
+  },
+  "settingLanguageAuto": {
+    "message": "自动(浏览器默认)",
+    "description": "Picker option that defers to the browser's UI language."
+  },
+  "settingAutoGroupMode": {
+    "message": "自动分组模式",
+    "description": "Label for the toggle that enables automatic grouping."
+  },
+  "settingGroupBy": {
+    "message": "分组方式",
+    "description": "Label for the group-by mode selector."
+  },
+  "settingGroupByRulesOnly": {
+    "message": "仅规则",
+    "description": "Option that groups only by custom rules."
+  },
+  "settingGroupByRulesAndDomain": {
+    "message": "规则和域名",
+    "description": "Option that groups by rules plus base domain (popup)."
+  },
+  "settingGroupByRulesAndSubdomain": {
+    "message": "规则和子域名",
+    "description": "Option that groups by rules plus subdomain (popup)."
+  },
+  "settingGroupByDomain": {
+    "message": "域名",
+    "description": "Option that groups by base domain (sidebar)."
+  },
+  "settingGroupBySubdomain": {
+    "message": "子域名",
+    "description": "Option that groups by subdomain (sidebar)."
+  },
+  "settingGroupNewEmptyTabs": {
+    "message": "将新的空白标签页归入“System”",
+    "description": "Label for the toggle that groups blank/new tabs under a System group."
+  },
+  "settingMinimumTabsForGroup": {
+    "message": "形成分组所需的最少标签页数",
+    "description": "Label for the numeric input that sets the minimum tab count required to create a group."
+  },
+  "settingAutoCollapseInactive": {
+    "message": "自动折叠非活动分组",
+    "description": "Label for the toggle that auto-collapses groups the user isn't looking at."
+  },
+  "settingCollapseDelay": {
+    "message": "折叠延迟",
+    "description": "Label for the numeric input that sets the auto-collapse delay."
+  },
+  "settingCollapseDelayHelp": {
+    "message": "0 = 立即,或设置折叠前的延迟 (100-5000 毫秒)",
+    "description": "Help text under the collapse-delay input."
+  },
+  "settingOpenNewTabsNextToCurrent": {
+    "message": "在当前标签页旁打开新标签页",
+    "description": "Label for the toggle that opens new tabs adjacent to the active tab."
+  },
+  "settingPinnedTabsNote": {
+    "message": "固定的标签页永远不会被自动分组",
+    "description": "Informational note about pinned tabs."
+  },
+
+  "sortingSectionTitle": {
+    "message": "排序",
+    "description": "Title for the collapsible sorting section."
+  },
+  "settingSortGroupsAlphabetically": {
+    "message": "按字母顺序保持分组排序",
+    "description": "Toggle that keeps tab groups sorted alphabetically."
+  },
+  "settingSortDirection": {
+    "message": "方向",
+    "description": "Label for the sort direction toggle (A-Z vs Z-A)."
+  },
+  "settingSortDirectionAsc": {
+    "message": "A - Z",
+    "description": "Ascending alphabetical sort direction option."
+  },
+  "settingSortDirectionDesc": {
+    "message": "Z - A",
+    "description": "Descending alphabetical sort direction option."
+  },
+  "settingNumberGroups": {
+    "message": "为分组编号 (1. AI, 2. Docs...)",
+    "description": "Toggle that prefixes group titles with their sort index."
+  },
+  "settingNumberGroupsHelp": {
+    "message": "为分组标题添加位置编号,便于快速引用",
+    "description": "Help text describing the Number Groups toggle."
+  },
+
+  "aiSectionTitle": {
+    "message": "AI 功能",
+    "description": "Title for the AI features section."
+  },
+  "aiExperimentalBadge": {
+    "message": "实验性",
+    "description": "Badge shown next to the AI Features title."
+  },
+  "aiHelpTooltip": {
+    "message": "由 AI 提供的标签页分组建议。此功能为实验性功能。所有处理都在您的浏览器本地运行 — 不会向外部服务器发送任何数据。",
+    "description": "Tooltip explaining the AI Features."
+  },
+  "aiBadgeOn": {
+    "message": "开",
+    "description": "Status badge shown when AI is enabled."
+  },
+  "aiBadgeOff": {
+    "message": "关",
+    "description": "Status badge shown when AI is disabled."
+  },
+  "aiEnable": {
+    "message": "启用 AI",
+    "description": "Toggle that enables or disables AI features."
+  },
+  "aiModelLabel": {
+    "message": "模型",
+    "description": "Label for the AI model selector."
+  },
+  "aiStatusLabel": {
+    "message": "状态:",
+    "description": "Label for the AI model status."
+  },
+  "aiStatusIdle": {
+    "message": "空闲",
+    "description": "AI model status: idle."
+  },
+  "aiStatusReady": {
+    "message": "就绪",
+    "description": "AI model status: ready."
+  },
+  "aiStatusLoading": {
+    "message": "加载中 $progress$%",
+    "description": "AI model status while loading, with a progress percentage.",
+    "placeholders": {
+      "progress": { "content": "$1", "example": "42" }
+    }
+  },
+  "aiStatusError": {
+    "message": "错误",
+    "description": "AI model status: error."
+  },
+  "aiLoadModel": {
+    "message": "加载模型",
+    "description": "Button that starts loading the AI model."
+  },
+  "aiUnloadModel": {
+    "message": "卸载模型",
+    "description": "Button that unloads the AI model."
+  },
+  "aiLoadingButton": {
+    "message": "加载中...",
+    "description": "Label shown on the load button while loading."
+  },
+  "aiRetryLoad": {
+    "message": "重试加载",
+    "description": "Button shown after an AI model load error."
+  },
+  "aiWebGpuUnavailable": {
+    "message": "WebGPU 不可用。AI 功能需要支持 WebGPU 的浏览器。",
+    "description": "Warning shown when WebGPU is not supported."
+  },
+  "aiDownloadNote": {
+    "message": "模型在您的浏览器本地运行。首次加载将下载模型 (约 250MB-900MB)。",
+    "description": "Help text beneath the load model button."
+  },
+  "aiSuggestGroups": {
+    "message": "建议分组",
+    "description": "Button that asks the AI to suggest tab groups."
+  },
+  "aiAnalyzing": {
+    "message": "正在分析您的标签页...",
+    "description": "Status text while the AI analyzes open tabs."
+  },
+  "aiNoSuggestions": {
+    "message": "未找到建议",
+    "description": "Status text shown when the AI returns zero suggestions."
+  },
+  "aiFailedToGetSuggestions": {
+    "message": "获取建议失败",
+    "description": "Error shown when AI suggestion fails."
+  },
+  "aiDismiss": {
+    "message": "忽略",
+    "description": "Button that dismisses AI suggestions."
+  },
+  "aiApply": {
+    "message": "应用",
+    "description": "Button that applies an AI suggestion."
+  },
+  "aiApplying": {
+    "message": "应用中...",
+    "description": "Button label while applying a suggestion."
+  },
+  "aiApplied": {
+    "message": "已应用!",
+    "description": "Button label after applying a suggestion."
+  },
+  "aiFailed": {
+    "message": "失败",
+    "description": "Button label after a suggestion fails."
+  },
+  "aiCreateRule": {
+    "message": "创建规则",
+    "description": "Button that creates a rule from a suggestion."
+  },
+  "aiTabsCount": {
+    "message": "$count$ 个标签页",
+    "description": "Tab count label for a suggestion.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "plural": { "content": "$2" }
+    }
+  },
+  "aiAppliedWithStale": {
+    "message": "已应用 ($count$ 个标签页已关闭)",
+    "description": "Shown when a suggestion is applied but some tabs were closed.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "plural": { "content": "$2" }
+    }
+  },
+  "aiFirefoxNotice": {
+    "message": "AI 功能目前仅在 Chrome 中可用。Firefox 支持即将推出。",
+    "description": "Notice shown to Firefox users."
+  },
+
+  "rulesSectionTitle": {
+    "message": "自定义规则",
+    "description": "Title for the custom rules section."
+  },
+  "rulesAddNewRule": {
+    "message": "添加新规则",
+    "description": "Button that opens the new rule dialog."
+  },
+  "rulesExport": {
+    "message": "导出",
+    "description": "Button that exports rules to JSON."
+  },
+  "rulesImport": {
+    "message": "导入",
+    "description": "Button that imports rules from JSON."
+  },
+  "rulesExportTitle": {
+    "message": "将所有规则导出为 JSON 文件",
+    "description": "Tooltip on the Export button."
+  },
+  "rulesImportTitle": {
+    "message": "从 JSON 文件导入规则",
+    "description": "Tooltip on the Import button."
+  },
+  "rulesExportImportHelp": {
+    "message": "以 JSON 文件的形式导出/导入规则,用于备份或分享",
+    "description": "Help text under the export/import buttons."
+  },
+  "rulesEmptyState": {
+    "message": "尚无自定义规则。创建您的第一条规则以按偏好对标签页进行分组!",
+    "description": "Shown when there are no custom rules."
+  },
+  "rulesEdit": {
+    "message": "编辑",
+    "description": "Edit button on a rule row."
+  },
+  "rulesDelete": {
+    "message": "删除",
+    "description": "Delete button on a rule row."
+  },
+  "rulesEditTitle": {
+    "message": "编辑规则",
+    "description": "Tooltip for the edit button."
+  },
+  "rulesDeleteTitle": {
+    "message": "删除规则",
+    "description": "Tooltip for the delete button."
+  },
+  "rulesAddTabTitle": {
+    "message": "将标签页添加到现有规则",
+    "description": "Tooltip for the + button that adds the current tab to a rule."
+  },
+  "rulesDeleteConfirm": {
+    "message": "确定要删除规则“$name$”吗?",
+    "description": "Confirmation prompt before deleting a rule.",
+    "placeholders": {
+      "name": { "content": "$1" }
+    }
+  },
+  "rulesFailedToLoad": {
+    "message": "加载自定义规则失败",
+    "description": "Error when loading rules fails."
+  },
+  "rulesFailedToDelete": {
+    "message": "删除规则失败",
+    "description": "Error when deleting a rule fails."
+  },
+  "rulesExportSuccess": {
+    "message": "规则导出成功!",
+    "description": "Confirmation after exporting rules."
+  },
+  "rulesFailedToExport": {
+    "message": "导出规则失败",
+    "description": "Error when export fails."
+  },
+  "rulesImportSuccess": {
+    "message": "规则导入成功!",
+    "description": "Confirmation after importing rules."
+  },
+  "rulesImportSummary": {
+    "message": "导入成功!\n已导入: $imported$ 条规则\n已跳过: $skipped$ 条规则",
+    "description": "Summary shown after rules are imported.",
+    "placeholders": {
+      "imported": { "content": "$1" },
+      "skipped": { "content": "$2" }
+    }
+  },
+  "rulesFailedToImport": {
+    "message": "导入规则失败",
+    "description": "Error when import fails."
+  },
+  "rulesImportReplacePrompt": {
+    "message": "是否要替换所有现有规则?\n\n点击“确定”以导入的规则替换所有现有规则\n点击“取消”将导入的规则与现有规则合并",
+    "description": "Prompt that asks whether to merge or replace on import."
+  },
+  "rulesNoExport": {
+    "message": "没有可导出的规则",
+    "description": "Tooltip shown on a disabled export button when there are no rules."
+  },
+  "rulesNoDomains": {
+    "message": "无域名",
+    "description": "Shown when a rule has no configured domains."
+  },
+  "rulesDomainsSeparator": {
+    "message": " 还有另外 $count$ 个",
+    "description": "Appended to truncated domain lists.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "rulesAddTabNoTab": {
+    "message": "未找到活动标签页",
+    "description": "Tooltip shown on the add-tab button when no active tab is available."
+  },
+  "rulesAddTabCantExtract": {
+    "message": "无法从此标签页中提取域名",
+    "description": "Tooltip when the current tab's URL has no domain."
+  },
+  "rulesAddTabAlreadyExists": {
+    "message": "此规则中已存在该域名",
+    "description": "Tooltip when the tab's domain is already part of the rule."
+  },
+  "rulesAddTabAdded": {
+    "message": "已添加!",
+    "description": "Tooltip shown briefly after adding a tab to a rule."
+  },
+  "rulesAddTabFailed": {
+    "message": "添加域名失败",
+    "description": "Tooltip when adding a domain fails."
+  },
+
+  "blacklistSectionTitle": {
+    "message": "黑名单",
+    "description": "Title for the blacklist section."
+  },
+  "blacklistAddButton": {
+    "message": "添加到黑名单",
+    "description": "Button to add a domain to the blacklist."
+  },
+  "blacklistHelp": {
+    "message": "黑名单中的域名永远不会被分组",
+    "description": "Help text under the blacklist section."
+  },
+  "blacklistEmpty": {
+    "message": "尚无黑名单域名。",
+    "description": "Shown when the blacklist is empty."
+  },
+  "blacklistEditTitle": {
+    "message": "编辑黑名单规则",
+    "description": "Tooltip for the blacklist edit button."
+  },
+  "blacklistDeleteTitle": {
+    "message": "删除黑名单规则",
+    "description": "Tooltip for the blacklist delete button."
+  },
+
+  "advancedSectionTitle": {
+    "message": "高级",
+    "description": "Title for the advanced settings section."
+  },
+  "advancedHideContextMenu": {
+    "message": "隐藏右键上下文菜单",
+    "description": "Toggle that hides the extension's context menu items."
+  },
+  "advancedHideContextMenuHelp": {
+    "message": "启用后,Auto Tab Groups 将不会把其选项添加到页面右键菜单中。",
+    "description": "Help text for the hide context menu toggle."
+  },
+
+  "footerMadeBy": {
+    "message": "作者",
+    "description": "Prefix for the author attribution in the footer."
+  },
+  "footerFor": {
+    "message": "适用于",
+    "description": "Connector text: 'Made by X, for Chrome'."
+  },
+  "footerBrowserChrome": {
+    "message": "Chrome",
+    "description": "Name of the Chrome browser in the footer."
+  },
+  "footerBrowserFirefox": {
+    "message": "Firefox",
+    "description": "Name of the Firefox browser in the footer."
+  },
+  "footerFeedback": {
+    "message": "反馈与请求与支持",
+    "description": "Text of the feedback link."
+  },
+  "footerVersion": {
+    "message": "版本:",
+    "description": "Prefix before the version number."
+  },
+
+  "contextMenuCreateRuleFromGroup": {
+    "message": "从分组创建规则",
+    "description": "Right-click menu: create a custom rule from the clicked tab's group."
+  },
+  "contextMenuAddTabToExistingRule": {
+    "message": "将标签页添加到现有规则",
+    "description": "Right-click menu: submenu to add the current tab's domain to an existing rule."
+  },
+  "contextMenuAddToBlacklist": {
+    "message": "添加到黑名单",
+    "description": "Right-click menu: add the current tab's domain to the blacklist."
+  },
+  "contextMenuNoRulesYet": {
+    "message": "尚无规则",
+    "description": "Disabled placeholder shown when the Add Tab submenu has no rules."
+  },
+
+  "ruleModalCreateTitle": {
+    "message": "创建自定义规则",
+    "description": "Title shown when creating a new rule."
+  },
+  "ruleModalEditTitle": {
+    "message": "编辑自定义规则",
+    "description": "Title shown when editing an existing rule."
+  },
+  "ruleModalNameLabel": {
+    "message": "规则名称",
+    "description": "Label for the rule name input."
+  },
+  "ruleModalNamePlaceholder": {
+    "message": "例如:工作应用",
+    "description": "Placeholder for the rule name input."
+  },
+  "ruleModalNameHelp": {
+    "message": "支持任何语言,包括中文、日文、韩文和表情符号",
+    "description": "Help text under the rule name input."
+  },
+  "ruleModalAiAssistLabel": {
+    "message": "AI 辅助",
+    "description": "Label for the AI assist section."
+  },
+  "ruleModalAiAssistPlaceholder": {
+    "message": "描述您的规则,例如:“分组所有 Google 服务”或“分组 AWS 控制台标签页”",
+    "description": "Placeholder for the AI assist input."
+  },
+  "ruleModalAiGenerate": {
+    "message": "生成",
+    "description": "Button that asks the AI to generate a rule."
+  },
+  "ruleModalAiAssistHelp": {
+    "message": "描述您想要分组的内容,AI 将建议名称、域名和颜色",
+    "description": "Help text under the AI assist input."
+  },
+  "ruleModalPatternModeLabel": {
+    "message": "模式匹配",
+    "description": "Label for the pattern mode toggle."
+  },
+  "ruleModalPatternModeSimple": {
+    "message": "简单 (域名)",
+    "description": "Simple pattern mode: matches whole domains."
+  },
+  "ruleModalPatternModeExplicit": {
+    "message": "精确 (完整 URL)",
+    "description": "Explicit pattern mode: matches full URLs."
+  },
+  "ruleModalSimpleModeHint": {
+    "message": "分组来自这些基础域名的所有页面",
+    "description": "Hint shown in simple pattern mode."
+  },
+  "ruleModalExplicitModeHint": {
+    "message": "仅分组匹配这些完整 URL 模式的页面",
+    "description": "Hint shown in explicit pattern mode."
+  },
+  "ruleModalPatternsLabel": {
+    "message": "URL 模式 (每行一个)",
+    "description": "Label for the patterns textarea."
+  },
+  "ruleModalPatternsHelp": {
+    "message": "支持:域名、通配符 (*.example.com)、路径 (example.com/api/*)、IP 地址",
+    "description": "Help text for the patterns textarea."
+  },
+  "ruleModalColorLabel": {
+    "message": "分组颜色",
+    "description": "Label for the color picker."
+  },
+  "ruleModalColorBlue": { "message": "蓝色", "description": "Color option: blue." },
+  "ruleModalColorRed": { "message": "红色", "description": "Color option: red." },
+  "ruleModalColorYellow": { "message": "黄色", "description": "Color option: yellow." },
+  "ruleModalColorGreen": { "message": "绿色", "description": "Color option: green." },
+  "ruleModalColorPink": { "message": "粉色", "description": "Color option: pink." },
+  "ruleModalColorPurple": { "message": "紫色", "description": "Color option: purple." },
+  "ruleModalColorCyan": { "message": "青色", "description": "Color option: cyan." },
+  "ruleModalColorOrange": { "message": "橙色", "description": "Color option: orange." },
+  "ruleModalColorGrey": { "message": "灰色", "description": "Color option: grey." },
+  "ruleModalEnabledLabel": {
+    "message": "已启用",
+    "description": "Checkbox: whether the rule is enabled."
+  },
+  "ruleModalSave": {
+    "message": "保存规则",
+    "description": "Submit button for the rule form."
+  },
+  "ruleModalUpdate": {
+    "message": "更新规则",
+    "description": "Submit button when editing an existing rule."
+  },
+  "ruleModalCancel": {
+    "message": "取消",
+    "description": "Cancel button for the rule form."
+  },
+  "ruleModalConflictTitle": {
+    "message": "检测到模式冲突",
+    "description": "Heading of the conflict warning box."
+  },
+  "ruleModalConflictSubtitle": {
+    "message": "这些模式与现有规则重叠。同时匹配两条规则的标签页将只被分配给其中一条。",
+    "description": "Subtitle of the conflict warning."
+  },
+  "ruleModalAiSuggestions": {
+    "message": "AI 建议",
+    "description": "Heading for the AI-generated resolution suggestions."
+  },
+  "ruleModalSaveAnyway": {
+    "message": "仍要保存",
+    "description": "Button that saves the rule despite conflicts."
+  },
+  "ruleModalGoBack": {
+    "message": "返回",
+    "description": "Button that returns to editing after a conflict warning."
+  },
+  "ruleModalChecking": {
+    "message": "检查中...",
+    "description": "Label shown on the save button while checking for conflicts."
+  },
+  "ruleModalGenerating": {
+    "message": "生成中...",
+    "description": "Label shown on the AI generate button while generating a rule."
+  },
+  "ruleModalAiThinking": {
+    "message": "AI 正在思考...",
+    "description": "Status text while the AI generates a rule."
+  },
+  "ruleModalAiNeedsModel": {
+    "message": "请从弹出窗口的 AI 功能部分加载 AI 模型以使用 AI 辅助",
+    "description": "Status shown when AI Assist is invoked but no model is loaded."
+  },
+  "ruleModalAiGenerated": {
+    "message": "规则已生成!请在下方查看和编辑,然后保存。",
+    "description": "Status after the AI generates a rule."
+  },
+  "ruleModalAiGenerateError": {
+    "message": "生成规则失败。请尝试重新表述您的描述。",
+    "description": "Error shown when AI rule generation fails."
+  },
+  "ruleModalAiEnterDescription": {
+    "message": "请输入描述",
+    "description": "Error shown when AI Assist is triggered with no description."
+  },
+  "ruleModalEnterPattern": {
+    "message": "请至少输入一个 URL 模式",
+    "description": "Alert shown when submitting with no patterns."
+  },
+  "ruleModalEnterName": {
+    "message": "请输入规则名称",
+    "description": "Alert shown when submitting a rule with no name."
+  },
+  "ruleModalFailedToLoad": {
+    "message": "加载要编辑的规则失败",
+    "description": "Alert when the rule modal can't load the rule."
+  },
+  "ruleModalFailedToSave": {
+    "message": "保存规则失败",
+    "description": "Alert when saving a rule fails."
+  },
+
+  "importPageTitle": {
+    "message": "导入规则",
+    "description": "Title for the import rules page."
+  },
+  "importDropInstruction": {
+    "message": "将 JSON 文件拖放到此处",
+    "description": "Instruction shown in the import drop zone."
+  },
+  "importOr": {
+    "message": "或",
+    "description": "Separator between drag-drop and button."
+  },
+  "importBrowseFiles": {
+    "message": "浏览文件",
+    "description": "Button that opens the file picker."
+  },
+  "importPreviewHeading": {
+    "message": "预览",
+    "description": "Heading above the import preview."
+  },
+  "importModeLabel": {
+    "message": "导入模式",
+    "description": "Label above the import mode radio buttons."
+  },
+  "importMerge": {
+    "message": "与现有规则合并",
+    "description": "Radio option: merge on import."
+  },
+  "importReplace": {
+    "message": "替换所有现有规则",
+    "description": "Radio option: replace on import."
+  },
+  "importButton": {
+    "message": "导入规则",
+    "description": "Button that performs the import."
+  },
+  "importCancel": {
+    "message": "取消",
+    "description": "Cancel button on the import page."
+  },
+  "importStatValid": {
+    "message": "有效规则",
+    "description": "Label for the valid rule count in the import preview."
+  },
+  "importStatInvalid": {
+    "message": "无效 (将被跳过)",
+    "description": "Label for the invalid rule count in the import preview."
+  },
+  "importPatternsSuffix": {
+    "message": "$count$ 个模式",
+    "description": "Label showing pattern count for an imported rule.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importMoreRules": {
+    "message": "...还有另外 $count$ 条规则",
+    "description": "Shown when more rules exist beyond the preview slice.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importUnnamed": {
+    "message": "未命名",
+    "description": "Placeholder name for rules with no name."
+  },
+  "importImporting": {
+    "message": "导入中...",
+    "description": "Label on the import button while importing."
+  },
+  "importSuccess": {
+    "message": "成功导入 $count$ 条规则",
+    "description": "Success message after import.",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "importSuccessWithSkipped": {
+    "message": "成功导入 $count$ 条规则 ($skipped$ 条已跳过)",
+    "description": "Success message when some rules are skipped.",
+    "placeholders": {
+      "count": { "content": "$1" },
+      "skipped": { "content": "$2" }
+    }
+  },
+  "importFailed": {
+    "message": "导入失败",
+    "description": "Generic import failure message."
+  },
+  "importInvalidJson": {
+    "message": "无效的 JSON",
+    "description": "Error when file is not valid JSON."
+  },
+  "importInvalidFormat": {
+    "message": "文件格式无效:缺少“rules”属性",
+    "description": "Error when file has no 'rules' key."
+  },
+  "importNoRules": {
+    "message": "文件中未找到规则",
+    "description": "Error when file has no rules."
+  },
+  "importSelectJson": {
+    "message": "请选择一个 JSON 文件",
+    "description": "Error when a non-JSON file is selected."
+  }
+}

--- a/services/ContextMenuService.ts
+++ b/services/ContextMenuService.ts
@@ -6,6 +6,7 @@
 import type { Browser } from "wxt/browser"
 import type { CustomRule, TabGroupColor } from "../types"
 import { extractDomain } from "../utils/DomainUtils"
+import { t } from "../utils/i18n"
 import { rulesService } from "./RulesService"
 import { tabGroupService } from "./TabGroupService"
 import { tabGroupState } from "./TabGroupState"
@@ -49,6 +50,8 @@ class ContextMenuService {
   private readonly MENU_ID_ADD_TO_BLACKLIST = "add-to-blacklist"
   private readonly MENU_ID_NO_RULES = "add-to-rule-none"
   private initialized = false
+  private menusCreated = false
+  private listenerAttached = false
   /** Track current sub-menu rule IDs for cleanup */
   private currentRuleMenuIds: string[] = []
 
@@ -63,42 +66,77 @@ class ContextMenuService {
     }
 
     try {
-      // Remove any existing menu items first (in case of reload)
-      await browser.contextMenus.removeAll()
+      // Listener is attached once and persists for the service worker lifetime;
+      // visibility is controlled by creating/removing the menu items themselves.
+      if (!this.listenerAttached) {
+        browser.contextMenus.onClicked.addListener(this.handleMenuClick.bind(this))
+        this.listenerAttached = true
+      }
 
-      const contexts = this.getContextTypes()
-
-      // Create "Create Rule from Group" menu item
-      await browser.contextMenus.create({
-        id: this.MENU_ID_CREATE_RULE,
-        title: "Create Rule from Group",
-        contexts
-      })
-
-      // Create "Add Tab to Existing Rule" parent menu item
-      await browser.contextMenus.create({
-        id: this.MENU_ID_ADD_TO_RULE_PARENT,
-        title: "Add Tab to Existing Rule",
-        contexts
-      })
-
-      // Create "Add to Blacklist" menu item
-      await browser.contextMenus.create({
-        id: this.MENU_ID_ADD_TO_BLACKLIST,
-        title: "Add to Blacklist",
-        contexts
-      })
-
-      // Populate rule sub-menu items
-      await this.refreshRuleSubMenuItems()
-
-      // Listen for menu clicks
-      browser.contextMenus.onClicked.addListener(this.handleMenuClick.bind(this))
+      if (tabGroupState.hideContextMenu) {
+        // Ensure no stale items remain from a previous session
+        await browser.contextMenus.removeAll()
+        this.menusCreated = false
+        this.currentRuleMenuIds = []
+        console.log("[ContextMenuService] Context menus hidden by user setting")
+      } else {
+        await this.createMenus()
+      }
 
       this.initialized = true
-      console.log("[ContextMenuService] Initialized context menus")
     } catch (error) {
       console.error("[ContextMenuService] Failed to initialize:", error)
+    }
+  }
+
+  /**
+   * Creates the top-level context menu items and populates rule sub-menu.
+   * Safe to call repeatedly — removes any existing items first.
+   */
+  private async createMenus(): Promise<void> {
+    await browser.contextMenus.removeAll()
+    this.currentRuleMenuIds = []
+
+    const contexts = this.getContextTypes()
+
+    await browser.contextMenus.create({
+      id: this.MENU_ID_CREATE_RULE,
+      title: t("contextMenuCreateRuleFromGroup", "Create Rule from Group"),
+      contexts
+    })
+
+    await browser.contextMenus.create({
+      id: this.MENU_ID_ADD_TO_RULE_PARENT,
+      title: t("contextMenuAddTabToExistingRule", "Add Tab to Existing Rule"),
+      contexts
+    })
+
+    await browser.contextMenus.create({
+      id: this.MENU_ID_ADD_TO_BLACKLIST,
+      title: t("contextMenuAddToBlacklist", "Add to Blacklist"),
+      contexts
+    })
+
+    await this.refreshRuleSubMenuItems()
+
+    this.menusCreated = true
+    console.log("[ContextMenuService] Context menus created")
+  }
+
+  /**
+   * Applies the current `hideContextMenu` setting — creates or removes
+   * all menu items. Called when the user toggles the setting.
+   */
+  async applyVisibility(): Promise<void> {
+    if (tabGroupState.hideContextMenu) {
+      if (this.menusCreated) {
+        await browser.contextMenus.removeAll()
+        this.menusCreated = false
+        this.currentRuleMenuIds = []
+        console.log("[ContextMenuService] Context menus removed (hidden)")
+      }
+    } else if (!this.menusCreated) {
+      await this.createMenus()
     }
   }
 
@@ -123,6 +161,9 @@ class ContextMenuService {
    * Call this after any rule add/update/delete to keep the menu in sync
    */
   async refreshRuleSubMenuItems(): Promise<void> {
+    // If menus are hidden, there's nothing to refresh
+    if (!this.menusCreated) return
+
     // Remove old sub-menu items
     for (const menuId of this.currentRuleMenuIds) {
       try {
@@ -143,7 +184,7 @@ class ContextMenuService {
       await browser.contextMenus.create({
         id: this.MENU_ID_NO_RULES,
         parentId: this.MENU_ID_ADD_TO_RULE_PARENT,
-        title: "No rules yet",
+        title: t("contextMenuNoRulesYet", "No rules yet"),
         enabled: false,
         contexts: this.getContextTypes()
       })

--- a/services/ContextMenuService.ts
+++ b/services/ContextMenuService.ts
@@ -141,6 +141,20 @@ class ContextMenuService {
   }
 
   /**
+   * Destroys and recreates all menu items so their titles pick up the
+   * current locale. No-op when menus are hidden.
+   */
+  async rebuildMenus(): Promise<void> {
+    if (tabGroupState.hideContextMenu) return
+    if (this.menusCreated) {
+      await browser.contextMenus.removeAll()
+      this.menusCreated = false
+      this.currentRuleMenuIds = []
+    }
+    await this.createMenus()
+  }
+
+  /**
    * Returns the appropriate context types based on browser
    * Firefox supports "tab" context (tab strip); Chrome does not
    * Uses type assertion because WXT types are Chrome-based and don't include "tab"

--- a/services/TabGroupState.ts
+++ b/services/TabGroupState.ts
@@ -9,7 +9,8 @@ import type {
   GroupByMode,
   RuleMatchingMode,
   SortDirection,
-  StorageSchema
+  StorageSchema,
+  UserLocale
 } from "../types"
 import { DEFAULT_STATE } from "../types/storage"
 
@@ -27,6 +28,7 @@ class TabGroupState {
   sortGroupsDirection: SortDirection
   indexGroupTitles: boolean
   hideContextMenu: boolean
+  userLocale: UserLocale
 
   constructor() {
     this.autoGroupingEnabled = DEFAULT_STATE.autoGroupingEnabled
@@ -42,6 +44,7 @@ class TabGroupState {
     this.sortGroupsDirection = DEFAULT_STATE.sortGroupsDirection
     this.indexGroupTitles = DEFAULT_STATE.indexGroupTitles
     this.hideContextMenu = DEFAULT_STATE.hideContextMenu
+    this.userLocale = DEFAULT_STATE.userLocale
   }
 
   /**
@@ -60,6 +63,7 @@ class TabGroupState {
     this.sortGroupsDirection = data.sortGroupsDirection ?? this.sortGroupsDirection
     this.indexGroupTitles = data.indexGroupTitles ?? this.indexGroupTitles
     this.hideContextMenu = data.hideContextMenu ?? this.hideContextMenu
+    this.userLocale = data.userLocale ?? this.userLocale
 
     this.customRules.clear()
 
@@ -89,6 +93,7 @@ class TabGroupState {
       sortGroupsDirection: this.sortGroupsDirection,
       indexGroupTitles: this.indexGroupTitles,
       hideContextMenu: this.hideContextMenu,
+      userLocale: this.userLocale,
       // AI settings managed by AiService, pass defaults for storage schema
       aiEnabled: DEFAULT_STATE.aiEnabled,
       aiProvider: DEFAULT_STATE.aiProvider,

--- a/services/TabGroupState.ts
+++ b/services/TabGroupState.ts
@@ -24,6 +24,7 @@ class TabGroupState {
   openTabNextToCurrent: boolean
   sortGroupsAlphabetically: boolean
   indexGroupTitles: boolean
+  hideContextMenu: boolean
 
   constructor() {
     this.autoGroupingEnabled = DEFAULT_STATE.autoGroupingEnabled
@@ -37,6 +38,7 @@ class TabGroupState {
     this.openTabNextToCurrent = DEFAULT_STATE.openTabNextToCurrent
     this.sortGroupsAlphabetically = DEFAULT_STATE.sortGroupsAlphabetically
     this.indexGroupTitles = DEFAULT_STATE.indexGroupTitles
+    this.hideContextMenu = DEFAULT_STATE.hideContextMenu
   }
 
   /**
@@ -53,6 +55,7 @@ class TabGroupState {
     this.openTabNextToCurrent = data.openTabNextToCurrent ?? this.openTabNextToCurrent
     this.sortGroupsAlphabetically = data.sortGroupsAlphabetically ?? this.sortGroupsAlphabetically
     this.indexGroupTitles = data.indexGroupTitles ?? this.indexGroupTitles
+    this.hideContextMenu = data.hideContextMenu ?? this.hideContextMenu
 
     this.customRules.clear()
 
@@ -80,6 +83,7 @@ class TabGroupState {
       openTabNextToCurrent: this.openTabNextToCurrent,
       sortGroupsAlphabetically: this.sortGroupsAlphabetically,
       indexGroupTitles: this.indexGroupTitles,
+      hideContextMenu: this.hideContextMenu,
       // AI settings managed by AiService, pass defaults for storage schema
       aiEnabled: DEFAULT_STATE.aiEnabled,
       aiProvider: DEFAULT_STATE.aiProvider,

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -4,7 +4,7 @@
 
 import type { AiMessage, AiMessageAction } from "./ai-messages"
 import type { CustomRule, RuleData, RulesExportData, RulesStats } from "./rules"
-import type { GroupByMode, SortDirection } from "./storage"
+import type { GroupByMode, SortDirection, UserLocale } from "./storage"
 
 /**
  * All possible message actions
@@ -37,6 +37,8 @@ export type MessageAction =
   | "toggleIndexGroupTitles"
   | "getHideContextMenu"
   | "toggleHideContextMenu"
+  | "getUserLocale"
+  | "setUserLocale"
   | "getCustomRules"
   | "addCustomRule"
   | "updateCustomRule"
@@ -78,6 +80,7 @@ export interface SimpleMessage extends BaseMessage {
     | "getSortGroupsDirection"
     | "getIndexGroupTitles"
     | "getHideContextMenu"
+    | "getUserLocale"
     | "getCustomRules"
     | "getRulesStats"
     | "exportRules"
@@ -163,6 +166,14 @@ export interface ToggleHideContextMenuMessage extends BaseMessage {
 }
 
 /**
+ * Set user-selected UI locale message
+ */
+export interface SetUserLocaleMessage extends BaseMessage {
+  action: "setUserLocale"
+  locale: UserLocale
+}
+
+/**
  * Add custom rule message
  */
 export interface AddCustomRuleMessage extends BaseMessage {
@@ -219,6 +230,7 @@ export type Message =
   | SetSortGroupsDirectionMessage
   | ToggleIndexGroupTitlesMessage
   | ToggleHideContextMenuMessage
+  | SetUserLocaleMessage
   | AddCustomRuleMessage
   | UpdateCustomRuleMessage
   | DeleteCustomRuleMessage
@@ -283,6 +295,13 @@ export interface GroupByModeResponse {
  */
 export interface SortGroupsDirectionResponse {
   direction: SortDirection
+}
+
+/**
+ * Response for get/set user locale
+ */
+export interface UserLocaleResponse {
+  locale: UserLocale
 }
 
 /**

--- a/types/storage.ts
+++ b/types/storage.ts
@@ -59,6 +59,8 @@ export interface StorageSchema {
   sortGroupsAlphabetically: boolean
   /** Whether to prefix group titles with their sort position (e.g., "1. AI") */
   indexGroupTitles: boolean
+  /** Whether to hide the extension's right-click context menu items */
+  hideContextMenu: boolean
 }
 
 /**
@@ -79,7 +81,8 @@ export const DEFAULT_STATE: StorageSchema = {
   aiModelId: "Qwen2.5-3B-Instruct-q4f16_1-MLC",
   openTabNextToCurrent: false,
   sortGroupsAlphabetically: false,
-  indexGroupTitles: false
+  indexGroupTitles: false,
+  hideContextMenu: false
 }
 
 /**

--- a/types/storage.ts
+++ b/types/storage.ts
@@ -21,6 +21,12 @@ export type RuleMatchingMode = "exact" | "contains" | "regex"
 export type SortDirection = "asc" | "desc"
 
 /**
+ * User-selected UI locale. "auto" defers to the browser's UI locale.
+ * Widen this union when shipping additional locales.
+ */
+export type UserLocale = "auto" | "en" | "he"
+
+/**
  * Mapping of group titles to their colors
  */
 export type GroupColorMapping = Record<string, TabGroupColor>
@@ -68,6 +74,8 @@ export interface StorageSchema {
   indexGroupTitles: boolean
   /** Whether to hide the extension's right-click context menu items */
   hideContextMenu: boolean
+  /** User-selected UI locale override ("auto" = follow browser) */
+  userLocale: UserLocale
 }
 
 /**
@@ -90,7 +98,8 @@ export const DEFAULT_STATE: StorageSchema = {
   sortGroupsAlphabetically: false,
   sortGroupsDirection: "asc",
   indexGroupTitles: false,
-  hideContextMenu: false
+  hideContextMenu: false,
+  userLocale: "auto"
 }
 
 /**

--- a/types/storage.ts
+++ b/types/storage.ts
@@ -24,7 +24,7 @@ export type SortDirection = "asc" | "desc"
  * User-selected UI locale. "auto" defers to the browser's UI locale.
  * Widen this union when shipping additional locales.
  */
-export type UserLocale = "auto" | "en" | "he"
+export type UserLocale = "auto" | "en" | "he" | "ar" | "es" | "hi" | "ru" | "zh"
 
 /**
  * Mapping of group titles to their colors

--- a/utils/i18n.ts
+++ b/utils/i18n.ts
@@ -1,0 +1,82 @@
+/**
+ * Internationalization helpers built on top of the browser.i18n API.
+ *
+ * Translations live in `public/_locales/<lang>/messages.json`, following the
+ * WebExtension i18n spec. The browser selects the active locale automatically
+ * based on the user's browser language, falling back to the default_locale
+ * declared in the manifest.
+ *
+ * Usage:
+ *   - In TypeScript: `t("popupGroupTabs", "Group Tabs")` to fetch a message
+ *     with an English fallback if the key is missing.
+ *   - In HTML: add `data-i18n="messageKey"` to an element to localize its
+ *     text content, or `data-i18n-title="messageKey"` to localize its title
+ *     attribute. Call `applyI18nToDom()` once the DOM is ready.
+ */
+
+/**
+ * Fetches a localized message by key. Returns the provided fallback (or the
+ * key itself) when the message is missing — useful during development and
+ * for locales that are not yet translated.
+ */
+export function t(key: string, fallback?: string, substitutions?: string | string[]): string {
+  try {
+    // Cast is needed because WXT generates a narrow union from messages.json
+    // but we want to allow callers to pass any key and fall back gracefully
+    // if it's missing (e.g. during development when a key is not yet added).
+    const getMessage = browser.i18n.getMessage as (
+      key: string,
+      substitutions?: string | string[]
+    ) => string
+    const message = getMessage(key, substitutions)
+    if (message) return message
+  } catch {
+    // browser.i18n may be unavailable in some runtimes (e.g. tests)
+  }
+  return fallback ?? key
+}
+
+/**
+ * Walks the DOM and replaces text/attributes on elements tagged with
+ * `data-i18n*` attributes. Safe to call multiple times.
+ */
+export function applyI18nToDom(root: ParentNode = document): void {
+  // Translate text content
+  root.querySelectorAll<HTMLElement>("[data-i18n]").forEach(el => {
+    const key = el.dataset.i18n
+    if (!key) return
+    const fallback = el.textContent?.trim() || undefined
+    el.textContent = t(key, fallback)
+  })
+
+  // Translate `title` attributes
+  root.querySelectorAll<HTMLElement>("[data-i18n-title]").forEach(el => {
+    const key = el.getAttribute("data-i18n-title")
+    if (!key) return
+    const fallback = el.getAttribute("title") || undefined
+    el.setAttribute("title", t(key, fallback))
+  })
+
+  // Translate `placeholder` attributes
+  root.querySelectorAll<HTMLElement>("[data-i18n-placeholder]").forEach(el => {
+    const key = el.getAttribute("data-i18n-placeholder")
+    if (!key) return
+    const fallback = el.getAttribute("placeholder") || undefined
+    el.setAttribute("placeholder", t(key, fallback))
+  })
+
+  // Translate `aria-label` / `data-tooltip` attributes
+  root.querySelectorAll<HTMLElement>("[data-i18n-aria-label]").forEach(el => {
+    const key = el.getAttribute("data-i18n-aria-label")
+    if (!key) return
+    const fallback = el.getAttribute("aria-label") || undefined
+    el.setAttribute("aria-label", t(key, fallback))
+  })
+
+  root.querySelectorAll<HTMLElement>("[data-i18n-tooltip]").forEach(el => {
+    const key = el.getAttribute("data-i18n-tooltip")
+    if (!key) return
+    const fallback = el.getAttribute("data-tooltip") || undefined
+    el.setAttribute("data-tooltip", t(key, fallback))
+  })
+}

--- a/utils/i18n.ts
+++ b/utils/i18n.ts
@@ -1,29 +1,97 @@
 /**
- * Internationalization helpers built on top of the browser.i18n API.
+ * Internationalization helpers with runtime-overridable locale.
  *
- * Translations live in `public/_locales/<lang>/messages.json`, following the
- * WebExtension i18n spec. The browser selects the active locale automatically
- * based on the user's browser language, falling back to the default_locale
- * declared in the manifest.
+ * Two translation paths:
+ * 1. **Auto mode** (default) — defers to the browser's i18n API, which resolves
+ *    against the user's browser UI locale. This is the WebExtensions-native
+ *    behavior and also the only path that can localize manifest fields
+ *    (extension name/description).
+ * 2. **Override mode** — when the user picks a specific locale in the
+ *    extension's language picker, we load `_locales/<lang>/messages.json`
+ *    ourselves and resolve keys against that catalog. Falls back to
+ *    `browser.i18n` → provided fallback → key on miss.
  *
- * Usage:
- *   - In TypeScript: `t("popupGroupTabs", "Group Tabs")` to fetch a message
- *     with an English fallback if the key is missing.
- *   - In HTML: add `data-i18n="messageKey"` to an element to localize its
- *     text content, or `data-i18n-title="messageKey"` to localize its title
- *     attribute. Call `applyI18nToDom()` once the DOM is ready.
+ * HTML markup uses `data-i18n*` attributes; `applyI18nToDom()` translates them
+ * in place. It can be called repeatedly (e.g. after a language change) to
+ * re-translate without reloading the page.
  */
 
+type Catalog = Record<string, string>
+
+interface RawMessage {
+  message: string
+  description?: string
+  placeholders?: Record<string, { content: string; example?: string }>
+}
+
 /**
- * Fetches a localized message by key. Returns the provided fallback (or the
- * key itself) when the message is missing — useful during development and
- * for locales that are not yet translated.
+ * When non-null, `t()` consults this catalog before `browser.i18n`. Reset to
+ * null by calling `initI18n("auto")`.
+ */
+let activeCatalog: Catalog | null = null
+
+/**
+ * Locales that render right-to-left. Extend when adding more RTL languages.
+ */
+const RTL_LOCALES = new Set<string>(["he", "ar", "fa", "ur"])
+
+/**
+ * Loads a locale override catalog, or clears it for auto-mode. Safe to call
+ * multiple times. Failure to fetch leaves the previous catalog in place if
+ * any, otherwise auto-mode.
+ */
+export async function initI18n(locale: string): Promise<void> {
+  if (locale === "auto") {
+    activeCatalog = null
+    return
+  }
+
+  try {
+    // Cast: WXT narrows getURL to known public paths, but _locales JSON
+    // files are present at runtime (browser copies public/_locales wholesale).
+    const getUrl = browser.runtime.getURL as (path: string) => string
+    const url = getUrl(`/_locales/${locale}/messages.json`)
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`fetch failed: ${response.status}`)
+    }
+    const raw = (await response.json()) as Record<string, RawMessage>
+    const flattened: Catalog = {}
+    for (const [key, value] of Object.entries(raw)) {
+      if (value && typeof value.message === "string") {
+        flattened[key] = value.message
+      }
+    }
+    activeCatalog = flattened
+  } catch (error) {
+    console.error(`[i18n] Failed to load locale "${locale}":`, error)
+    activeCatalog = null
+  }
+}
+
+/**
+ * Resolves `$1`/`$2`/… WebExtensions-style positional substitutions.
+ */
+function applySubstitutions(message: string, substitutions?: string | string[]): string {
+  if (!substitutions) return message
+  const list = Array.isArray(substitutions) ? substitutions : [substitutions]
+  return message.replace(/\$(\d+)/g, (_, index) => {
+    const i = Number.parseInt(index, 10) - 1
+    return list[i] ?? ""
+  })
+}
+
+/**
+ * Fetches a localized message by key. Consults the active override catalog
+ * first, then the browser's i18n API, then the provided fallback.
  */
 export function t(key: string, fallback?: string, substitutions?: string | string[]): string {
+  if (activeCatalog) {
+    const hit = activeCatalog[key]
+    if (hit) return applySubstitutions(hit, substitutions)
+  }
+
   try {
-    // Cast is needed because WXT generates a narrow union from messages.json
-    // but we want to allow callers to pass any key and fall back gracefully
-    // if it's missing (e.g. during development when a key is not yet added).
     const getMessage = browser.i18n.getMessage as (
       key: string,
       substitutions?: string | string[]
@@ -33,50 +101,80 @@ export function t(key: string, fallback?: string, substitutions?: string | strin
   } catch {
     // browser.i18n may be unavailable in some runtimes (e.g. tests)
   }
+
   return fallback ?? key
 }
 
 /**
+ * Returns the concrete locale that will be used for rendering. For `"auto"`,
+ * consults the browser UI language. Always returns a bare language code
+ * (e.g. "en", "he"), stripping any region (e.g. "en-US" → "en").
+ */
+export function resolveEffectiveLocale(userLocale: string): string {
+  if (userLocale && userLocale !== "auto") return userLocale
+  try {
+    const uiLang = browser.i18n.getUILanguage?.() ?? "en"
+    return uiLang.split("-")[0] || "en"
+  } catch {
+    return "en"
+  }
+}
+
+/**
+ * Sets `<html dir>` and `<html lang>` for the current document based on the
+ * effective locale. Safe to call repeatedly; only touches attributes when
+ * they change.
+ */
+export function applyDirectionToDom(effectiveLocale: string, root: Document = document): void {
+  const dir = RTL_LOCALES.has(effectiveLocale) ? "rtl" : "ltr"
+  const html = root.documentElement
+  if (html.getAttribute("dir") !== dir) html.setAttribute("dir", dir)
+  if (html.getAttribute("lang") !== effectiveLocale) html.setAttribute("lang", effectiveLocale)
+}
+
+/**
  * Walks the DOM and replaces text/attributes on elements tagged with
- * `data-i18n*` attributes. Safe to call multiple times.
+ * `data-i18n*` attributes. Safe to call multiple times — uses each element's
+ * current text/attribute value as the fallback only on the first pass; on
+ * later passes it looks up the stored original in a `data-i18n-orig*` attr
+ * so re-translation keeps working after a language change.
  */
 export function applyI18nToDom(root: ParentNode = document): void {
-  // Translate text content
-  root.querySelectorAll<HTMLElement>("[data-i18n]").forEach(el => {
-    const key = el.dataset.i18n
+  const translateText = (el: HTMLElement, key: string | undefined) => {
     if (!key) return
-    const fallback = el.textContent?.trim() || undefined
+    const originalAttr = "data-i18n-orig-text"
+    const stored = el.getAttribute(originalAttr)
+    const fallback = stored ?? el.textContent?.trim() ?? undefined
+    if (stored === null && fallback) el.setAttribute(originalAttr, fallback)
     el.textContent = t(key, fallback)
+  }
+
+  const translateAttr = (el: HTMLElement, attrName: string, key: string | undefined) => {
+    if (!key) return
+    const originalAttr = `data-i18n-orig-${attrName}`
+    const stored = el.getAttribute(originalAttr)
+    const fallback = stored ?? el.getAttribute(attrName) ?? undefined
+    if (stored === null && fallback) el.setAttribute(originalAttr, fallback)
+    el.setAttribute(attrName, t(key, fallback))
+  }
+
+  root.querySelectorAll<HTMLElement>("[data-i18n]").forEach(el => {
+    translateText(el, el.dataset.i18n)
   })
 
-  // Translate `title` attributes
   root.querySelectorAll<HTMLElement>("[data-i18n-title]").forEach(el => {
-    const key = el.getAttribute("data-i18n-title")
-    if (!key) return
-    const fallback = el.getAttribute("title") || undefined
-    el.setAttribute("title", t(key, fallback))
+    translateAttr(el, "title", el.getAttribute("data-i18n-title") ?? undefined)
   })
 
-  // Translate `placeholder` attributes
   root.querySelectorAll<HTMLElement>("[data-i18n-placeholder]").forEach(el => {
-    const key = el.getAttribute("data-i18n-placeholder")
-    if (!key) return
-    const fallback = el.getAttribute("placeholder") || undefined
-    el.setAttribute("placeholder", t(key, fallback))
+    translateAttr(el, "placeholder", el.getAttribute("data-i18n-placeholder") ?? undefined)
   })
 
-  // Translate `aria-label` / `data-tooltip` attributes
   root.querySelectorAll<HTMLElement>("[data-i18n-aria-label]").forEach(el => {
-    const key = el.getAttribute("data-i18n-aria-label")
-    if (!key) return
-    const fallback = el.getAttribute("aria-label") || undefined
-    el.setAttribute("aria-label", t(key, fallback))
+    translateAttr(el, "aria-label", el.getAttribute("data-i18n-aria-label") ?? undefined)
   })
 
   root.querySelectorAll<HTMLElement>("[data-i18n-tooltip]").forEach(el => {
-    const key = el.getAttribute("data-i18n-tooltip")
-    if (!key) return
-    const fallback = el.getAttribute("data-tooltip") || undefined
-    el.setAttribute("data-tooltip", t(key, fallback))
+    translateAttr(el, "data-tooltip", el.getAttribute("data-i18n-tooltip") ?? undefined)
   })
 }

--- a/utils/i18n.ts
+++ b/utils/i18n.ts
@@ -59,7 +59,7 @@ export async function initI18n(locale: string): Promise<void> {
     const flattened: Catalog = {}
     for (const [key, value] of Object.entries(raw)) {
       if (value && typeof value.message === "string") {
-        flattened[key] = value.message
+        flattened[key] = resolveNamedPlaceholders(value.message, value.placeholders)
       }
     }
     activeCatalog = flattened
@@ -67,6 +67,29 @@ export async function initI18n(locale: string): Promise<void> {
     console.error(`[i18n] Failed to load locale "${locale}":`, error)
     activeCatalog = null
   }
+}
+
+/**
+ * Resolves WebExtensions-style named placeholders (`$count$`, `$name$`, …)
+ * to their positional form (`$1`, `$2`, …). Case-insensitive name match, per
+ * the spec. Unknown placeholders are left intact so `applySubstitutions` can
+ * still handle raw positional refs.
+ */
+function resolveNamedPlaceholders(
+  message: string,
+  placeholders: RawMessage["placeholders"]
+): string {
+  if (!placeholders) return message
+  const lookup: Record<string, string> = {}
+  for (const [name, def] of Object.entries(placeholders)) {
+    if (def && typeof def.content === "string") {
+      lookup[name.toLowerCase()] = def.content
+    }
+  }
+  return message.replace(/\$([A-Za-z0-9_@]+)\$/g, (match, name: string) => {
+    const replacement = lookup[name.toLowerCase()]
+    return replacement ?? match
+  })
 }
 
 /**

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -13,7 +13,8 @@ import type {
   RuleMatchingMode,
   SortDirection,
   StorageSchema,
-  TabGroupColor
+  TabGroupColor,
+  UserLocale
 } from "../types"
 import { DEFAULT_STATE } from "../types/storage"
 
@@ -89,6 +90,10 @@ export const hideContextMenu = storage.defineItem<boolean>("local:hideContextMen
   fallback: DEFAULT_STATE.hideContextMenu
 })
 
+export const userLocale = storage.defineItem<UserLocale>("local:userLocale", {
+  fallback: DEFAULT_STATE.userLocale
+})
+
 /**
  * Cached AI suggestions (survives popup reopens, not a user setting)
  */
@@ -118,7 +123,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     sortGroupsAlphabeticallyValue,
     sortGroupsDirectionValue,
     indexGroupTitlesValue,
-    hideContextMenuValue
+    hideContextMenuValue,
+    userLocaleValue
   ] = await Promise.all([
     autoGroupingEnabled.getValue(),
     groupNewTabs.getValue(),
@@ -136,7 +142,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     sortGroupsAlphabetically.getValue(),
     sortGroupsDirection.getValue(),
     indexGroupTitles.getValue(),
-    hideContextMenu.getValue()
+    hideContextMenu.getValue(),
+    userLocale.getValue()
   ])
 
   return {
@@ -156,7 +163,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     sortGroupsAlphabetically: sortGroupsAlphabeticallyValue,
     sortGroupsDirection: sortGroupsDirectionValue,
     indexGroupTitles: indexGroupTitlesValue,
-    hideContextMenu: hideContextMenuValue
+    hideContextMenu: hideContextMenuValue,
+    userLocale: userLocaleValue
   }
 }
 
@@ -216,6 +224,9 @@ export async function saveAllStorage(data: Partial<StorageSchema>): Promise<void
   }
   if (data.hideContextMenu !== undefined) {
     promises.push(hideContextMenu.setValue(data.hideContextMenu))
+  }
+  if (data.userLocale !== undefined) {
+    promises.push(userLocale.setValue(data.userLocale))
   }
   await Promise.all(promises)
 }

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -80,6 +80,10 @@ export const indexGroupTitles = storage.defineItem<boolean>("local:indexGroupTit
   fallback: DEFAULT_STATE.indexGroupTitles
 })
 
+export const hideContextMenu = storage.defineItem<boolean>("local:hideContextMenu", {
+  fallback: DEFAULT_STATE.hideContextMenu
+})
+
 /**
  * Cached AI suggestions (survives popup reopens, not a user setting)
  */
@@ -107,7 +111,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     aiModelIdValue,
     openTabNextToCurrentValue,
     sortGroupsAlphabeticallyValue,
-    indexGroupTitlesValue
+    indexGroupTitlesValue,
+    hideContextMenuValue
   ] = await Promise.all([
     autoGroupingEnabled.getValue(),
     groupNewTabs.getValue(),
@@ -123,7 +128,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     aiModelId.getValue(),
     openTabNextToCurrent.getValue(),
     sortGroupsAlphabetically.getValue(),
-    indexGroupTitles.getValue()
+    indexGroupTitles.getValue(),
+    hideContextMenu.getValue()
   ])
 
   return {
@@ -141,7 +147,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     aiModelId: aiModelIdValue,
     openTabNextToCurrent: openTabNextToCurrentValue,
     sortGroupsAlphabetically: sortGroupsAlphabeticallyValue,
-    indexGroupTitles: indexGroupTitlesValue
+    indexGroupTitles: indexGroupTitlesValue,
+    hideContextMenu: hideContextMenuValue
   }
 }
 
@@ -195,6 +202,9 @@ export async function saveAllStorage(data: Partial<StorageSchema>): Promise<void
   }
   if (data.indexGroupTitles !== undefined) {
     promises.push(indexGroupTitles.setValue(data.indexGroupTitles))
+  }
+  if (data.hideContextMenu !== undefined) {
+    promises.push(hideContextMenu.setValue(data.hideContextMenu))
   }
   await Promise.all(promises)
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -34,8 +34,9 @@ export default defineConfig({
   }),
   manifest: ({ browser }) => {
     const baseManifest = {
-      name: "Auto Tab Groups",
-      description: "Automatically groups tabs by domain.",
+      name: "__MSG_extensionName__",
+      description: "__MSG_extensionDescription__",
+      default_locale: "en",
       author: "Nitzan Papini",
       permissions: ["tabs", "storage", "tabGroups", "contextMenus"],
       icons: {
@@ -77,7 +78,7 @@ export default defineConfig({
             48: "icon/48.png",
             128: "icon/128.png"
           },
-          default_title: "Auto Tab Groups"
+          default_title: "__MSG_extensionName__"
         }
       }
     }


### PR DESCRIPTION
## Summary
- Adds a **runtime language picker** (popup + sidebar) with persistence across restarts/service-worker cycles. "Auto" keeps the existing browser-detected behavior.
- Ships **7 locales**: English, Hebrew, Arabic, Spanish, Hindi, Russian, Chinese (all 131 keys fully translated). Hebrew + Arabic flip the UI to RTL via `<html dir="rtl">`.
- Adds an **Advanced** collapsible section with a "Hide context menu" toggle. Context menu items (including "Add to Blacklist") are now translatable and rebuild on locale change.
- Wires i18n attributes (`data-i18n`, `-title`, `-placeholder`, `-aria-label`, `-tooltip`) across popup, sidebar, rules modal, and import-rules dialog.

## Architecture
`browser.i18n.getMessage()` resolves at load time and can't be overridden, so a parallel catalog path was added:
- `initI18n(locale)` fetches `_locales/<lang>/messages.json` via `browser.runtime.getURL`, flattens it, and pre-resolves named placeholders (`$count$` → `$1`) per the WebExtensions spec.
- `t()` consults the active catalog first, falls through to `browser.i18n.getMessage()` for Auto, then to the inline fallback.
- `applyI18nToDom()` caches originals in `data-i18n-orig-*` so the DOM re-translates on language change.
- `applyDirectionToDom()` manages `<html dir>` + `<html lang>`.
- Background reinitializes its own catalog and rebuilds the context menu when locale changes.

Storage follows the established `hideContextMenu` pattern: `userLocale: UserLocale` in `StorageSchema`, `DEFAULT_STATE`, `TabGroupState`, plus `getUserLocale` / `setUserLocale` messages.

## Known platform limitation
Extension **name** and **description** shown in `chrome://extensions` continue to follow the browser UI locale, not the in-extension override. The manifest is resolved before our code runs — no workaround exists. All UI rendered by the extension itself honors the override.

## Bug fixes bundled in
- **RTL section titles** didn't right-align — replaced hardcoded `text-align: left` with logical `text-align: start`.
- **Literal `\$count\$`** appeared in rules-import counts — catalog loader now pre-resolves named placeholders before positional substitution.
- **"Edit" / "Delete" / "and X more" / "No blacklisted domains yet"** rendered in English on Hebrew reload — root cause was a race between async `initI18n` and top-level dynamic rendering. Gated `loadCustomRules()` / `loadCachedSuggestions()` on an `i18nReady` promise, and language-change handler now calls `updateRulesDisplay()` + `updateBlacklistDisplay()` for live switching.
- **Pattern / URL inputs** now stay LTR under `dir="rtl"` via scoped override.

## Test plan
- [x] `bun run code:check` (Biome + tsc) clean.
- [x] `bunx vitest run` — 775/775 pass.
- [x] `bun run build:chrome` + `bun run build:firefox` — both succeed, all 7 `_locales/*` ship.
- [x] Install locally, switch to each locale from the picker, verify UI translates without reload.
- [x] Hebrew + Arabic: confirm `<html dir="rtl">` flip, section titles right-align, badges/arrows mirror, pattern inputs remain LTR.
- [x] Restart browser → picker selection persists.
- [x] Right-click tab → context menu items render in the chosen locale.
- [x] Open rules modal + import-rules dialog → both inherit the chosen locale + RTL.
- [x] Toggle "Hide context menu" under Advanced → context menu hides/reappears.