### PR TITLE
feat: add opt-in setting to remove the "System" group

### DIFF
--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -172,6 +172,26 @@ export default defineBackground(() => {
             result = { enabled: tabGroupState.groupNewTabs }
             break
 
+          case "getSystemGroupEnabled":
+            result = { enabled: tabGroupState.systemGroupEnabled }
+            break
+
+          case "toggleSystemGroup":
+            tabGroupState.systemGroupEnabled = msg.enabled
+            await saveState()
+
+            if (msg.enabled) {
+              if (tabGroupState.autoGroupingEnabled) {
+                await tabGroupService.groupAllTabs()
+              }
+            } else {
+              // Dissolve the System group regardless of auto-grouping: the user
+              // asked for it gone, so it should disappear right away.
+              await tabGroupService.ungroupSystemTabs()
+            }
+            result = { enabled: tabGroupState.systemGroupEnabled }
+            break
+
           case "getGroupByMode":
             result = { mode: tabGroupState.groupByMode }
             break

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -69,6 +69,13 @@
           </div>
         </div>
         <div class="toggle-container">
+          <span data-i18n="settingSystemGroupEnabled">Group browser pages under "System"</span>
+          <label class="switch">
+            <input type="checkbox" id="systemGroupToggle" />
+            <span class="slider round"></span>
+          </label>
+        </div>
+        <div class="toggle-container">
           <span data-i18n="settingGroupNewEmptyTabs">Group new empty tabs under "System"</span>
           <label class="switch">
             <input type="checkbox" id="groupNewTabsToggle" />

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -19,6 +19,7 @@ const collapseAllButton = document.getElementById("collapseAllButton") as HTMLBu
 const expandAllButton = document.getElementById("expandAllButton") as HTMLButtonElement
 const autoGroupToggle = document.getElementById("autoGroupToggle") as HTMLInputElement
 const groupNewTabsToggle = document.getElementById("groupNewTabsToggle") as HTMLInputElement
+const systemGroupToggle = document.getElementById("systemGroupToggle") as HTMLInputElement
 const groupByToggleOptions = document.querySelectorAll<HTMLButtonElement>(
   ".group-by-toggle-bar:not(.sort-direction-toggle-bar) .toggle-option"
 )
@@ -657,6 +658,15 @@ generateNewColorsButton.addEventListener("click", () =>
 collapseAllButton.addEventListener("click", () => sendMessage({ action: "collapseAll" }))
 expandAllButton.addEventListener("click", () => sendMessage({ action: "expandAll" }))
 
+/**
+ * The "group new empty tabs" toggle only means something while the System group
+ * exists, so it follows the System group toggle.
+ */
+function syncGroupNewTabsAvailability(systemGroupEnabled: boolean): void {
+  groupNewTabsToggle.disabled = !systemGroupEnabled
+  groupNewTabsToggle.closest(".toggle-container")?.classList.toggle("disabled", !systemGroupEnabled)
+}
+
 // Initialize toggle states
 sendMessage<{ enabled?: boolean }>({ action: "getAutoGroupState" }).then(response => {
   if (response?.enabled !== undefined) {
@@ -667,6 +677,13 @@ sendMessage<{ enabled?: boolean }>({ action: "getAutoGroupState" }).then(respons
 sendMessage<{ enabled?: boolean }>({ action: "getGroupNewTabsState" }).then(response => {
   if (response?.enabled !== undefined) {
     groupNewTabsToggle.checked = response.enabled
+  }
+})
+
+sendMessage<{ enabled?: boolean }>({ action: "getSystemGroupEnabled" }).then(response => {
+  if (response?.enabled !== undefined) {
+    systemGroupToggle.checked = response.enabled
+    syncGroupNewTabsAvailability(response.enabled)
   }
 })
 
@@ -726,6 +743,12 @@ groupNewTabsToggle.addEventListener("change", event => {
     action: "toggleGroupNewTabs",
     enabled: (event.target as HTMLInputElement).checked
   })
+})
+
+systemGroupToggle.addEventListener("change", event => {
+  const enabled = (event.target as HTMLInputElement).checked
+  syncGroupNewTabsAvailability(enabled)
+  sendMessage({ action: "toggleSystemGroup", enabled })
 })
 
 // Group by toggle event listeners

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -222,6 +222,14 @@ footer {
   background-color: #3f8f6a;
 }
 
+.toggle-container.disabled {
+  opacity: 0.5;
+}
+
+.toggle-container.disabled .slider {
+  cursor: not-allowed;
+}
+
 .toggle-container {
   display: flex;
   justify-content: space-between;

--- a/entrypoints/sidebar/index.html
+++ b/entrypoints/sidebar/index.html
@@ -70,6 +70,13 @@
             </div>
           </div>
           <div class="toggle-container">
+            <span data-i18n="settingSystemGroupEnabled">Group browser pages under "System"</span>
+            <label class="switch">
+              <input type="checkbox" id="systemGroupToggle" />
+              <span class="slider round"></span>
+            </label>
+          </div>
+          <div class="toggle-container">
             <span data-i18n="settingGroupNewEmptyTabs">Group new empty tabs under "System"</span>
             <label class="switch">
               <input type="checkbox" id="groupNewTabsToggle" />

--- a/entrypoints/sidebar/main.ts
+++ b/entrypoints/sidebar/main.ts
@@ -20,6 +20,7 @@ const collapseAllButton = document.getElementById("collapseAllButton") as HTMLBu
 const expandAllButton = document.getElementById("expandAllButton") as HTMLButtonElement
 const autoGroupToggle = document.getElementById("autoGroupToggle") as HTMLInputElement
 const groupNewTabsToggle = document.getElementById("groupNewTabsToggle") as HTMLInputElement
+const systemGroupToggle = document.getElementById("systemGroupToggle") as HTMLInputElement
 const groupByToggleOptions = document.querySelectorAll<HTMLButtonElement>(
   ".group-by-toggle-bar:not(.sort-direction-toggle-bar) .toggle-option"
 )
@@ -707,6 +708,15 @@ generateNewColorsButton.addEventListener("click", () =>
 collapseAllButton.addEventListener("click", () => sendMessage({ action: "collapseAll" }))
 expandAllButton.addEventListener("click", () => sendMessage({ action: "expandAll" }))
 
+/**
+ * The "group new empty tabs" toggle only means something while the System group
+ * exists, so it follows the System group toggle.
+ */
+function syncGroupNewTabsAvailability(systemGroupEnabled: boolean): void {
+  groupNewTabsToggle.disabled = !systemGroupEnabled
+  groupNewTabsToggle.closest(".toggle-container")?.classList.toggle("disabled", !systemGroupEnabled)
+}
+
 // Initialize toggle states
 sendMessage<{ enabled?: boolean }>({ action: "getAutoGroupState" }).then(response => {
   if (response?.enabled !== undefined) {
@@ -717,6 +727,13 @@ sendMessage<{ enabled?: boolean }>({ action: "getAutoGroupState" }).then(respons
 sendMessage<{ enabled?: boolean }>({ action: "getGroupNewTabsState" }).then(response => {
   if (response?.enabled !== undefined) {
     groupNewTabsToggle.checked = response.enabled
+  }
+})
+
+sendMessage<{ enabled?: boolean }>({ action: "getSystemGroupEnabled" }).then(response => {
+  if (response?.enabled !== undefined) {
+    systemGroupToggle.checked = response.enabled
+    syncGroupNewTabsAvailability(response.enabled)
   }
 })
 
@@ -776,6 +793,12 @@ groupNewTabsToggle.addEventListener("change", event => {
     action: "toggleGroupNewTabs",
     enabled: (event.target as HTMLInputElement).checked
   })
+})
+
+systemGroupToggle.addEventListener("change", event => {
+  const enabled = (event.target as HTMLInputElement).checked
+  syncGroupNewTabsAvailability(enabled)
+  sendMessage({ action: "toggleSystemGroup", enabled })
 })
 
 // Group by toggle event listeners

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/public/_locales/ar/messages.json
+++ b/public/_locales/ar/messages.json
@@ -77,6 +77,10 @@
     "message": "النطاق الفرعي",
     "description": "Option that groups by subdomain (sidebar)."
   },
+  "settingSystemGroupEnabled": {
+    "message": "تجميع صفحات المتصفح تحت «System»",
+    "description": "Label for the toggle that groups browser/system pages under a System group."
+  },
   "settingGroupNewEmptyTabs": {
     "message": "تجميع علامات التبويب الفارغة الجديدة تحت «System»",
     "description": "Label for the toggle that groups blank/new tabs under a System group."

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -77,6 +77,10 @@
     "message": "Subdomain",
     "description": "Option that groups by subdomain (sidebar)."
   },
+  "settingSystemGroupEnabled": {
+    "message": "Browserseiten unter „System“ gruppieren",
+    "description": "Label for the toggle that groups browser/system pages under a System group."
+  },
   "settingGroupNewEmptyTabs": {
     "message": "Neue leere Tabs unter „System“ gruppieren",
     "description": "Label for the toggle that groups blank/new tabs under a System group."

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -77,6 +77,10 @@
     "message": "Sub-domain",
     "description": "Option that groups by subdomain (sidebar)."
   },
+  "settingSystemGroupEnabled": {
+    "message": "Group browser pages under \"System\"",
+    "description": "Label for the toggle that groups browser/system pages under a System group."
+  },
   "settingGroupNewEmptyTabs": {
     "message": "Group new empty tabs under \"System\"",
     "description": "Label for the toggle that groups blank/new tabs under a System group."

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -77,6 +77,10 @@
     "message": "Subdominio",
     "description": "Option that groups by subdomain (sidebar)."
   },
+  "settingSystemGroupEnabled": {
+    "message": "Agrupar páginas del navegador en «System»",
+    "description": "Label for the toggle that groups browser/system pages under a System group."
+  },
   "settingGroupNewEmptyTabs": {
     "message": "Agrupar nuevas pestañas vacías en «System»",
     "description": "Label for the toggle that groups blank/new tabs under a System group."

--- a/public/_locales/he/messages.json
+++ b/public/_locales/he/messages.json
@@ -77,6 +77,10 @@
     "message": "תת-דומיין",
     "description": "Option that groups by subdomain (sidebar)."
   },
+  "settingSystemGroupEnabled": {
+    "message": "קבץ דפי דפדפן תחת \"System\"",
+    "description": "Label for the toggle that groups browser/system pages under a System group."
+  },
   "settingGroupNewEmptyTabs": {
     "message": "קבץ לשוניות ריקות חדשות תחת \"System\"",
     "description": "Label for the toggle that groups blank/new tabs under a System group."

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -77,6 +77,10 @@
     "message": "उप-डोमेन",
     "description": "Option that groups by subdomain (sidebar)."
   },
+  "settingSystemGroupEnabled": {
+    "message": "ब्राउज़र पेजों को \"System\" के अंतर्गत समूहित करें",
+    "description": "Label for the toggle that groups browser/system pages under a System group."
+  },
   "settingGroupNewEmptyTabs": {
     "message": "नए खाली टैब्स को \"System\" के अंतर्गत समूहित करें",
     "description": "Label for the toggle that groups blank/new tabs under a System group."

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -77,6 +77,10 @@
     "message": "Поддомен",
     "description": "Option that groups by subdomain (sidebar)."
   },
+  "settingSystemGroupEnabled": {
+    "message": "Группировать страницы браузера в «System»",
+    "description": "Label for the toggle that groups browser/system pages under a System group."
+  },
   "settingGroupNewEmptyTabs": {
     "message": "Группировать новые пустые вкладки в «System»",
     "description": "Label for the toggle that groups blank/new tabs under a System group."

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -77,6 +77,10 @@
     "message": "子域名",
     "description": "Option that groups by subdomain (sidebar)."
   },
+  "settingSystemGroupEnabled": {
+    "message": "将浏览器页面归入“System”",
+    "description": "Label for the toggle that groups browser/system pages under a System group."
+  },
   "settingGroupNewEmptyTabs": {
     "message": "将新的空白标签页归入“System”",
     "description": "Label for the toggle that groups blank/new tabs under a System group."

--- a/services/TabGroupService.ts
+++ b/services/TabGroupService.ts
@@ -88,8 +88,10 @@ class TabGroupServiceSimplified {
       const tab = await browser.tabs.get(tabId)
       console.log(`[TabGroupService] Tab URL: ${tab.url}`)
 
-      // Check if this is a system URL and user has disabled grouping system tabs
-      if (!forceGrouping && !tabGroupState.groupNewTabs) {
+      // Check if this is a system URL and user has disabled grouping system tabs.
+      // systemGroupEnabled wins over forceGrouping: when the System group is off
+      // it must never appear, not even from an explicit "Group Tabs" click.
+      if (!tabGroupState.systemGroupEnabled || (!forceGrouping && !tabGroupState.groupNewTabs)) {
         const domain = extractDomain(tab.url || "", false)
         if (domain === "system") {
           console.log(
@@ -124,6 +126,7 @@ class TabGroupServiceSimplified {
         // Handle system URLs
         const domain = extractDomain(tab.url || "", false)
         if (!customRule && domain === "system") {
+          if (!tabGroupState.systemGroupEnabled) return false
           return await this.moveTabToTargetGroup(tabId, tab, "System", null, "grey")
         }
 
@@ -443,7 +446,7 @@ class TabGroupServiceSimplified {
 
           // Handle tabs with empty/undefined URLs as potential new tabs
           if (!tab.url || tab.url === "") {
-            if (tabGroupState.groupNewTabs) {
+            if (tabGroupState.groupNewTabs && tabGroupState.systemGroupEnabled) {
               await this.moveTabToTargetGroup(tab.id, tab, "System", null, "grey")
             }
             continue
@@ -484,7 +487,7 @@ class TabGroupServiceSimplified {
 
           // Handle tabs with empty/undefined URLs as potential new tabs
           if (!tab.url || tab.url === "") {
-            if (tabGroupState.groupNewTabs) {
+            if (tabGroupState.groupNewTabs && tabGroupState.systemGroupEnabled) {
               await this.moveTabToTargetGroup(tab.id, tab, "System", null, "grey")
             }
             continue
@@ -492,7 +495,10 @@ class TabGroupServiceSimplified {
 
           // For system URLs, respect the groupNewTabs setting
           const domain = extractDomain(tab.url, false)
-          if (domain === "system" && !tabGroupState.groupNewTabs) {
+          if (
+            domain === "system" &&
+            !(tabGroupState.groupNewTabs && tabGroupState.systemGroupEnabled)
+          ) {
             console.log(`[TabGroupService] Skipping system tab ${tab.id} - groupNewTabs disabled`)
             continue
           }
@@ -606,22 +612,24 @@ class TabGroupServiceSimplified {
   }
 
   /**
-   * Ungroups all tabs from the System group (used when groupNewTabs is disabled)
+   * Ungroups all tabs from every System group (used when the System group or
+   * groupNewTabs is disabled). Covers all windows — turning the System group off
+   * should not leave one behind in a window that happens not to be focused.
    */
   async ungroupSystemTabs(): Promise<boolean> {
     try {
       if (!browser.tabGroups) return false
 
-      const groups = await browser.tabGroups.query({ windowId: browser.windows.WINDOW_ID_CURRENT })
-      const systemGroup = groups.find(group => group.title === "System")
+      const groups = await browser.tabGroups.query({})
+      const systemGroups = groups.filter(group => stripIndexPrefix(group.title || "") === "System")
 
-      if (!systemGroup) {
+      if (systemGroups.length === 0) {
         console.log(`[TabGroupService] No System group found`)
         return true
       }
 
-      const tabs = await browser.tabs.query({ groupId: systemGroup.id })
-      if (tabs.length > 0) {
+      for (const systemGroup of systemGroups) {
+        const tabs = await browser.tabs.query({ groupId: systemGroup.id })
         const tabIds = tabs.map(tab => tab.id!).filter(id => id !== undefined)
         if (tabIds.length > 0) {
           await withTabEditRetry(() => browser.tabs.ungroup(tabIds as [number, ...number[]]))

--- a/services/TabGroupState.ts
+++ b/services/TabGroupState.ts
@@ -17,6 +17,7 @@ import { DEFAULT_STATE } from "../types/storage"
 class TabGroupState {
   autoGroupingEnabled: boolean
   groupNewTabs: boolean
+  systemGroupEnabled: boolean
   groupByMode: GroupByMode
   customRules: Map<string, CustomRule>
   ruleMatchingMode: RuleMatchingMode
@@ -33,6 +34,7 @@ class TabGroupState {
   constructor() {
     this.autoGroupingEnabled = DEFAULT_STATE.autoGroupingEnabled
     this.groupNewTabs = DEFAULT_STATE.groupNewTabs
+    this.systemGroupEnabled = DEFAULT_STATE.systemGroupEnabled
     this.groupByMode = DEFAULT_STATE.groupByMode
     this.customRules = new Map()
     this.ruleMatchingMode = DEFAULT_STATE.ruleMatchingMode
@@ -53,6 +55,7 @@ class TabGroupState {
   updateFromStorage(data: Partial<StorageSchema>): void {
     this.autoGroupingEnabled = data.autoGroupingEnabled ?? this.autoGroupingEnabled
     this.groupNewTabs = data.groupNewTabs ?? this.groupNewTabs
+    this.systemGroupEnabled = data.systemGroupEnabled ?? this.systemGroupEnabled
     this.groupByMode = data.groupByMode ?? this.groupByMode
     this.ruleMatchingMode = data.ruleMatchingMode ?? this.ruleMatchingMode
     this.minimumTabsForGroup = data.minimumTabsForGroup ?? this.minimumTabsForGroup
@@ -81,6 +84,7 @@ class TabGroupState {
     return {
       autoGroupingEnabled: this.autoGroupingEnabled,
       groupNewTabs: this.groupNewTabs,
+      systemGroupEnabled: this.systemGroupEnabled,
       groupByMode: this.groupByMode,
       ruleMatchingMode: this.ruleMatchingMode,
       customRules: this.getCustomRulesObject(),

--- a/tests/TabGroupService.test.ts
+++ b/tests/TabGroupService.test.ts
@@ -527,6 +527,132 @@ describe("TabGroupService", () => {
     })
   })
 
+  describe("systemGroupEnabled", () => {
+    beforeEach(() => {
+      tabGroupState.autoGroupingEnabled = true
+      tabGroupState.systemGroupEnabled = false
+      // groupNewTabs stays on: the System group toggle must win regardless
+      tabGroupState.groupNewTabs = true
+    })
+
+    it("should skip system URLs when the System group is disabled", async () => {
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "chrome://settings/",
+        pinned: false,
+        windowId: 1
+      })
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(false)
+      expect(mockBrowser.tabs.group).not.toHaveBeenCalled()
+    })
+
+    it("should skip system URLs even when grouping is forced", async () => {
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "about:config",
+        pinned: false,
+        windowId: 1
+      })
+
+      const result = await tabGroupService.handleTabUpdate(1, true)
+
+      expect(result).toBe(false)
+      expect(mockBrowser.tabs.group).not.toHaveBeenCalled()
+    })
+
+    it("should skip system URLs in rules-only mode when the System group is disabled", async () => {
+      tabGroupState.groupByMode = "rules-only"
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "chrome://extensions/",
+        pinned: false,
+        windowId: 1
+      })
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(false)
+      expect(mockBrowser.tabs.group).not.toHaveBeenCalled()
+    })
+
+    it("should skip empty-URL tabs during bulk grouping when the System group is disabled", async () => {
+      mockBrowser.tabs.query.mockResolvedValue([{ id: 1, url: "", groupId: -1, pinned: false }])
+
+      await tabGroupService.groupAllTabs()
+
+      expect(mockBrowser.tabs.group).not.toHaveBeenCalled()
+    })
+
+    it("should still group regular URLs when the System group is disabled", async () => {
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "https://example.com",
+        pinned: false,
+        windowId: 1,
+        groupId: -1
+      })
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 1, url: "https://example.com", pinned: false, groupId: -1, windowId: 1 }
+      ])
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(true)
+      expect(mockBrowser.tabs.group).toHaveBeenCalled()
+    })
+
+    it("should still group system URLs when the System group is enabled", async () => {
+      tabGroupState.systemGroupEnabled = true
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "chrome://settings/",
+        pinned: false,
+        windowId: 1,
+        groupId: -1
+      })
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 1, url: "chrome://settings/", pinned: false, groupId: -1, windowId: 1 }
+      ])
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(true)
+      expect(mockBrowser.tabs.group).toHaveBeenCalled()
+    })
+  })
+
+  describe("ungroupSystemTabs", () => {
+    it("should ungroup System groups across all windows", async () => {
+      mockBrowser.tabGroups.query.mockResolvedValue([
+        { id: 10, title: "System", windowId: 1 },
+        { id: 11, title: "Example", windowId: 1 },
+        { id: 12, title: "System", windowId: 2 }
+      ])
+      mockBrowser.tabs.query.mockImplementation(({ groupId }: { groupId: number }) =>
+        Promise.resolve(groupId === 10 ? [{ id: 1 }] : groupId === 12 ? [{ id: 2 }] : [])
+      )
+
+      const result = await tabGroupService.ungroupSystemTabs()
+
+      expect(result).toBe(true)
+      expect(mockBrowser.tabs.ungroup).toHaveBeenCalledTimes(2)
+      expect(mockBrowser.tabs.ungroup).toHaveBeenCalledWith([1])
+      expect(mockBrowser.tabs.ungroup).toHaveBeenCalledWith([2])
+    })
+
+    it("should ungroup System groups that carry a sort index prefix", async () => {
+      mockBrowser.tabGroups.query.mockResolvedValue([{ id: 10, title: "3. System", windowId: 1 }])
+      mockBrowser.tabs.query.mockResolvedValue([{ id: 1 }])
+
+      await tabGroupService.ungroupSystemTabs()
+
+      expect(mockBrowser.tabs.ungroup).toHaveBeenCalledWith([1])
+    })
+  })
+
   describe("findGroupByTitle", () => {
     it("should return group when found by title", async () => {
       const group = { id: 1, title: "Test", windowId: 1 }

--- a/tests/e2e/system-group.e2e.ts
+++ b/tests/e2e/system-group.e2e.ts
@@ -1,0 +1,144 @@
+/**
+ * E2E Tests: System Group Toggle
+ *
+ * Tests the opt-in setting that removes the "System" group entirely:
+ * - System tabs stay ungrouped while the setting is off
+ * - Existing System groups are dissolved when the setting is turned off
+ * - The dependent "group new empty tabs" toggle follows it in the UI
+ */
+
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import {
+  closeTestTabs,
+  createTab,
+  disableAutoGroup,
+  enableAutoGroup,
+  getExtensionId,
+  getTabGroups,
+  groupAllTabs,
+  openPopup,
+  sendMessage,
+  setGroupByMode,
+  setMinimumTabs,
+  TEST_URLS,
+  ungroupAllTabs
+} from "./helpers/extension-helpers"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const extensionPath = join(__dirname, "../../.output/chrome-mv3")
+
+let context: BrowserContext
+let extensionId: string
+let popupPage: Page
+
+/** A blank tab resolves to the "system" domain, same as chrome:// pages */
+const SYSTEM_TAB_URL = "about:blank"
+
+async function setSystemGroupEnabled(page: Page, enabled: boolean): Promise<void> {
+  await sendMessage(page, "toggleSystemGroup", { enabled })
+}
+
+async function hasSystemGroup(page: Page): Promise<boolean> {
+  const groups = await getTabGroups(page)
+  return groups.some(group => group.title === "System")
+}
+
+test.beforeAll(async () => {
+  context = await chromium.launchPersistentContext("", {
+    headless: false,
+    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
+  })
+  extensionId = await getExtensionId(context)
+})
+
+test.afterAll(async () => {
+  await context.close()
+})
+
+test.beforeEach(async () => {
+  await closeTestTabs(context)
+  popupPage = await openPopup(context, extensionId)
+  await disableAutoGroup(popupPage)
+  await ungroupAllTabs(popupPage)
+  await setMinimumTabs(popupPage, 1)
+  await setGroupByMode(popupPage, "domain")
+  await setSystemGroupEnabled(popupPage, true)
+})
+
+test.afterEach(async () => {
+  if (popupPage && !popupPage.isClosed()) {
+    await disableAutoGroup(popupPage)
+    await setSystemGroupEnabled(popupPage, true)
+    await ungroupAllTabs(popupPage)
+    await popupPage.close()
+  }
+  await closeTestTabs(context)
+})
+
+test.describe("System Group Toggle", () => {
+  test("is enabled by default", async () => {
+    const result = (await sendMessage(popupPage, "getSystemGroupEnabled")) as { enabled: boolean }
+    expect(result.enabled).toBe(true)
+    await expect(popupPage.locator("#systemGroupToggle")).toBeChecked()
+  })
+
+  test("does not create a System group while disabled", async () => {
+    await setSystemGroupEnabled(popupPage, false)
+    await enableAutoGroup(popupPage)
+
+    await createTab(context, SYSTEM_TAB_URL)
+    await popupPage.waitForTimeout(1000)
+
+    expect(await hasSystemGroup(popupPage)).toBe(false)
+  })
+
+  test("does not create a System group from an explicit Group Tabs click", async () => {
+    await setSystemGroupEnabled(popupPage, false)
+
+    await createTab(context, SYSTEM_TAB_URL)
+    await groupAllTabs(popupPage)
+    await popupPage.waitForTimeout(1000)
+
+    expect(await hasSystemGroup(popupPage)).toBe(false)
+  })
+
+  test("dissolves an existing System group when turned off", async () => {
+    await enableAutoGroup(popupPage)
+    await createTab(context, SYSTEM_TAB_URL)
+    await popupPage.waitForTimeout(1000)
+    expect(await hasSystemGroup(popupPage)).toBe(true)
+
+    await setSystemGroupEnabled(popupPage, false)
+    await popupPage.waitForTimeout(1000)
+
+    expect(await hasSystemGroup(popupPage)).toBe(false)
+  })
+
+  test("still groups regular tabs while disabled", async () => {
+    await setSystemGroupEnabled(popupPage, false)
+    await enableAutoGroup(popupPage)
+
+    await createTab(context, TEST_URLS.domain1)
+    await popupPage.waitForTimeout(1500)
+
+    const groups = await getTabGroups(popupPage)
+    expect(groups.some(group => group.title === "Example")).toBe(true)
+  })
+
+  test("disables the dependent new-empty-tabs toggle in the popup", async () => {
+    const systemToggle = popupPage.locator("#systemGroupToggle")
+    const newTabsToggle = popupPage.locator("#groupNewTabsToggle")
+
+    await expect(newTabsToggle).toBeEnabled()
+
+    // Click the visible label — the checkbox itself is styled away
+    await systemToggle.locator("xpath=ancestor::label").click()
+    await popupPage.waitForTimeout(500)
+
+    await expect(systemToggle).not.toBeChecked()
+    await expect(newTabsToggle).toBeDisabled()
+  })
+})

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -20,9 +20,11 @@ export type MessageAction =
   | "getGroupsCollapseState"
   | "getAutoGroupState"
   | "getGroupNewTabsState"
+  | "getSystemGroupEnabled"
   | "getOnlyApplyToNewTabs"
   | "toggleAutoGroup"
   | "toggleGroupNewTabs"
+  | "toggleSystemGroup"
   | "getGroupByMode"
   | "setGroupByMode"
   | "getMinimumTabsForGroup"
@@ -72,6 +74,7 @@ export interface SimpleMessage extends BaseMessage {
     | "getGroupsCollapseState"
     | "getAutoGroupState"
     | "getGroupNewTabsState"
+    | "getSystemGroupEnabled"
     | "getOnlyApplyToNewTabs"
     | "getGroupByMode"
     | "getMinimumTabsForGroup"
@@ -106,6 +109,14 @@ export interface ToggleAutoGroupMessage extends BaseMessage {
  */
 export interface ToggleGroupNewTabsMessage extends BaseMessage {
   action: "toggleGroupNewTabs"
+  enabled: boolean
+}
+
+/**
+ * Toggle the "System" group on/off message
+ */
+export interface ToggleSystemGroupMessage extends BaseMessage {
+  action: "toggleSystemGroup"
   enabled: boolean
 }
 

--- a/types/storage.ts
+++ b/types/storage.ts
@@ -44,6 +44,8 @@ export interface StorageSchema {
   autoGroupingEnabled: boolean
   /** Whether to group new empty tabs under "System" */
   groupNewTabs: boolean
+  /** Whether the "System" group exists at all (off = system tabs stay ungrouped) */
+  systemGroupEnabled: boolean
   /** How to group tabs: by rules only, domain, or subdomain */
   groupByMode: GroupByMode
   /** Custom rules for grouping specific domains */
@@ -84,6 +86,7 @@ export interface StorageSchema {
 export const DEFAULT_STATE: StorageSchema = {
   autoGroupingEnabled: true,
   groupNewTabs: true,
+  systemGroupEnabled: true,
   groupByMode: "domain",
   customRules: {},
   ruleMatchingMode: "exact",

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -29,6 +29,10 @@ export const groupNewTabs = storage.defineItem<boolean>("local:groupNewTabs", {
   fallback: DEFAULT_STATE.groupNewTabs
 })
 
+export const systemGroupEnabled = storage.defineItem<boolean>("local:systemGroupEnabled", {
+  fallback: DEFAULT_STATE.systemGroupEnabled
+})
+
 export const groupByMode = storage.defineItem<GroupByMode>("local:groupByMode", {
   fallback: DEFAULT_STATE.groupByMode
 })
@@ -109,6 +113,7 @@ export async function loadAllStorage(): Promise<StorageSchema> {
   const [
     autoGroupingEnabledValue,
     groupNewTabsValue,
+    systemGroupEnabledValue,
     groupByModeValue,
     customRulesValue,
     ruleMatchingModeValue,
@@ -128,6 +133,7 @@ export async function loadAllStorage(): Promise<StorageSchema> {
   ] = await Promise.all([
     autoGroupingEnabled.getValue(),
     groupNewTabs.getValue(),
+    systemGroupEnabled.getValue(),
     groupByMode.getValue(),
     customRules.getValue(),
     ruleMatchingMode.getValue(),
@@ -149,6 +155,7 @@ export async function loadAllStorage(): Promise<StorageSchema> {
   return {
     autoGroupingEnabled: autoGroupingEnabledValue,
     groupNewTabs: groupNewTabsValue,
+    systemGroupEnabled: systemGroupEnabledValue,
     groupByMode: groupByModeValue,
     customRules: customRulesValue,
     ruleMatchingMode: ruleMatchingModeValue,
@@ -179,6 +186,9 @@ export async function saveAllStorage(data: Partial<StorageSchema>): Promise<void
   }
   if (data.groupNewTabs !== undefined) {
     promises.push(groupNewTabs.setValue(data.groupNewTabs))
+  }
+  if (data.systemGroupEnabled !== undefined) {
+    promises.push(systemGroupEnabled.setValue(data.systemGroupEnabled))
   }
   if (data.groupByMode !== undefined) {
     promises.push(groupByMode.setValue(data.groupByMode))


### PR DESCRIPTION
Closes #31

## What

Adds a **"Group browser pages under 'System'"** toggle to the popup and sidebar. It is **on by default**, so nothing changes for existing users — as requested in the issue thread, the default stays the current behavior so system tabs don't end up scattered outside every group.

Turning it off:
- keeps browser/system pages (`chrome://`, `about:`, extension pages) ungrouped
- keeps new empty tabs ungrouped
- dissolves any existing System group immediately, in **every** window

## Behavior notes

- The System group toggle wins over `groupNewTabs` **and** over forced grouping. If a user asked for the group to be gone, it must not come back from an explicit "Group Tabs" click.
- The existing "Group new empty tabs under 'System'" toggle is greyed out and disabled while the System group is off, since it has nothing to act on.

## Drive-by fixes in `ungroupSystemTabs`

Both were pre-existing and would have made the new toggle look broken:
- It only queried the **current window**, so a System group in any other window survived.
- It matched the title `"System"` exactly, so it missed `"3. System"` when `indexGroupTitles` is on.

## Test plan

- [x] `bunx vitest run` — 788 pass, including 8 new unit tests covering the auto path, forced grouping, rules-only mode, bulk grouping, and the all-windows/index-prefix ungrouping
- [x] `bunx playwright test` — 34 pass (3 pre-existing skips), including a new `tests/e2e/system-group.e2e.ts` that drives the real popup toggle
- [x] `bun run code:check` clean
- [x] Chrome + Firefox packages build at 3.6.0
- [ ] Manual: confirm the toggle in both popup and sidebar, in Chrome and Firefox

## Localization

New key `settingSystemGroupEnabled` added to all 8 locales (en, de, es, ru, he, ar, hi, zh).

Version bumped to 3.6.0 (new user-facing setting).