### PR TITLE
feat: add catch-all rules for everything unmatched

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -38,6 +38,22 @@ Custom rules support advanced URL pattern matching beyond simple domains.
 | Domain + Path | `docs.google.com/forms` | `docs.google.com/forms*` |
 | TLD Wildcard | `google.**/forms` | `google.com/forms`, `google.org/forms` |
 | Path Wildcard | `site.com/**/admin` | `site.com/any/path/admin` |
+| Catch-All | `*` | everything no other rule took |
+
+### Catch-All Rules
+
+A rule whose pattern is a lone `*` is a catch-all: a bucket for tabs nothing else
+claimed. It never competes with normal rules — it is consulted only after every
+other rule has declined the tab.
+
+- **Rules-only mode**: collects every tab no rule matched.
+- **Domain/sub-domain mode**: collects tabs that can't form their own group,
+  i.e. domains below the minimum group size.
+- Browser/system pages are never collected — they belong to the System group.
+- Blacklist rules still win.
+- Exclusions work as usual: `*` plus `!github.com` catches everything except GitHub.
+- The global minimum group size does not apply to a catch-all group (it defaults
+  to 1); set the rule's own minimum if you want one.
 
 ### Examples
 

--- a/entrypoints/rules-modal.unlisted/index.html
+++ b/entrypoints/rules-modal.unlisted/index.html
@@ -54,7 +54,7 @@ example.com/admin/*
 192.168.1.*"
             required
           ></textarea>
-          <div class="help-text pattern-help" data-i18n="ruleModalPatternsHelp">Supports: domains, wildcards (*.example.com), paths (example.com/api/*), IP addresses</div>
+          <div class="help-text pattern-help" data-i18n="ruleModalPatternsHelp">Supports: domains, wildcards (*.example.com), paths (example.com/api/*), IP addresses, and * on its own for everything else</div>
           <div id="patternFeedback" class="pattern-feedback"></div>
         </div>
         <div class="form-group" id="colorGroup">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/public/_locales/ar/messages.json
+++ b/public/_locales/ar/messages.json
@@ -547,7 +547,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "يدعم: النطاقات، الرموز البدل (*.example.com)، المسارات (example.com/api/*)، عناوين IP",
+    "message": "يدعم: النطاقات، الرموز البدل (*.example.com)، المسارات (example.com/api/*)، عناوين IP، و * بمفردها لكل ما تبقى",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -547,7 +547,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "Unterstützt: Domains, Platzhalter (*.example.com), Pfade (example.com/api/*), IP-Adressen",
+    "message": "Unterstützt: Domains, Platzhalter (*.example.com), Pfade (example.com/api/*), IP-Adressen und * allein für alles Übrige",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -547,7 +547,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "Supports: domains, wildcards (*.example.com), paths (example.com/api/*), IP addresses",
+    "message": "Supports: domains, wildcards (*.example.com), paths (example.com/api/*), IP addresses, and * on its own for everything else",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -547,7 +547,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "Admite: dominios, comodines (*.example.com), rutas (example.com/api/*), direcciones IP",
+    "message": "Admite: dominios, comodines (*.example.com), rutas (example.com/api/*), direcciones IP y * por sí solo para todo lo demás",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/he/messages.json
+++ b/public/_locales/he/messages.json
@@ -547,7 +547,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "תומך ב: דומיינים, תווים כלליים (*.example.com), נתיבים (example.com/api/*), כתובות IP",
+    "message": "תומך ב: דומיינים, תווים כלליים (*.example.com), נתיבים (example.com/api/*), כתובות IP, ו-* לבד עבור כל השאר",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -547,7 +547,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "समर्थित है: डोमेन, वाइल्डकार्ड (*.example.com), पथ (example.com/api/*), IP पते",
+    "message": "समर्थित है: डोमेन, वाइल्डकार्ड (*.example.com), पथ (example.com/api/*), IP पते, और बाकी सब के लिए अकेला *",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -547,7 +547,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "Поддерживаются: домены, подстановки (*.example.com), пути (example.com/api/*), IP-адреса",
+    "message": "Поддерживаются: домены, подстановки (*.example.com), пути (example.com/api/*), IP-адреса и одиночная * для всего остального",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -547,7 +547,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "支持:域名、通配符 (*.example.com)、路径 (example.com/api/*)、IP 地址",
+    "message": "支持:域名、通配符 (*.example.com)、路径 (example.com/api/*)、IP 地址,以及单独的 * 表示其余全部",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/services/RulesService.ts
+++ b/services/RulesService.ts
@@ -5,6 +5,7 @@
 
 import type { CustomRule, RuleData, RulesStats, TabGroupColor } from "../types"
 import { isValidColor } from "../utils/Constants"
+import { extractDomain } from "../utils/DomainUtils"
 import { saveAllStorage } from "../utils/storage"
 import { urlPatternMatcher } from "../utils/UrlPatternMatcher"
 import { tabGroupState } from "./TabGroupState"
@@ -44,6 +45,16 @@ interface ImportResult {
 
 class RulesService {
   /**
+   * A catch-all rule is one with a lone "*" include pattern — it matches every
+   * URL, so it is never treated as a normal rule. It is consulted only after
+   * everything else has declined the tab, via findCatchAllRule().
+   */
+  isCatchAllRule(rule: CustomRule): boolean {
+    const { includePatterns } = this.splitPatterns(rule.domains)
+    return includePatterns.some(pattern => pattern.trim() === "*")
+  }
+
+  /**
    * Finds a matching custom rule for a given URL
    * Uses two-pass matching: exact matches first, then auto-www matches
    * This ensures explicit www.domain.com rules take priority over domain.com with auto-www
@@ -52,7 +63,9 @@ class RulesService {
     if (!url) return null
 
     const customRules = tabGroupState.getCustomRulesObject()
-    const groupingRules = Object.values(customRules).filter(r => !r.isBlacklist)
+    const groupingRules = Object.values(customRules).filter(
+      r => !r.isBlacklist && !this.isCatchAllRule(r)
+    )
 
     console.log(`[RulesService] Found ${groupingRules.length} grouping rules to check`)
 
@@ -62,6 +75,29 @@ class RulesService {
 
     // Second pass: auto-subdomain matches (domain.com matches *.domain.com)
     return this.findMatchInRules(url, groupingRules, true)
+  }
+
+  /**
+   * Finds the catch-all rule for a given URL, if one exists and applies.
+   * Exclusion patterns still count, so a catch-all can carve out exceptions
+   * (e.g. "*" plus "!github.com" catches everything except GitHub).
+   */
+  async findCatchAllRule(url: string): Promise<MatchedRule | null> {
+    if (!url) return null
+
+    // Browser/system pages belong to the System group (or nowhere), never to a
+    // leftovers bucket. Note chrome://settings/ parses with hostname "settings",
+    // which a bare "*" would otherwise happily match.
+    if (extractDomain(url, false) === "system") return null
+
+    const customRules = tabGroupState.getCustomRulesObject()
+    const catchAllRules = Object.values(customRules).filter(
+      r => !r.isBlacklist && this.isCatchAllRule(r)
+    )
+
+    if (catchAllRules.length === 0) return null
+
+    return this.findMatchInRules(url, catchAllRules, false)
   }
 
   /**

--- a/services/TabGroupService.ts
+++ b/services/TabGroupService.ts
@@ -130,13 +130,16 @@ class TabGroupServiceSimplified {
           return await this.moveTabToTargetGroup(tabId, tab, "System", null, "grey")
         }
 
-        if (!customRule) {
+        // Nothing matched — fall back to a catch-all ("*") rule if the user has one
+        const effectiveRule = customRule ?? (await rulesService.findCatchAllRule(tab.url || ""))
+
+        if (!effectiveRule) {
           console.log(`[TabGroupService] Rules-only mode: No rule found for ${tab.url}`)
           return false
         }
 
-        const groupName = customRule.effectiveGroupName || customRule.name
-        return await this.moveTabToTargetGroup(tabId, tab, groupName, customRule)
+        const groupName = effectiveRule.effectiveGroupName || effectiveRule.name
+        return await this.moveTabToTargetGroup(tabId, tab, groupName, effectiveRule)
       }
 
       // Domain/subdomain mode
@@ -169,6 +172,14 @@ class TabGroupServiceSimplified {
     if (customRule && customRule.minimumTabs !== null && customRule.minimumTabs !== undefined) {
       return customRule.minimumTabs
     }
+
+    // A catch-all group collects what nothing else wanted, so the global minimum
+    // does not apply: needing N leftovers before bucketing them is the opposite
+    // of what a leftovers group is for. An explicit per-rule minimum still wins.
+    if (customRule && rulesService.isCatchAllRule(customRule)) {
+      return 1
+    }
+
     return tabGroupState.minimumTabsForGroup || 1
   }
 
@@ -192,9 +203,21 @@ class TabGroupServiceSimplified {
         if (blacklisted) continue
 
         if (customRule) {
-          const matchingRule = await rulesService.findMatchingRule(tab.url || "")
           const expectedGroupName =
             "effectiveGroupName" in customRule ? customRule.effectiveGroupName : customRule.name
+
+          // A catch-all rule only owns tabs that no normal rule claimed.
+          // ponytail: in domain mode this over-counts tabs that domain grouping
+          // will happily group itself. Harmless — over-counting only makes the
+          // leftovers group easier to form, and its minimum is usually 1.
+          const isCatchAll = rulesService.isCatchAllRule(customRule)
+          if (isCatchAll && (await rulesService.findMatchingRule(tab.url || ""))) {
+            continue
+          }
+
+          const matchingRule = isCatchAll
+            ? await rulesService.findCatchAllRule(tab.url || "")
+            : await rulesService.findMatchingRule(tab.url || "")
           const matchGroupName = matchingRule
             ? matchingRule.effectiveGroupName || matchingRule.name
             : null
@@ -235,7 +258,8 @@ class TabGroupServiceSimplified {
     tab: Browser.tabs.Tab,
     expectedTitle: string,
     customRule: MatchedRule | CustomRule | null = null,
-    defaultColor: TabGroupColor | null = null
+    defaultColor: TabGroupColor | null = null,
+    allowCatchAllFallback = true
   ): Promise<boolean> {
     // Check for tabGroups API availability
     if (!browser.tabGroups) {
@@ -294,6 +318,17 @@ class TabGroupServiceSimplified {
 
     if (tabCount < minimumTabs) {
       console.log(`[TabGroupService] Not enough tabs to create group "${expectedTitle}"`)
+
+      // A tab that can't form its own group is exactly what a catch-all rule is for
+      if (allowCatchAllFallback) {
+        const catchAll = await rulesService.findCatchAllRule(tab.url || "")
+        const catchAllTitle = catchAll ? catchAll.effectiveGroupName || catchAll.name : null
+
+        if (catchAllTitle && catchAllTitle !== expectedTitle) {
+          console.log(`[TabGroupService] Falling back to catch-all group "${catchAllTitle}"`)
+          return await this.moveTabToTargetGroup(tabId, tab, catchAllTitle, catchAll, null, false)
+        }
+      }
 
       if (tab.groupId && tab.groupId !== -1) {
         await withTabEditRetry(() => browser.tabs.ungroup([tabId]))

--- a/tests/CatchAllRules.test.ts
+++ b/tests/CatchAllRules.test.ts
@@ -1,0 +1,324 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { tabGroupState } from "../services/TabGroupState"
+import type { CustomRule } from "../types"
+import { DEFAULT_STATE } from "../types/storage"
+import { mockBrowser } from "./setup"
+
+// Mock storage utilities before importing the services
+vi.mock("../utils/storage", () => ({
+  saveAllStorage: vi.fn().mockResolvedValue(undefined),
+  getGroupColor: vi.fn().mockResolvedValue(null),
+  updateGroupColor: vi.fn().mockResolvedValue(undefined),
+  groupColorMapping: {
+    getValue: vi.fn().mockResolvedValue({})
+  }
+}))
+
+import { rulesService } from "../services/RulesService"
+import { tabGroupService } from "../services/TabGroupService"
+
+/**
+ * Tests for catch-all rules — a rule whose pattern is a lone "*".
+ * It never competes with normal rules; it only collects what nothing else took.
+ */
+describe("Catch-all rules", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    tabGroupState.updateFromStorage(DEFAULT_STATE)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function createRule(overrides: Partial<CustomRule> & { id: string }): CustomRule {
+    return {
+      name: "Test Rule",
+      domains: ["example.com"],
+      color: "blue",
+      enabled: true,
+      priority: 1,
+      isBlacklist: false,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      ...overrides
+    }
+  }
+
+  function setupRules(rules: Record<string, CustomRule>): void {
+    tabGroupState.updateFromStorage({
+      ...DEFAULT_STATE,
+      autoGroupingEnabled: true,
+      customRules: rules
+    })
+  }
+
+  const catchAll = (overrides: Partial<CustomRule> = {}) =>
+    createRule({ id: "rule-catch", name: "Other", domains: ["*"], ...overrides })
+
+  describe("isCatchAllRule", () => {
+    it("should detect a lone wildcard pattern", () => {
+      expect(rulesService.isCatchAllRule(catchAll())).toBe(true)
+    })
+
+    it("should detect a catch-all that also carries exclusions", () => {
+      expect(rulesService.isCatchAllRule(catchAll({ domains: ["*", "!github.com"] }))).toBe(true)
+    })
+
+    it("should not treat a scoped wildcard as catch-all", () => {
+      expect(rulesService.isCatchAllRule(createRule({ id: "r", domains: ["*.github.com"] }))).toBe(
+        false
+      )
+      expect(rulesService.isCatchAllRule(createRule({ id: "r", domains: ["google.**"] }))).toBe(
+        false
+      )
+    })
+  })
+
+  describe("findMatchingRule", () => {
+    it("should never return a catch-all rule", async () => {
+      setupRules({ "rule-catch": catchAll() })
+
+      expect(await rulesService.findMatchingRule("https://example.com")).toBeNull()
+    })
+
+    it("should still return normal rules when a catch-all exists", async () => {
+      setupRules({
+        "rule-catch": catchAll(),
+        "rule-gh": createRule({ id: "rule-gh", name: "GitHub", domains: ["github.com"] })
+      })
+
+      const match = await rulesService.findMatchingRule("https://github.com/foo")
+      expect(match?.name).toBe("GitHub")
+    })
+  })
+
+  describe("findCatchAllRule", () => {
+    it("should match any URL", async () => {
+      setupRules({ "rule-catch": catchAll() })
+
+      const match = await rulesService.findCatchAllRule("https://anything.example.org/page")
+      expect(match?.name).toBe("Other")
+    })
+
+    it("should return null when no catch-all rule exists", async () => {
+      setupRules({
+        "rule-gh": createRule({ id: "rule-gh", name: "GitHub", domains: ["github.com"] })
+      })
+
+      expect(await rulesService.findCatchAllRule("https://example.com")).toBeNull()
+    })
+
+    it("should respect exclusion patterns", async () => {
+      setupRules({ "rule-catch": catchAll({ domains: ["*", "!github.com"] }) })
+
+      expect(await rulesService.findCatchAllRule("https://example.com")).not.toBeNull()
+      expect(await rulesService.findCatchAllRule("https://github.com/foo")).toBeNull()
+    })
+
+    it("should ignore disabled catch-all rules", async () => {
+      setupRules({ "rule-catch": catchAll({ enabled: false }) })
+
+      expect(await rulesService.findCatchAllRule("https://example.com")).toBeNull()
+    })
+
+    it("should not match system URLs", async () => {
+      setupRules({ "rule-catch": catchAll() })
+
+      expect(await rulesService.findCatchAllRule("about:blank")).toBeNull()
+      expect(await rulesService.findCatchAllRule("chrome://settings/")).toBeNull()
+    })
+  })
+
+  describe("rules-only mode", () => {
+    beforeEach(() => {
+      mockBrowser.tabGroups.query.mockResolvedValue([])
+      mockBrowser.tabs.group.mockResolvedValue(100)
+    })
+
+    function setMode(rules: Record<string, CustomRule>) {
+      setupRules(rules)
+      tabGroupState.groupByMode = "rules-only"
+    }
+
+    it("should group unmatched tabs into the catch-all group", async () => {
+      setMode({ "rule-catch": catchAll() })
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "https://unmatched.com",
+        pinned: false,
+        windowId: 1,
+        groupId: -1
+      })
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 1, url: "https://unmatched.com", pinned: false, windowId: 1, groupId: -1 }
+      ])
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(true)
+      expect(mockBrowser.tabGroups.update).toHaveBeenCalledWith(
+        100,
+        expect.objectContaining({ title: "Other" })
+      )
+    })
+
+    it("should prefer a normal rule over the catch-all", async () => {
+      setMode({
+        "rule-catch": catchAll(),
+        "rule-gh": createRule({ id: "rule-gh", name: "GitHub", domains: ["github.com"] })
+      })
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "https://github.com/foo",
+        pinned: false,
+        windowId: 1,
+        groupId: -1
+      })
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 1, url: "https://github.com/foo", pinned: false, windowId: 1, groupId: -1 }
+      ])
+
+      await tabGroupService.handleTabUpdate(1)
+
+      expect(mockBrowser.tabGroups.update).toHaveBeenCalledWith(
+        100,
+        expect.objectContaining({ title: "GitHub" })
+      )
+    })
+
+    it("should leave tabs ungrouped when no catch-all rule exists", async () => {
+      setMode({
+        "rule-gh": createRule({ id: "rule-gh", name: "GitHub", domains: ["github.com"] })
+      })
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "https://unmatched.com",
+        pinned: false,
+        windowId: 1,
+        groupId: -1
+      })
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(false)
+      expect(mockBrowser.tabs.group).not.toHaveBeenCalled()
+    })
+
+    it("should not let the catch-all swallow blacklisted tabs", async () => {
+      setMode({
+        "rule-catch": catchAll(),
+        "rule-bl": createRule({
+          id: "rule-bl",
+          name: "Blocked",
+          domains: ["blocked.com"],
+          isBlacklist: true
+        })
+      })
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "https://blocked.com/page",
+        pinned: false,
+        windowId: 1,
+        groupId: -1
+      })
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(false)
+      expect(mockBrowser.tabs.group).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("domain mode", () => {
+    beforeEach(() => {
+      mockBrowser.tabGroups.query.mockResolvedValue([])
+      mockBrowser.tabs.group.mockResolvedValue(100)
+    })
+
+    it("should not swallow tabs that domain grouping can handle", async () => {
+      setupRules({ "rule-catch": catchAll() })
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "https://example.com",
+        pinned: false,
+        windowId: 1,
+        groupId: -1
+      })
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 1, url: "https://example.com", pinned: false, windowId: 1, groupId: -1 }
+      ])
+
+      await tabGroupService.handleTabUpdate(1)
+
+      expect(mockBrowser.tabGroups.update).toHaveBeenCalledWith(
+        100,
+        expect.objectContaining({ title: "Example" })
+      )
+    })
+
+    it("should collect tabs that fall below the minimum group size", async () => {
+      setupRules({ "rule-catch": catchAll() })
+      tabGroupState.minimumTabsForGroup = 2
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "https://lonely.com",
+        pinned: false,
+        windowId: 1,
+        groupId: -1
+      })
+      // Only one tab of this domain — not enough for its own group
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 1, url: "https://lonely.com", pinned: false, windowId: 1, groupId: -1 }
+      ])
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(true)
+      expect(mockBrowser.tabGroups.update).toHaveBeenCalledWith(
+        100,
+        expect.objectContaining({ title: "Other" })
+      )
+    })
+
+    it("should leave below-threshold tabs ungrouped when there is no catch-all", async () => {
+      setupRules({})
+      tabGroupState.minimumTabsForGroup = 2
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "https://lonely.com",
+        pinned: false,
+        windowId: 1,
+        groupId: 5
+      })
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 1, url: "https://lonely.com", pinned: false, windowId: 1, groupId: 5 }
+      ])
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(false)
+      expect(mockBrowser.tabs.ungroup).toHaveBeenCalledWith([1])
+    })
+
+    it("should ungroup rather than recurse when the catch-all itself is below its minimum", async () => {
+      setupRules({ "rule-catch": catchAll({ minimumTabs: 5 }) })
+      tabGroupState.minimumTabsForGroup = 2
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "https://lonely.com",
+        pinned: false,
+        windowId: 1,
+        groupId: 5
+      })
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 1, url: "https://lonely.com", pinned: false, windowId: 1, groupId: 5 }
+      ])
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(false)
+      expect(mockBrowser.tabs.group).not.toHaveBeenCalled()
+      expect(mockBrowser.tabs.ungroup).toHaveBeenCalledWith([1])
+    })
+  })
+})

