### PR TITLE
feat: add priority and minimum tabs fields to the rule editor

### DIFF
--- a/entrypoints/rules-modal.unlisted/index.html
+++ b/entrypoints/rules-modal.unlisted/index.html
@@ -72,6 +72,18 @@ example.com/admin/*
           </div>
           <input type="hidden" id="ruleColor" value="blue" />
         </div>
+        <div class="form-group advanced-group">
+          <div class="advanced-field">
+            <label for="rulePriority" data-i18n="ruleModalPriorityLabel">Priority</label>
+            <input type="number" id="rulePriority" min="1" max="999" step="1" value="1" />
+            <div class="help-text" data-i18n="ruleModalPriorityHelp">Higher wins when two rules match the same tab</div>
+          </div>
+          <div class="advanced-field" id="minimumTabsField">
+            <label for="ruleMinimumTabs" data-i18n="ruleModalMinimumTabsLabel">Minimum tabs</label>
+            <input type="number" id="ruleMinimumTabs" min="1" max="10" step="1" placeholder="Global setting" data-i18n-placeholder="ruleModalMinimumTabsPlaceholder" />
+            <div class="help-text" data-i18n="ruleModalMinimumTabsHelp">Tabs needed before this group forms. Leave empty to use the global setting</div>
+          </div>
+        </div>
         <div class="form-group checkbox-group">
           <label>
             <input type="checkbox" id="ruleEnabled" checked />

--- a/entrypoints/rules-modal.unlisted/main.ts
+++ b/entrypoints/rules-modal.unlisted/main.ts
@@ -29,6 +29,9 @@ const rulePatternsInput = document.getElementById("rulePatterns") as HTMLTextAre
 const ruleColorInput = document.getElementById("ruleColor") as HTMLInputElement
 const colorPicker = document.getElementById("colorPicker") as HTMLDivElement
 const ruleEnabledCheckbox = document.getElementById("ruleEnabled") as HTMLInputElement
+const rulePriorityInput = document.getElementById("rulePriority") as HTMLInputElement
+const ruleMinimumTabsInput = document.getElementById("ruleMinimumTabs") as HTMLInputElement
+const minimumTabsField = document.getElementById("minimumTabsField") as HTMLDivElement
 const colorGroup = document.getElementById("colorGroup") as HTMLDivElement
 
 // Blacklist mode — determined by URL param, not a checkbox
@@ -121,6 +124,9 @@ async function loadExistingRule(): Promise<void> {
       rulePatternsInput.value = rule.domains.join("\n")
       setColorPickerValue(rule.color || "blue")
       ruleEnabledCheckbox.checked = rule.enabled !== false
+      rulePriorityInput.value = String(rule.priority ?? 1)
+      ruleMinimumTabsInput.value =
+        rule.minimumTabs === null || rule.minimumTabs === undefined ? "" : String(rule.minimumTabs)
     }
   } catch (error) {
     console.error("Error loading rule:", error)
@@ -148,7 +154,34 @@ function buildRuleData(): RuleData | null {
     return null
   }
 
-  return { name, domains: patterns, color, enabled, priority: 1, isBlacklist: isBlacklistMode }
+  const priority = Number.parseInt(rulePriorityInput.value, 10)
+  if (Number.isNaN(priority) || priority < 1) {
+    alert(t("ruleModalInvalidPriority", "Priority must be a whole number of 1 or more"))
+    return null
+  }
+
+  // Empty means "use the global setting" — null tells the background to clear
+  // any per-rule override, which undefined would leave in place.
+  const rawMinimumTabs = ruleMinimumTabsInput.value.trim()
+  let minimumTabs: number | null = null
+  if (rawMinimumTabs !== "") {
+    minimumTabs = Number.parseInt(rawMinimumTabs, 10)
+    if (Number.isNaN(minimumTabs) || minimumTabs < 1 || minimumTabs > 10) {
+      alert(t("ruleModalInvalidMinimumTabs", "Minimum tabs must be a number between 1 and 10"))
+      return null
+    }
+  }
+
+  return {
+    name,
+    domains: patterns,
+    color,
+    enabled,
+    priority,
+    // Blacklist rules never form groups, so a minimum tab count is meaningless
+    minimumTabs: isBlacklistMode ? null : minimumTabs,
+    isBlacklist: isBlacklistMode
+  }
 }
 
 // Persist rule to background
@@ -293,6 +326,7 @@ function applyBlacklistMode(): void {
     ? t("ruleModalUpdate", "Update Rule")
     : t("ruleModalSave", "Save Rule")
   colorGroup.style.display = "none"
+  minimumTabsField.style.display = "none"
   ruleNameInput.required = false
   const ruleNameGroup = ruleNameInput.closest(".form-group")
   if (ruleNameGroup) (ruleNameGroup as HTMLElement).style.display = "none"

--- a/entrypoints/rules-modal.unlisted/style.css
+++ b/entrypoints/rules-modal.unlisted/style.css
@@ -69,6 +69,30 @@ h1 {
   min-height: 100px;
 }
 
+.advanced-group {
+  display: flex;
+  gap: 12px;
+}
+
+.advanced-field {
+  flex: 1;
+  min-width: 0;
+}
+
+.form-group input[type="number"] {
+  width: 100%;
+  padding: 10px 12px;
+  border: 2px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 14px;
+  transition: border-color 0.2s;
+}
+
+.form-group input[type="number"]:focus {
+  outline: none;
+  border-color: var(--primary-color);
+}
+
 .checkbox-group {
   display: flex;
   align-items: center;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.7.1",
+  "version": "3.8.0",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/public/_locales/ar/messages.json
+++ b/public/_locales/ar/messages.json
@@ -563,6 +563,34 @@
   "ruleModalColorCyan": { "message": "سماوي", "description": "Color option: cyan." },
   "ruleModalColorOrange": { "message": "برتقالي", "description": "Color option: orange." },
   "ruleModalColorGrey": { "message": "رمادي", "description": "Color option: grey." },
+  "ruleModalPriorityLabel": {
+    "message": "الأولوية",
+    "description": "Label for the rule priority input in the rule editor."
+  },
+  "ruleModalPriorityHelp": {
+    "message": "الأعلى يفوز عندما تتطابق قاعدتان مع نفس علامة التبويب",
+    "description": "Help text explaining what rule priority does."
+  },
+  "ruleModalMinimumTabsLabel": {
+    "message": "الحد الأدنى لعلامات التبويب",
+    "description": "Label for the per-rule minimum tabs input in the rule editor."
+  },
+  "ruleModalMinimumTabsHelp": {
+    "message": "عدد علامات التبويب اللازمة لإنشاء هذه المجموعة. اتركه فارغًا لاستخدام الإعداد العام",
+    "description": "Help text for the per-rule minimum tabs input."
+  },
+  "ruleModalMinimumTabsPlaceholder": {
+    "message": "الإعداد العام",
+    "description": "Placeholder for the per-rule minimum tabs input, meaning the global setting applies."
+  },
+  "ruleModalInvalidPriority": {
+    "message": "يجب أن تكون الأولوية عددًا صحيحًا من 1 أو أكثر",
+    "description": "Alert shown when the entered rule priority is not a positive whole number."
+  },
+  "ruleModalInvalidMinimumTabs": {
+    "message": "يجب أن يكون الحد الأدنى لعلامات التبويب رقمًا بين 1 و10",
+    "description": "Alert shown when the entered per-rule minimum tabs value is out of range."
+  },
   "ruleModalEnabledLabel": {
     "message": "مُفعَّلة",
     "description": "Checkbox: whether the rule is enabled."

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -563,6 +563,34 @@
   "ruleModalColorCyan": { "message": "Türkis", "description": "Color option: cyan." },
   "ruleModalColorOrange": { "message": "Orange", "description": "Color option: orange." },
   "ruleModalColorGrey": { "message": "Grau", "description": "Color option: grey." },
+  "ruleModalPriorityLabel": {
+    "message": "Priorität",
+    "description": "Label for the rule priority input in the rule editor."
+  },
+  "ruleModalPriorityHelp": {
+    "message": "Höher gewinnt, wenn zwei Regeln auf denselben Tab passen",
+    "description": "Help text explaining what rule priority does."
+  },
+  "ruleModalMinimumTabsLabel": {
+    "message": "Mindestanzahl Tabs",
+    "description": "Label for the per-rule minimum tabs input in the rule editor."
+  },
+  "ruleModalMinimumTabsHelp": {
+    "message": "Tabs, die nötig sind, damit diese Gruppe entsteht. Leer lassen für die globale Einstellung",
+    "description": "Help text for the per-rule minimum tabs input."
+  },
+  "ruleModalMinimumTabsPlaceholder": {
+    "message": "Globale Einstellung",
+    "description": "Placeholder for the per-rule minimum tabs input, meaning the global setting applies."
+  },
+  "ruleModalInvalidPriority": {
+    "message": "Priorität muss eine ganze Zahl ab 1 sein",
+    "description": "Alert shown when the entered rule priority is not a positive whole number."
+  },
+  "ruleModalInvalidMinimumTabs": {
+    "message": "Mindestanzahl Tabs muss zwischen 1 und 10 liegen",
+    "description": "Alert shown when the entered per-rule minimum tabs value is out of range."
+  },
   "ruleModalEnabledLabel": {
     "message": "Aktiviert",
     "description": "Checkbox: whether the rule is enabled."

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -563,6 +563,34 @@
   "ruleModalColorCyan": { "message": "Cyan", "description": "Color option: cyan." },
   "ruleModalColorOrange": { "message": "Orange", "description": "Color option: orange." },
   "ruleModalColorGrey": { "message": "Grey", "description": "Color option: grey." },
+  "ruleModalPriorityLabel": {
+    "message": "Priority",
+    "description": "Label for the rule priority input in the rule editor."
+  },
+  "ruleModalPriorityHelp": {
+    "message": "Higher wins when two rules match the same tab",
+    "description": "Help text explaining what rule priority does."
+  },
+  "ruleModalMinimumTabsLabel": {
+    "message": "Minimum tabs",
+    "description": "Label for the per-rule minimum tabs input in the rule editor."
+  },
+  "ruleModalMinimumTabsHelp": {
+    "message": "Tabs needed before this group forms. Leave empty to use the global setting",
+    "description": "Help text for the per-rule minimum tabs input."
+  },
+  "ruleModalMinimumTabsPlaceholder": {
+    "message": "Global setting",
+    "description": "Placeholder for the per-rule minimum tabs input, meaning the global setting applies."
+  },
+  "ruleModalInvalidPriority": {
+    "message": "Priority must be a whole number of 1 or more",
+    "description": "Alert shown when the entered rule priority is not a positive whole number."
+  },
+  "ruleModalInvalidMinimumTabs": {
+    "message": "Minimum tabs must be a number between 1 and 10",
+    "description": "Alert shown when the entered per-rule minimum tabs value is out of range."
+  },
   "ruleModalEnabledLabel": {
     "message": "Enabled",
     "description": "Checkbox: whether the rule is enabled."

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -563,6 +563,34 @@
   "ruleModalColorCyan": { "message": "Cian", "description": "Color option: cyan." },
   "ruleModalColorOrange": { "message": "Naranja", "description": "Color option: orange." },
   "ruleModalColorGrey": { "message": "Gris", "description": "Color option: grey." },
+  "ruleModalPriorityLabel": {
+    "message": "Prioridad",
+    "description": "Label for the rule priority input in the rule editor."
+  },
+  "ruleModalPriorityHelp": {
+    "message": "El valor más alto gana cuando dos reglas coinciden con la misma pestaña",
+    "description": "Help text explaining what rule priority does."
+  },
+  "ruleModalMinimumTabsLabel": {
+    "message": "Pestañas mínimas",
+    "description": "Label for the per-rule minimum tabs input in the rule editor."
+  },
+  "ruleModalMinimumTabsHelp": {
+    "message": "Pestañas necesarias para crear este grupo. Déjalo vacío para usar el ajuste global",
+    "description": "Help text for the per-rule minimum tabs input."
+  },
+  "ruleModalMinimumTabsPlaceholder": {
+    "message": "Ajuste global",
+    "description": "Placeholder for the per-rule minimum tabs input, meaning the global setting applies."
+  },
+  "ruleModalInvalidPriority": {
+    "message": "La prioridad debe ser un número entero de 1 o más",
+    "description": "Alert shown when the entered rule priority is not a positive whole number."
+  },
+  "ruleModalInvalidMinimumTabs": {
+    "message": "Las pestañas mínimas deben ser un número entre 1 y 10",
+    "description": "Alert shown when the entered per-rule minimum tabs value is out of range."
+  },
   "ruleModalEnabledLabel": {
     "message": "Activada",
     "description": "Checkbox: whether the rule is enabled."

--- a/public/_locales/he/messages.json
+++ b/public/_locales/he/messages.json
@@ -563,6 +563,34 @@
   "ruleModalColorCyan": { "message": "טורקיז", "description": "Color option: cyan." },
   "ruleModalColorOrange": { "message": "כתום", "description": "Color option: orange." },
   "ruleModalColorGrey": { "message": "אפור", "description": "Color option: grey." },
+  "ruleModalPriorityLabel": {
+    "message": "עדיפות",
+    "description": "Label for the rule priority input in the rule editor."
+  },
+  "ruleModalPriorityHelp": {
+    "message": "ערך גבוה יותר מנצח כששני כללים מתאימים לאותה לשונית",
+    "description": "Help text explaining what rule priority does."
+  },
+  "ruleModalMinimumTabsLabel": {
+    "message": "מינימום לשוניות",
+    "description": "Label for the per-rule minimum tabs input in the rule editor."
+  },
+  "ruleModalMinimumTabsHelp": {
+    "message": "כמה לשוניות נדרשות כדי ליצור את הקבוצה. השאירו ריק לשימוש בהגדרה הגלובלית",
+    "description": "Help text for the per-rule minimum tabs input."
+  },
+  "ruleModalMinimumTabsPlaceholder": {
+    "message": "הגדרה גלובלית",
+    "description": "Placeholder for the per-rule minimum tabs input, meaning the global setting applies."
+  },
+  "ruleModalInvalidPriority": {
+    "message": "העדיפות חייבת להיות מספר שלם של 1 או יותר",
+    "description": "Alert shown when the entered rule priority is not a positive whole number."
+  },
+  "ruleModalInvalidMinimumTabs": {
+    "message": "מינימום הלשוניות חייב להיות מספר בין 1 ל-10",
+    "description": "Alert shown when the entered per-rule minimum tabs value is out of range."
+  },
   "ruleModalEnabledLabel": {
     "message": "מופעל",
     "description": "Checkbox: whether the rule is enabled."

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -563,6 +563,34 @@
   "ruleModalColorCyan": { "message": "सियान", "description": "Color option: cyan." },
   "ruleModalColorOrange": { "message": "नारंगी", "description": "Color option: orange." },
   "ruleModalColorGrey": { "message": "स्लेटी", "description": "Color option: grey." },
+  "ruleModalPriorityLabel": {
+    "message": "प्राथमिकता",
+    "description": "Label for the rule priority input in the rule editor."
+  },
+  "ruleModalPriorityHelp": {
+    "message": "जब दो नियम एक ही टैब से मेल खाते हैं तो अधिक मान जीतता है",
+    "description": "Help text explaining what rule priority does."
+  },
+  "ruleModalMinimumTabsLabel": {
+    "message": "न्यूनतम टैब्स",
+    "description": "Label for the per-rule minimum tabs input in the rule editor."
+  },
+  "ruleModalMinimumTabsHelp": {
+    "message": "यह समूह बनने के लिए आवश्यक टैब्स। वैश्विक सेटिंग उपयोग करने के लिए खाली छोड़ें",
+    "description": "Help text for the per-rule minimum tabs input."
+  },
+  "ruleModalMinimumTabsPlaceholder": {
+    "message": "वैश्विक सेटिंग",
+    "description": "Placeholder for the per-rule minimum tabs input, meaning the global setting applies."
+  },
+  "ruleModalInvalidPriority": {
+    "message": "प्राथमिकता 1 या उससे अधिक की पूर्ण संख्या होनी चाहिए",
+    "description": "Alert shown when the entered rule priority is not a positive whole number."
+  },
+  "ruleModalInvalidMinimumTabs": {
+    "message": "न्यूनतम टैब्स 1 और 10 के बीच की संख्या होनी चाहिए",
+    "description": "Alert shown when the entered per-rule minimum tabs value is out of range."
+  },
   "ruleModalEnabledLabel": {
     "message": "सक्षम",
     "description": "Checkbox: whether the rule is enabled."

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -563,6 +563,34 @@
   "ruleModalColorCyan": { "message": "Голубой", "description": "Color option: cyan." },
   "ruleModalColorOrange": { "message": "Оранжевый", "description": "Color option: orange." },
   "ruleModalColorGrey": { "message": "Серый", "description": "Color option: grey." },
+  "ruleModalPriorityLabel": {
+    "message": "Приоритет",
+    "description": "Label for the rule priority input in the rule editor."
+  },
+  "ruleModalPriorityHelp": {
+    "message": "При совпадении двух правил побеждает большее значение",
+    "description": "Help text explaining what rule priority does."
+  },
+  "ruleModalMinimumTabsLabel": {
+    "message": "Минимум вкладок",
+    "description": "Label for the per-rule minimum tabs input in the rule editor."
+  },
+  "ruleModalMinimumTabsHelp": {
+    "message": "Сколько вкладок нужно для создания группы. Оставьте пустым для общей настройки",
+    "description": "Help text for the per-rule minimum tabs input."
+  },
+  "ruleModalMinimumTabsPlaceholder": {
+    "message": "Общая настройка",
+    "description": "Placeholder for the per-rule minimum tabs input, meaning the global setting applies."
+  },
+  "ruleModalInvalidPriority": {
+    "message": "Приоритет должен быть целым числом от 1",
+    "description": "Alert shown when the entered rule priority is not a positive whole number."
+  },
+  "ruleModalInvalidMinimumTabs": {
+    "message": "Минимум вкладок должен быть числом от 1 до 10",
+    "description": "Alert shown when the entered per-rule minimum tabs value is out of range."
+  },
   "ruleModalEnabledLabel": {
     "message": "Включено",
     "description": "Checkbox: whether the rule is enabled."

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -563,6 +563,34 @@
   "ruleModalColorCyan": { "message": "青色", "description": "Color option: cyan." },
   "ruleModalColorOrange": { "message": "橙色", "description": "Color option: orange." },
   "ruleModalColorGrey": { "message": "灰色", "description": "Color option: grey." },
+  "ruleModalPriorityLabel": {
+    "message": "优先级",
+    "description": "Label for the rule priority input in the rule editor."
+  },
+  "ruleModalPriorityHelp": {
+    "message": "当两条规则匹配同一标签页时,数值大的优先",
+    "description": "Help text explaining what rule priority does."
+  },
+  "ruleModalMinimumTabsLabel": {
+    "message": "最少标签页数",
+    "description": "Label for the per-rule minimum tabs input in the rule editor."
+  },
+  "ruleModalMinimumTabsHelp": {
+    "message": "创建该分组所需的标签页数。留空则使用全局设置",
+    "description": "Help text for the per-rule minimum tabs input."
+  },
+  "ruleModalMinimumTabsPlaceholder": {
+    "message": "全局设置",
+    "description": "Placeholder for the per-rule minimum tabs input, meaning the global setting applies."
+  },
+  "ruleModalInvalidPriority": {
+    "message": "优先级必须是大于或等于 1 的整数",
+    "description": "Alert shown when the entered rule priority is not a positive whole number."
+  },
+  "ruleModalInvalidMinimumTabs": {
+    "message": "最少标签页数必须是 1 到 10 之间的数字",
+    "description": "Alert shown when the entered per-rule minimum tabs value is out of range."
+  },
   "ruleModalEnabledLabel": {
     "message": "已启用",
     "description": "Checkbox: whether the rule is enabled."

--- a/services/RulesService.ts
+++ b/services/RulesService.ts
@@ -246,7 +246,7 @@ class RulesService {
         : "blue") as TabGroupColor,
       enabled: ruleData.enabled !== false,
       priority: ruleData.priority || 1,
-      minimumTabs: ruleData.minimumTabs,
+      minimumTabs: ruleData.minimumTabs ?? undefined,
       isBlacklist: ruleData.isBlacklist ?? false,
       createdAt: new Date().toISOString()
     }
@@ -284,7 +284,11 @@ class RulesService {
         : existingRule.color) as TabGroupColor,
       enabled: ruleData.enabled !== false,
       priority: ruleData.priority || existingRule.priority,
-      minimumTabs: ruleData.minimumTabs ?? existingRule.minimumTabs,
+      // null clears the override; undefined means "not supplied, keep what's there"
+      minimumTabs:
+        ruleData.minimumTabs === null
+          ? undefined
+          : (ruleData.minimumTabs ?? existingRule.minimumTabs),
       isBlacklist: ruleData.isBlacklist ?? existingRule.isBlacklist ?? false
     }
 

--- a/tests/RuleEditing.test.ts
+++ b/tests/RuleEditing.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { tabGroupState } from "../services/TabGroupState"
+import type { CustomRule } from "../types"
+import { DEFAULT_STATE } from "../types/storage"
+
+vi.mock("../utils/storage", () => ({
+  saveAllStorage: vi.fn().mockResolvedValue(undefined),
+  getGroupColor: vi.fn().mockResolvedValue(null),
+  updateGroupColor: vi.fn().mockResolvedValue(undefined),
+  groupColorMapping: {
+    getValue: vi.fn().mockResolvedValue({})
+  }
+}))
+
+import { rulesService } from "../services/RulesService"
+
+/**
+ * Tests for editing the per-rule priority and minimum tabs fields exposed by
+ * the rule editor.
+ */
+describe("Rule editing - priority and minimum tabs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    tabGroupState.updateFromStorage(DEFAULT_STATE)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function seedRule(overrides: Partial<CustomRule> = {}): string {
+    const rule: CustomRule = {
+      id: "rule-1",
+      name: "Docs",
+      domains: ["docs.google.com"],
+      color: "blue",
+      enabled: true,
+      priority: 1,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      ...overrides
+    }
+    tabGroupState.updateFromStorage({ ...DEFAULT_STATE, customRules: { "rule-1": rule } })
+    return "rule-1"
+  }
+
+  const stored = (ruleId: string) => tabGroupState.getCustomRulesObject()[ruleId]
+
+  describe("addRule", () => {
+    it("should persist a priority and a per-rule minimum", async () => {
+      const ruleId = await rulesService.addRule({
+        name: "Docs",
+        domains: ["docs.google.com"],
+        priority: 7,
+        minimumTabs: 3
+      })
+
+      expect(stored(ruleId).priority).toBe(7)
+      expect(stored(ruleId).minimumTabs).toBe(3)
+    })
+
+    it("should default priority to 1 when not supplied", async () => {
+      const ruleId = await rulesService.addRule({ name: "Docs", domains: ["docs.google.com"] })
+
+      expect(stored(ruleId).priority).toBe(1)
+    })
+
+    it("should store null minimum tabs as no override", async () => {
+      const ruleId = await rulesService.addRule({
+        name: "Docs",
+        domains: ["docs.google.com"],
+        minimumTabs: null
+      })
+
+      expect(stored(ruleId).minimumTabs).toBeUndefined()
+    })
+
+    it("should reject an out-of-range minimum", async () => {
+      await expect(
+        rulesService.addRule({ name: "Docs", domains: ["docs.google.com"], minimumTabs: 99 })
+      ).rejects.toThrow(/Minimum tabs/)
+    })
+  })
+
+  describe("updateRule", () => {
+    it("should update the priority", async () => {
+      const ruleId = seedRule({ priority: 1 })
+
+      await rulesService.updateRule(ruleId, {
+        name: "Docs",
+        domains: ["docs.google.com"],
+        priority: 5
+      })
+
+      expect(stored(ruleId).priority).toBe(5)
+    })
+
+    it("should set a per-rule minimum", async () => {
+      const ruleId = seedRule()
+
+      await rulesService.updateRule(ruleId, {
+        name: "Docs",
+        domains: ["docs.google.com"],
+        minimumTabs: 4
+      })
+
+      expect(stored(ruleId).minimumTabs).toBe(4)
+    })
+
+    it("should clear the per-rule minimum when given null", async () => {
+      const ruleId = seedRule({ minimumTabs: 4 })
+
+      await rulesService.updateRule(ruleId, {
+        name: "Docs",
+        domains: ["docs.google.com"],
+        minimumTabs: null
+      })
+
+      expect(stored(ruleId).minimumTabs).toBeUndefined()
+    })
+
+    it("should keep the existing minimum when the field is not supplied", async () => {
+      const ruleId = seedRule({ minimumTabs: 4 })
+
+      await rulesService.updateRule(ruleId, { name: "Docs", domains: ["docs.google.com"] })
+
+      expect(stored(ruleId).minimumTabs).toBe(4)
+    })
+  })
+
+  describe("effective minimum tabs", () => {
+    it("should fall back to the global setting once the override is cleared", async () => {
+      const { tabGroupService } = await import("../services/TabGroupService")
+      const ruleId = seedRule({ minimumTabs: 4 })
+      tabGroupState.minimumTabsForGroup = 2
+
+      expect(tabGroupService.getEffectiveMinimumTabs(stored(ruleId))).toBe(4)
+
+      await rulesService.updateRule(ruleId, {
+        name: "Docs",
+        domains: ["docs.google.com"],
+        minimumTabs: null
+      })
+
+      expect(tabGroupService.getEffectiveMinimumTabs(stored(ruleId))).toBe(2)
+    })
+  })
+})

