### PR TITLE
fix: honor rule priority when matching tabs

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -63,6 +63,20 @@ github.com/**/issues        -> github.com/owner/repo/issues
 console.cloud.google.com/** -> any path on console.cloud.google.com
 ```
 
+### Rule Priority
+
+When two rules match the same tab, the one with the higher `priority` wins.
+Rules default to priority `1`, and rules that tie keep creation order — so the
+older rule wins, as before.
+
+Two caveats:
+
+- An exact pattern still beats an implied one regardless of priority:
+  `www.example.com` wins over `example.com` matching `www.example.com` by
+  auto-subdomain, even if the latter has a higher priority.
+- Priority has no UI yet. Set it the same way as `minimumTabs`: export your
+  rules, edit the JSON, re-import.
+
 ### Limitations
 
 - Single `**` per domain or path component
@@ -95,7 +109,8 @@ console.cloud.google.com/** -> any path on console.cloud.google.com
       "domains": ["example.com", "*.subdomain.com"],
       "color": "blue",
       "enabled": true,
-      "minimumTabs": 1
+      "minimumTabs": 1,
+      "priority": 1
     }
   },
   "totalRules": 1

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -245,7 +245,7 @@ function updateRulesDisplay(): void {
   } else {
     groupingRules.sort((a, b) => {
       if (a.priority !== b.priority) {
-        return a.priority - b.priority
+        return b.priority - a.priority
       }
       return a.name.localeCompare(b.name)
     })

--- a/entrypoints/sidebar/main.ts
+++ b/entrypoints/sidebar/main.ts
@@ -247,7 +247,7 @@ function updateRulesDisplay(): void {
   } else {
     groupingRules.sort((a, b) => {
       if (a.priority !== b.priority) {
-        return a.priority - b.priority
+        return b.priority - a.priority
       }
       return a.name.localeCompare(b.name)
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/services/ContextMenuService.ts
+++ b/services/ContextMenuService.ts
@@ -206,9 +206,9 @@ class ContextMenuService {
       return
     }
 
-    // Sort by priority then name
+    // Sort by priority (highest first, matching how rules are evaluated) then name
     const sortedRules = [...enabledRules].sort((a, b) => {
-      if (a.priority !== b.priority) return a.priority - b.priority
+      if (a.priority !== b.priority) return b.priority - a.priority
       return a.name.localeCompare(b.name)
     })
 

--- a/services/RulesService.ts
+++ b/services/RulesService.ts
@@ -132,7 +132,7 @@ class RulesService {
   ): MatchedRule | null {
     const passLabel = allowAutoSubdomain ? " (auto-subdomain)" : ""
 
-    for (const rule of rules) {
+    for (const rule of this.byPriority(rules)) {
       if (!rule.enabled) continue
 
       const { includePatterns, excludePatterns } = this.splitPatterns(rule.domains)
@@ -165,6 +165,16 @@ class RulesService {
     }
 
     return null
+  }
+
+  /**
+   * Orders rules for matching: highest priority first. Array.prototype.sort is
+   * stable, so rules that share a priority keep their existing order — which
+   * preserves the previous first-created-wins behavior for the common case
+   * where every rule sits at the default priority of 1.
+   */
+  private byPriority(rules: readonly CustomRule[]): CustomRule[] {
+    return [...rules].sort((a, b) => (b.priority || 1) - (a.priority || 1))
   }
 
   /**

--- a/tests/RulePriority.test.ts
+++ b/tests/RulePriority.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { tabGroupState } from "../services/TabGroupState"
+import type { CustomRule } from "../types"
+import { DEFAULT_STATE } from "../types/storage"
+
+// Mock storage utilities before importing RulesService
+vi.mock("../utils/storage", () => ({
+  saveAllStorage: vi.fn().mockResolvedValue(undefined),
+  getGroupColor: vi.fn().mockResolvedValue(null),
+  updateGroupColor: vi.fn().mockResolvedValue(undefined),
+  groupColorMapping: {
+    getValue: vi.fn().mockResolvedValue({})
+  }
+}))
+
+import { rulesService } from "../services/RulesService"
+
+/**
+ * Tests for rule priority during matching.
+ * Higher priority wins; equal priorities fall back to creation order.
+ */
+describe("Rule priority", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    tabGroupState.updateFromStorage(DEFAULT_STATE)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function createRule(overrides: Partial<CustomRule> & { id: string }): CustomRule {
+    return {
+      name: "Test Rule",
+      domains: ["example.com"],
+      color: "blue",
+      enabled: true,
+      priority: 1,
+      isBlacklist: false,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      ...overrides
+    }
+  }
+
+  function setupRules(rules: Record<string, CustomRule>): void {
+    tabGroupState.updateFromStorage({
+      ...DEFAULT_STATE,
+      autoGroupingEnabled: true,
+      customRules: rules
+    })
+  }
+
+  it("should prefer the higher-priority rule over the older one", async () => {
+    // Insertion order puts "Everything Google" first — priority must override it
+    setupRules({
+      "rule-google": createRule({
+        id: "rule-google",
+        name: "Everything Google",
+        domains: ["*.google.com"],
+        priority: 1
+      }),
+      "rule-docs": createRule({
+        id: "rule-docs",
+        name: "Docs",
+        domains: ["docs.google.com"],
+        priority: 10
+      })
+    })
+
+    const match = await rulesService.findMatchingRule("https://docs.google.com/document/d/1")
+    expect(match?.name).toBe("Docs")
+  })
+
+  it("should prefer the higher-priority rule regardless of insertion order", async () => {
+    setupRules({
+      "rule-docs": createRule({
+        id: "rule-docs",
+        name: "Docs",
+        domains: ["docs.google.com"],
+        priority: 10
+      }),
+      "rule-google": createRule({
+        id: "rule-google",
+        name: "Everything Google",
+        domains: ["*.google.com"],
+        priority: 1
+      })
+    })
+
+    const match = await rulesService.findMatchingRule("https://docs.google.com/document/d/1")
+    expect(match?.name).toBe("Docs")
+  })
+
+  it("should fall back to insertion order when priorities are equal", async () => {
+    setupRules({
+      "rule-a": createRule({ id: "rule-a", name: "First", domains: ["*.google.com"] }),
+      "rule-b": createRule({ id: "rule-b", name: "Second", domains: ["docs.google.com"] })
+    })
+
+    const match = await rulesService.findMatchingRule("https://docs.google.com/doc")
+    expect(match?.name).toBe("First")
+  })
+
+  it("should treat a missing priority as the default of 1", async () => {
+    setupRules({
+      "rule-low": createRule({
+        id: "rule-low",
+        name: "No Priority",
+        domains: ["*.google.com"],
+        priority: undefined as unknown as number
+      }),
+      "rule-high": createRule({
+        id: "rule-high",
+        name: "Explicit",
+        domains: ["docs.google.com"],
+        priority: 2
+      })
+    })
+
+    const match = await rulesService.findMatchingRule("https://docs.google.com/doc")
+    expect(match?.name).toBe("Explicit")
+  })
+
+  it("should skip disabled rules even at a higher priority", async () => {
+    setupRules({
+      "rule-off": createRule({
+        id: "rule-off",
+        name: "Disabled High",
+        domains: ["docs.google.com"],
+        priority: 10,
+        enabled: false
+      }),
+      "rule-on": createRule({
+        id: "rule-on",
+        name: "Enabled Low",
+        domains: ["*.google.com"],
+        priority: 1
+      })
+    })
+
+    const match = await rulesService.findMatchingRule("https://docs.google.com/doc")
+    expect(match?.name).toBe("Enabled Low")
+  })
+
+  it("should apply priority to blacklist rules too", async () => {
+    setupRules({
+      "rule-bl-low": createRule({
+        id: "rule-bl-low",
+        name: "Broad Block",
+        domains: ["*.google.com"],
+        isBlacklist: true,
+        priority: 1
+      }),
+      "rule-bl-high": createRule({
+        id: "rule-bl-high",
+        name: "Specific Block",
+        domains: ["docs.google.com"],
+        isBlacklist: true,
+        priority: 5
+      })
+    })
+
+    const match = await rulesService.findBlacklistMatch("https://docs.google.com/doc")
+    expect(match?.name).toBe("Specific Block")
+  })
+
+  it("should keep exact matches ahead of auto-subdomain matches regardless of priority", async () => {
+    // The two-pass exact-then-auto-subdomain design still wins over priority:
+    // an explicitly written pattern is more specific than an implied one.
+    setupRules({
+      "rule-exact": createRule({
+        id: "rule-exact",
+        name: "Exact",
+        domains: ["www.example.com"],
+        priority: 1
+      }),
+      "rule-auto": createRule({
+        id: "rule-auto",
+        name: "Auto",
+        domains: ["example.com"],
+        priority: 10
+      })
+    })
+
+    const match = await rulesService.findMatchingRule("https://www.example.com/page")
+    expect(match?.name).toBe("Exact")
+  })
+
+  it("should not mutate the stored rule order", async () => {
+    setupRules({
+      "rule-a": createRule({ id: "rule-a", name: "Low", domains: ["a.com"], priority: 1 }),
+      "rule-b": createRule({ id: "rule-b", name: "High", domains: ["b.com"], priority: 9 })
+    })
+
+    await rulesService.findMatchingRule("https://b.com")
+
+    expect(Object.keys(tabGroupState.getCustomRulesObject())).toEqual(["rule-a", "rule-b"])
+  })
+})