--- a/tests/e2e/catch-all-rules.e2e.ts
+++ b/tests/e2e/catch-all-rules.e2e.ts
@@ -1,0 +1,163 @@
+/**
+ * E2E Tests: Catch-All Rules
+ *
+ * Tests the "*" rule that collects whatever no other rule claimed:
+ * - Rules-only mode: everything unmatched lands in the catch-all group
+ * - Domain mode: domain grouping wins, the catch-all takes below-threshold tabs
+ * - Normal rules and blacklist rules still take priority
+ */
+
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import {
+  addCustomRule,
+  closeTestTabs,
+  createTab,
+  deleteCustomRule,
+  disableAutoGroup,
+  enableAutoGroup,
+  getCustomRules,
+  getExtensionId,
+  getTabGroups,
+  openPopup,
+  setGroupByMode,
+  setMinimumTabs,
+  TEST_URLS,
+  ungroupAllTabs,
+  waitForGroup
+} from "./helpers/extension-helpers"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const extensionPath = join(__dirname, "../../.output/chrome-mv3")
+
+let context: BrowserContext
+let extensionId: string
+let popupPage: Page
+
+const CATCH_ALL_GROUP = "Other"
+
+async function deleteAllRules(page: Page): Promise<void> {
+  const rules = await getCustomRules(page)
+  for (const ruleId of Object.keys(rules)) {
+    await deleteCustomRule(page, ruleId)
+  }
+}
+
+test.beforeAll(async () => {
+  context = await chromium.launchPersistentContext("", {
+    headless: false,
+    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
+  })
+  extensionId = await getExtensionId(context)
+})
+
+test.afterAll(async () => {
+  await context.close()
+})
+
+test.beforeEach(async () => {
+  await closeTestTabs(context)
+  popupPage = await openPopup(context, extensionId)
+  await disableAutoGroup(popupPage)
+  await ungroupAllTabs(popupPage)
+  await deleteAllRules(popupPage)
+  await setMinimumTabs(popupPage, 1)
+  await setGroupByMode(popupPage, "domain")
+})
+
+test.afterEach(async () => {
+  if (popupPage && !popupPage.isClosed()) {
+    await disableAutoGroup(popupPage)
+    await ungroupAllTabs(popupPage)
+    await deleteAllRules(popupPage)
+    await setMinimumTabs(popupPage, 1)
+    await popupPage.close()
+  }
+  await closeTestTabs(context)
+})
+
+test.describe("Catch-All Rules - rules-only mode", () => {
+  test.beforeEach(async () => {
+    await setGroupByMode(popupPage, "rules-only")
+  })
+
+  test("collects tabs that no rule matched", async () => {
+    await addCustomRule(popupPage, { name: CATCH_ALL_GROUP, domains: ["*"], color: "grey" })
+    await enableAutoGroup(popupPage)
+
+    await createTab(context, TEST_URLS.domain1)
+    await waitForGroup(popupPage, CATCH_ALL_GROUP)
+
+    const groups = await getTabGroups(popupPage)
+    expect(groups.some(group => group.title === CATCH_ALL_GROUP)).toBe(true)
+  })
+
+  test("normal rules still win over the catch-all", async () => {
+    await addCustomRule(popupPage, { name: CATCH_ALL_GROUP, domains: ["*"], color: "grey" })
+    await addCustomRule(popupPage, { name: "Examples", domains: ["example.com"], color: "blue" })
+    await enableAutoGroup(popupPage)
+
+    await createTab(context, TEST_URLS.domain1)
+    await waitForGroup(popupPage, "Examples")
+
+    const groups = await getTabGroups(popupPage)
+    expect(groups.some(group => group.title === "Examples")).toBe(true)
+    expect(groups.some(group => group.title === CATCH_ALL_GROUP)).toBe(false)
+  })
+
+  test("exclusions carve holes in the catch-all", async () => {
+    await addCustomRule(popupPage, {
+      name: CATCH_ALL_GROUP,
+      domains: ["*", "!example.com"],
+      color: "grey"
+    })
+    await enableAutoGroup(popupPage)
+
+    await createTab(context, TEST_URLS.domain1)
+    await createTab(context, TEST_URLS.domain2)
+    await waitForGroup(popupPage, CATCH_ALL_GROUP)
+
+    // httpbin lands in the catch-all, example.com is excluded and stays ungrouped
+    const groups = await getTabGroups(popupPage)
+    const catchAllGroup = groups.find(group => group.title === CATCH_ALL_GROUP)
+    expect(catchAllGroup).toBeDefined()
+
+    const tabs = await popupPage.evaluate(async groupId => {
+      const result = await chrome.tabs.query({ groupId })
+      return result.map(tab => tab.url)
+    }, catchAllGroup?.id)
+
+    expect(tabs.some(url => url?.includes("httpbin"))).toBe(true)
+    expect(tabs.some(url => url?.includes("example.com"))).toBe(false)
+  })
+})
+
+test.describe("Catch-All Rules - domain mode", () => {
+  test("domain grouping wins over the catch-all", async () => {
+    await addCustomRule(popupPage, { name: CATCH_ALL_GROUP, domains: ["*"], color: "grey" })
+    await enableAutoGroup(popupPage)
+
+    await createTab(context, TEST_URLS.domain1)
+    await waitForGroup(popupPage, "Example")
+
+    const groups = await getTabGroups(popupPage)
+    expect(groups.some(group => group.title === "Example")).toBe(true)
+    expect(groups.some(group => group.title === CATCH_ALL_GROUP)).toBe(false)
+  })
+
+  test("collects tabs below the minimum group size", async () => {
+    await setMinimumTabs(popupPage, 2)
+    await addCustomRule(popupPage, { name: CATCH_ALL_GROUP, domains: ["*"], color: "grey" })
+    await enableAutoGroup(popupPage)
+
+    // A single tab of this domain can't reach the minimum of 2
+    await createTab(context, TEST_URLS.domain1)
+    await waitForGroup(popupPage, CATCH_ALL_GROUP)
+
+    const groups = await getTabGroups(popupPage)
+    expect(groups.some(group => group.title === CATCH_ALL_GROUP)).toBe(true)
+    expect(groups.some(group => group.title === "Example")).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #29

## What

A rule whose pattern is a lone `*` is now a **catch-all**: a bucket for tabs nothing else claimed. Create a rule named e.g. "Other" with the single pattern `*` and it collects the leftovers.

The key design point: a catch-all **never competes with normal rules**. It is pulled out of ordinary rule matching entirely and consulted only after everything else has declined the tab. Without that, a `*` rule would match every URL and — since rules outrank domain grouping — silently kill domain grouping for the whole extension.

## Behavior per mode

| Mode | What the catch-all collects |
| --- | --- |
| Rules-only | Every tab no rule matched (@rwiskerke's ask) |
| Domain / sub-domain | Tabs that can't form their own group, i.e. domains below the minimum group size (@cikkle's ask) |

Also:
- **Browser/system pages are never collected** — they belong to the System group. Worth noting `chrome://settings/` parses with hostname `settings`, which a bare `*` would otherwise happily match; this is explicitly guarded.
- **Blacklist rules still win.**
- **Exclusions work as usual**: `*` plus `!github.com` catches everything except GitHub.
- **The global minimum group size does not apply to a catch-all group** (it defaults to 1). Requiring N leftovers before bucketing them defeats the purpose — this is what makes @cikkle's "min 2, everything else in a wildcard group" case actually work. An explicit per-rule minimum still wins.

## Test plan

- [x] `bunx vitest run` — 806 pass, including 18 new tests in `tests/CatchAllRules.test.ts`
- [x] `bunx playwright test tests/e2e/catch-all-rules.e2e.ts` — 5 new E2E tests pass
- [x] `bun run code:check` clean
- [x] Chrome + Firefox packages build at 3.7.0
- [ ] Manual: create an `*` rule in both modes and confirm behavior

Note on the full E2E run: it fails one test per run, a different one each time (auto-collapse / auto-group toggle). I verified this reproduces on unmodified `master` too, so it is pre-existing flakiness under full-suite load, not a regression from this change.

## Not included

- **Rule `priority` is still unused in matching.** `CustomRule.priority` exists and is documented as "higher = more priority", but `RulesService.findMatchInRules` iterates in insertion order and ignores it; the UI sorts *ascending* and the rules modal hardcodes `priority: 1`. Catch-all ordering is handled structurally here (separate tier), so it did not need the priority fix — but two overlapping normal rules still resolve by creation order. Worth its own issue.
- **Re-evaluating existing tabs when a domain becomes viable.** A tab sitting in the catch-all stays there until something triggers its update, even if a second tab of its domain later arrives. This matches how the minimum-tabs threshold already behaves, so it is not a new gap.

## Docs & i18n

`docs/FEATURES.md` gains a Catch-All Rules section. The rules modal's pattern help now mentions `*`, updated across all 8 locales.

Version bumped to 3.7.0.