--- a/tests/e2e/rule-editor-fields.e2e.ts
+++ b/tests/e2e/rule-editor-fields.e2e.ts
@@ -1,0 +1,163 @@
+/**
+ * E2E Tests: Rule Editor Priority & Minimum Tabs Fields
+ *
+ * Drives the real rule editor form (rules-modal.html) rather than the message
+ * API, so the DOM wiring is actually exercised:
+ * - Creating a rule persists priority and the per-rule minimum
+ * - Editing a rule loads both fields back into the form
+ * - Clearing the minimum restores the global setting
+ * - Blacklist mode hides the minimum-tabs field
+ */
+
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import {
+  closeTestTabs,
+  deleteCustomRule,
+  disableAutoGroup,
+  getCustomRules,
+  getExtensionId,
+  openPopup,
+  ungroupAllTabs
+} from "./helpers/extension-helpers"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const extensionPath = join(__dirname, "../../.output/chrome-mv3")
+
+let context: BrowserContext
+let extensionId: string
+let popupPage: Page
+
+interface StoredRule {
+  id: string
+  name: string
+  priority?: number
+  minimumTabs?: number
+}
+
+async function deleteAllRules(page: Page): Promise<void> {
+  const rules = await getCustomRules(page)
+  for (const ruleId of Object.keys(rules)) {
+    await deleteCustomRule(page, ruleId)
+  }
+}
+
+async function openRuleEditor(query = ""): Promise<Page> {
+  const page = await context.newPage()
+  await page.goto(`chrome-extension://${extensionId}/rules-modal.html${query}`)
+  await page.waitForLoadState("domcontentloaded")
+  return page
+}
+
+/** Reads rules straight from storage, so it works after the editor closes itself */
+async function readRules(): Promise<Record<string, StoredRule>> {
+  const rules = await getCustomRules(popupPage)
+  return rules as unknown as Record<string, StoredRule>
+}
+
+async function findRule(name: string): Promise<StoredRule | undefined> {
+  return Object.values(await readRules()).find(rule => rule.name === name)
+}
+
+test.beforeAll(async () => {
+  context = await chromium.launchPersistentContext("", {
+    headless: false,
+    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
+  })
+  extensionId = await getExtensionId(context)
+})
+
+test.afterAll(async () => {
+  await context.close()
+})
+
+test.beforeEach(async () => {
+  await closeTestTabs(context)
+  popupPage = await openPopup(context, extensionId)
+  await disableAutoGroup(popupPage)
+  await ungroupAllTabs(popupPage)
+  await deleteAllRules(popupPage)
+})
+
+test.afterEach(async () => {
+  if (popupPage && !popupPage.isClosed()) {
+    await deleteAllRules(popupPage)
+    await popupPage.close()
+  }
+  await closeTestTabs(context)
+})
+
+test.describe("Rule editor - priority and minimum tabs", () => {
+  test("defaults priority to 1 and leaves the minimum empty", async () => {
+    const editor = await openRuleEditor()
+
+    await expect(editor.locator("#rulePriority")).toHaveValue("1")
+    await expect(editor.locator("#ruleMinimumTabs")).toHaveValue("")
+
+    await editor.close()
+  })
+
+  test("saves both fields when creating a rule", async () => {
+    const editor = await openRuleEditor()
+
+    await editor.locator("#ruleName").fill("Docs")
+    await editor.locator("#rulePatterns").fill("docs.google.com")
+    await editor.locator("#rulePriority").fill("7")
+    await editor.locator("#ruleMinimumTabs").fill("3")
+    await editor.locator("#saveButton").click()
+    await popupPage.waitForTimeout(500)
+
+    const rule = await findRule("Docs")
+    expect(rule?.priority).toBe(7)
+    expect(rule?.minimumTabs).toBe(3)
+  })
+
+  test("loads both fields back when editing a rule", async () => {
+    const create = await openRuleEditor()
+    await create.locator("#ruleName").fill("Docs")
+    await create.locator("#rulePatterns").fill("docs.google.com")
+    await create.locator("#rulePriority").fill("7")
+    await create.locator("#ruleMinimumTabs").fill("3")
+    await create.locator("#saveButton").click()
+    await popupPage.waitForTimeout(500)
+
+    const rule = await findRule("Docs")
+    const editor = await openRuleEditor(`?edit=true&ruleId=${rule?.id}`)
+
+    await expect(editor.locator("#rulePriority")).toHaveValue("7")
+    await expect(editor.locator("#ruleMinimumTabs")).toHaveValue("3")
+
+    await editor.close()
+  })
+
+  test("clearing the minimum removes the per-rule override", async () => {
+    const create = await openRuleEditor()
+    await create.locator("#ruleName").fill("Docs")
+    await create.locator("#rulePatterns").fill("docs.google.com")
+    await create.locator("#ruleMinimumTabs").fill("3")
+    await create.locator("#saveButton").click()
+    await popupPage.waitForTimeout(500)
+
+    const rule = await findRule("Docs")
+    expect(rule?.minimumTabs).toBe(3)
+
+    const editor = await openRuleEditor(`?edit=true&ruleId=${rule?.id}`)
+    await editor.locator("#ruleMinimumTabs").fill("")
+    await editor.locator("#saveButton").click()
+    await popupPage.waitForTimeout(500)
+
+    const updated = await findRule("Docs")
+    expect(updated?.minimumTabs).toBeUndefined()
+  })
+
+  test("hides the minimum-tabs field for blacklist rules but keeps priority", async () => {
+    const editor = await openRuleEditor("?blacklist=true")
+
+    await expect(editor.locator("#minimumTabsField")).toBeHidden()
+    await expect(editor.locator("#rulePriority")).toBeVisible()
+
+    await editor.close()
+  })
+})

