### PR TITLE
fix: display IDN domains as Unicode instead of punycode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/tests/DomainUtils.test.ts
+++ b/tests/DomainUtils.test.ts
@@ -150,6 +150,12 @@ describe("DomainUtils", () => {
     it("should return IP address as-is for other IPv4", () => {
       expect(getDomainDisplayName("192.168.1.100")).toBe("192.168.1.100")
     })
+
+    it("should display IDN domains as Unicode instead of punycode", () => {
+      expect(getDomainDisplayName("xn--mnchen-3ya.de")).toBe("München")
+      expect(getDomainDisplayName("www.xn--bcher-kva.example")).toBe("Bücher")
+      expect(getDomainDisplayName("xn--fiq228c42rmna.xn--fiqs8s")).toBe("中文网络")
+    })
   })
 
   describe("validateStrictDomain", () => {

--- a/tests/Punycode.test.ts
+++ b/tests/Punycode.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { punycodeToUnicode } from "../utils/Punycode"
+
+describe("punycodeToUnicode", () => {
+  it("decodes IDN hostnames", () => {
+    expect(punycodeToUnicode("xn--mnchen-3ya.de")).toBe("münchen.de")
+    expect(punycodeToUnicode("xn--bcher-kva.example")).toBe("bücher.example")
+    expect(punycodeToUnicode("xn--fiqs8s")).toBe("中国")
+    expect(punycodeToUnicode("xn--fiq228c42rmna.xn--fiqs8s")).toBe("中文网络.中国")
+    expect(punycodeToUnicode("xn--e1afmkfd.xn--p1ai")).toBe("пример.рф")
+    expect(punycodeToUnicode("xn--ls8h.la")).toBe("💩.la")
+  })
+
+  it("decodes only the punycode labels", () => {
+    expect(punycodeToUnicode("www.xn--mnchen-3ya.de")).toBe("www.münchen.de")
+    // Matches Node's punycode.toUnicode: uppercase labels are left alone
+    expect(punycodeToUnicode("XN--MNCHEN-3YA.de")).toBe("XN--MNCHEN-3YA.de")
+  })
+
+  it("leaves plain hostnames untouched", () => {
+    expect(punycodeToUnicode("example.com")).toBe("example.com")
+    expect(punycodeToUnicode("")).toBe("")
+  })
+
+  it("returns the label unchanged when it is not valid punycode", () => {
+    expect(punycodeToUnicode("xn--.com")).toBe("xn--.com")
+    expect(punycodeToUnicode("xn--mnchen-.com")).toBe("xn--mnchen-.com")
+    expect(punycodeToUnicode("xn--mnchen-3y!.com")).toBe("xn--mnchen-3y!.com")
+    expect(punycodeToUnicode("xn--zzzzzzzzzzzz.com")).toBe("xn--zzzzzzzzzzzz.com")
+  })
+})

--- a/utils/DomainUtils.ts
+++ b/utils/DomainUtils.ts
@@ -3,6 +3,7 @@
  */
 
 import type { PatternValidationResult } from "../types"
+import { punycodeToUnicode } from "./Punycode"
 
 /**
  * Common country code second-level domains that should be treated as single TLD units
@@ -169,11 +170,13 @@ export function getDomainDisplayName(domain: string): string {
       return domain
     }
 
-    const parts = domain.split(".")
+    // Show IDN domains as Unicode instead of punycode (e.g. xn--mnchen-3ya -> münchen)
+    const unicodeDomain = punycodeToUnicode(domain)
+    const parts = unicodeDomain.split(".")
 
     // If domain has no TLD (single word), return it capitalized
     if (parts.length === 1) {
-      return domain.charAt(0).toUpperCase() + domain.slice(1)
+      return unicodeDomain.charAt(0).toUpperCase() + unicodeDomain.slice(1)
     }
 
     // Use effective TLD length to properly remove TLD parts
@@ -193,7 +196,7 @@ export function getDomainDisplayName(domain: string): string {
     }
 
     // If we end up with an empty string, return the original domain
-    return domain
+    return unicodeDomain
   } catch {
     return domain // Fallback to original domain if error occurs
   }

--- a/utils/Punycode.ts
+++ b/utils/Punycode.ts
@@ -1,0 +1,107 @@
+/**
+ * Punycode (RFC 3492) decoding for displaying IDN domains as Unicode.
+ *
+ * ponytail: decode only — group titles are the only place we need Unicode,
+ * and browsers hand us ASCII hostnames everywhere else. No encoder, no dependency.
+ */
+
+const BASE = 36
+const TMIN = 1
+const TMAX = 26
+const SKEW = 38
+const DAMP = 700
+const INITIAL_BIAS = 72
+const INITIAL_N = 128
+const MAX_CODE_POINT = 0x10ffff
+
+function adapt(delta: number, numPoints: number, firstTime: boolean): number {
+  let d = firstTime ? Math.floor(delta / DAMP) : delta >> 1
+  d += Math.floor(d / numPoints)
+
+  let k = 0
+  while (d > ((BASE - TMIN) * TMAX) / 2) {
+    d = Math.floor(d / (BASE - TMIN))
+    k += BASE
+  }
+
+  return k + Math.floor(((BASE - TMIN + 1) * d) / (d + SKEW))
+}
+
+/** Maps a basic code point to its digit value, or -1 if it isn't a valid digit */
+function digitValue(code: number): number {
+  if (code >= 0x30 && code <= 0x39) return code - 0x30 + 26 // 0-9
+  if (code >= 0x61 && code <= 0x7a) return code - 0x61 // a-z
+  if (code >= 0x41 && code <= 0x5a) return code - 0x41 // A-Z
+  return -1
+}
+
+/**
+ * Decodes a single punycode label (without the "xn--" prefix).
+ * Returns null if the input is not valid punycode.
+ */
+function decodeLabel(input: string): string | null {
+  const delimiter = input.lastIndexOf("-")
+  const basic = delimiter > 0 ? input.slice(0, delimiter) : ""
+
+  const output: number[] = []
+  for (const char of basic) {
+    const code = char.codePointAt(0) as number
+    if (code >= 0x80) return null // basic part must be ASCII
+    output.push(code)
+  }
+
+  let n = INITIAL_N
+  let bias = INITIAL_BIAS
+  let i = 0
+  let index = delimiter > 0 ? delimiter + 1 : 0
+
+  if (index >= input.length) return null // nothing encoded
+
+  while (index < input.length) {
+    const oldI = i
+    let weight = 1
+
+    for (let k = BASE; ; k += BASE) {
+      if (index >= input.length) return null // truncated sequence
+
+      const digit = digitValue(input.charCodeAt(index++))
+      if (digit < 0 || digit > (MAX_CODE_POINT - i) / weight) return null
+
+      i += digit * weight
+
+      const t = k <= bias ? TMIN : k >= bias + TMAX ? TMAX : k - bias
+      if (digit < t) break
+
+      weight *= BASE - t
+    }
+
+    const outLength = output.length + 1
+    bias = adapt(i - oldI, outLength, oldI === 0)
+
+    n += Math.floor(i / outLength)
+    i %= outLength
+
+    if (n > MAX_CODE_POINT) return null
+
+    output.splice(i, 0, n)
+    i++
+  }
+
+  return String.fromCodePoint(...output)
+}
+
+/**
+ * Converts punycode labels in a hostname to Unicode.
+ * Labels that aren't punycode, or that fail to decode, are returned unchanged.
+ * @example punycodeToUnicode("xn--mnchen-3ya.de") // "münchen.de"
+ */
+export function punycodeToUnicode(hostname: string): string {
+  return hostname
+    .split(".")
+    .map(label => {
+      // ponytail: hostnames from URL.hostname are always lowercase
+      if (!label.startsWith("xn--")) return label
+      return decodeLabel(label.slice(4)) ?? label
+    })
+    .join(".")
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
         "utils/Constants.ts",
         "utils/DomainUtils.ts",
         "utils/PromptTemplates.ts",
+        "utils/Punycode.ts",
         "utils/RuleConflictDetector.ts",
         "utils/RulesUtils.ts",
         "utils/UrlPatternMatcher.ts",


### PR DESCRIPTION
Closes #74

## Problem

Tab groups for internationalized domains were named after the raw punycode label — `Xn--mnchen-3ya` instead of `München`.

## Fix

- New `utils/Punycode.ts`: a minimal RFC 3492 decoder (~100 lines, no new dependency).
- `getDomainDisplayName` decodes punycode labels before stripping the TLD.

Decoding is display-only. Matching, custom rules, and storage still operate on the ASCII hostname, so existing groups and rules are unaffected.

Version bumped to 3.5.2.

## Test plan

- [x] `bunx vitest run` — 780 tests pass, including new `tests/Punycode.test.ts`
- [x] Decoder fuzz-checked against Node's reference `punycode` module over 5000 random IDN hostnames (Latin, CJK, Cyrillic, Arabic, emoji) — all match
- [x] `bun run code:check` clean
- [x] `bun run zip` + `bun run zip:firefox` build cleanly at 3.5.2
- [x] Manual: open a tab on an IDN site (e.g. `münchen.de`) in Chrome and Firefox, confirm the group title shows Unicode

## Notes

Not included: a punycode encoder, and a homograph/mixed-script spoofing guard — group titles aren't a trust surface, and browsers already apply their own IDN display policy in the URL bar. Uppercase `XN--` labels are left undecoded, matching Node's reference behavior; browsers always hand us lowercase hostnames.