### PR DESCRIPTION
Closes #78

## The bug

`CustomRule.priority` was documented as "higher = more priority", validated on create and import, and preserved through export — and never read during matching. `findMatchInRules` iterated in insertion order and returned the first match, so overlapping rules resolved by **creation order**.

The rules modal already warns "these patterns overlap with existing rules; tabs matching both will only be assigned to one" — while offering no way to decide which.

## The fix

Rules are evaluated highest priority first. `Array.prototype.sort` is stable, so rules sharing a priority keep their existing order — which **preserves today's first-created-wins behavior** for the common case where every rule sits at the default priority of 1. Sorting happens on a copy; stored rule order is untouched (there's a test for that).

This lives in `findMatchInRules`, so it covers normal rules, blacklist rules, and catch-all rules in one place.

Two deliberate non-changes:

- **Exact still beats auto-subdomain, regardless of priority.** The existing two-pass design means an explicit `www.example.com` rule wins over `example.com` matching by auto-subdomain even if the latter has higher priority. Specificity before priority — covered by a test so it doesn't drift.
- **Display order flipped to match.** The rules list and context menu sorted *ascending* (lowest priority first), contradicting the documented meaning. Now highest first. No visible change for existing users, since every rule created through the UI has priority 1.

## Test plan

- [x] `bunx vitest run` — 814 pass, including 8 new tests in `tests/RulePriority.test.ts` (the exact scenario from the issue, tie-breaking, missing priority, disabled rules, blacklist rules, exact-vs-auto-subdomain, no mutation of stored order)
- [x] `bunx playwright test tests/e2e/custom-rules.e2e.ts tests/e2e/catch-all-rules.e2e.ts` — 11 pass
- [x] `bun run code:check` clean
- [x] Chrome + Firefox packages build at 3.7.1

## Still no UI for it

`priority` remains settable only via export → edit JSON → import, exactly like per-rule `minimumTabs`. That's a separate feature request; this PR just makes the field do what it always claimed to do. `docs/FEATURES.md` gains a Rule Priority section documenting the behavior and that workaround.

Version bumped to 3.7.1.