--- a/types/rules.ts
+++ b/types/rules.ts
@@ -61,7 +61,8 @@ export interface RuleData {
   color?: TabGroupColor
   enabled?: boolean
   priority?: number
-  minimumTabs?: number
+  /** Per-rule override; null clears it so the global setting applies again */
+  minimumTabs?: number | null
   isBlacklist?: boolean
   id?: string
   createdAt?: string


### PR DESCRIPTION
Follows #78 / #79, which made `priority` actually affect matching. This exposes it — and per-rule `minimumTabs` — in the UI.

## What

Both fields already existed on `CustomRule`, were validated, and survived export/import. But the rule editor hardcoded `priority: 1` and offered no minimum-tabs input at all, so the only way to set either was export → edit JSON → re-import.

The editor now shows them side by side under the color picker:

- **Priority** — whole number, defaults to 1. Higher wins when two rules match the same tab.
- **Minimum tabs** — 1–10, placeholder "Global setting". Empty means the global minimum applies.

Blacklist rules hide the minimum-tabs field (they never form groups) and the priority field expands to fill the row.

## A bug this surfaced

Clearing a per-rule minimum could not have worked: `updateRule` did `ruleData.minimumTabs ?? existingRule.minimumTabs`, so an emptied field sent `undefined` and the old override stayed put. `RuleData.minimumTabs` now accepts `null` to mean "clear it", with `undefined` still meaning "not supplied, keep what's there". Both paths are covered by tests.

## Test plan

- [x] `bunx vitest run` — 823 pass, including 9 new tests in `tests/RuleEditing.test.ts` (persisting both fields, defaults, clearing the override, the out-of-range rejection, and that clearing restores the global minimum)
- [x] `bunx playwright test tests/e2e/rule-editor-fields.e2e.ts` — 5 new tests that drive the **real modal form**, not the message API: create with both fields, reopen in edit mode and confirm they load back, clear the minimum, and blacklist mode hiding the field
- [x] `bun run code:check` clean
- [x] Rendering checked by screenshot in both normal and blacklist mode
- [x] Chrome + Firefox packages build at 3.8.0

Full E2E run fails one auto-collapse test, a different one each run; passes in isolation. Same pre-existing flakiness I verified on unmodified `master` while working on #29 — unrelated to this change, which touches no collapse code.

## Unrelated bug found while testing

The modal title is wrong in blacklist mode: it reads "Create Custom Rule" instead of "Add to Blacklist". `applyBlacklistMode()` sets the title synchronously, then the async i18n init calls `applyI18nToDom()`, which re-translates every `data-i18n` element and overwrites it. Edit mode is likely affected the same way. Pre-existing, unrelated to these fields, so I left it out of this diff — worth its own issue.

## Localization

7 new keys (2 labels, 2 help texts, 1 placeholder, 2 validation alerts) across all 8 locales; each file now has 190 keys.

Version bumped to 3.8.0.