### PR TITLE
fix: keep the rule editor title correct in every mode

### DIFF
--- a/entrypoints/rules-modal.unlisted/main.ts
+++ b/entrypoints/rules-modal.unlisted/main.ts
@@ -108,9 +108,6 @@ function sendMessage<T = Record<string, unknown>>(message: Record<string, unknow
 async function loadExistingRule(): Promise<void> {
   if (!isEditMode || !ruleId) return
 
-  modalTitle.textContent = t("ruleModalEditTitle", "Edit Custom Rule")
-  saveButton.textContent = t("ruleModalUpdate", "Update Rule")
-
   try {
     const response = await sendMessage<{
       customRules?: Record<string, RuleData>
@@ -319,12 +316,6 @@ function cancel(): void {
 // Apply blacklist mode UI adjustments
 function applyBlacklistMode(): void {
   if (!isBlacklistMode) return
-  modalTitle.textContent = isEditMode
-    ? t("blacklistEditTitle", "Edit Blacklist Rule")
-    : t("blacklistAddButton", "Add to Blacklist")
-  saveButton.textContent = isEditMode
-    ? t("ruleModalUpdate", "Update Rule")
-    : t("ruleModalSave", "Save Rule")
   colorGroup.style.display = "none"
   minimumTabsField.style.display = "none"
   ruleNameInput.required = false
@@ -360,8 +351,6 @@ function setupColorPicker(): void {
 // Pre-populate form from group data
 function loadFromGroup(): void {
   if (!isFromGroup) return
-
-  modalTitle.textContent = t("contextMenuCreateRuleFromGroup", "Create Rule from Group")
 
   // Pre-populate form fields
   ruleNameInput.value = groupName
@@ -483,6 +472,30 @@ async function generateRuleFromDescription(): Promise<void> {
     aiGenerateBtn.classList.remove("generating")
   }
 }
+/**
+ * Applies the title and save-button text for the current mode.
+ *
+ * This has to run *after* applyI18nToDom(): that pass re-translates every
+ * [data-i18n] element, so anything written to the title earlier — during
+ * blacklist, edit or from-group setup — would be overwritten by the generic
+ * "Create Custom Rule". Running it here also guarantees t() sees the loaded
+ * override catalog rather than falling back to the browser UI locale.
+ */
+function applyModeText(): void {
+  if (isBlacklistMode) {
+    modalTitle.textContent = isEditMode
+      ? t("blacklistEditTitle", "Edit Blacklist Rule")
+      : t("blacklistAddButton", "Add to Blacklist")
+  } else if (isEditMode) {
+    modalTitle.textContent = t("ruleModalEditTitle", "Edit Custom Rule")
+  } else if (isFromGroup) {
+    modalTitle.textContent = t("contextMenuCreateRuleFromGroup", "Create Rule from Group")
+  }
+
+  saveButton.textContent = isEditMode
+    ? t("ruleModalUpdate", "Update Rule")
+    : t("ruleModalSave", "Save Rule")
+}
 // Initialize — resolve locale from background, load override catalog if any,
 // then translate the DOM and set text direction.
 ;(async () => {
@@ -491,12 +504,15 @@ async function generateRuleFromDescription(): Promise<void> {
   await initI18n(locale)
   applyI18nToDom()
   applyDirectionToDom(resolveEffectiveLocale(locale))
+
+  // Both call t(), so they wait for the catalog and for the translation pass
+  applyModeText()
+  checkAiAvailability()
 })()
 setupColorPicker()
 loadExistingRule()
 loadFromGroup()
 setupPatternModeToggle()
-checkAiAvailability()
 
 // Auto-focus AI description when opened via AI Assist entry point
 if (isAiAssist) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/tests/e2e/rule-editor-title.e2e.ts
+++ b/tests/e2e/rule-editor-title.e2e.ts
@@ -1,0 +1,146 @@
+/**
+ * E2E Tests: Rule Editor Title & Save Button
+ *
+ * The editor's title and save button are mode-specific, but every [data-i18n]
+ * element is re-translated once the locale catalog loads. These tests pin the
+ * final rendered text for each mode so a translation pass can't quietly
+ * overwrite it again.
+ */
+
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import {
+  addCustomRule,
+  closeTestTabs,
+  deleteCustomRule,
+  disableAutoGroup,
+  getCustomRules,
+  getExtensionId,
+  openPopup
+} from "./helpers/extension-helpers"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const extensionPath = join(__dirname, "../../.output/chrome-mv3")
+
+let context: BrowserContext
+let extensionId: string
+let popupPage: Page
+
+async function deleteAllRules(page: Page): Promise<void> {
+  const rules = await getCustomRules(page)
+  for (const ruleId of Object.keys(rules)) {
+    await deleteCustomRule(page, ruleId)
+  }
+}
+
+async function openRuleEditor(query = ""): Promise<Page> {
+  const page = await context.newPage()
+  await page.goto(`chrome-extension://${extensionId}/rules-modal.html${query}`)
+  await page.waitForLoadState("networkidle")
+  return page
+}
+
+test.beforeAll(async () => {
+  context = await chromium.launchPersistentContext("", {
+    headless: false,
+    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
+  })
+  extensionId = await getExtensionId(context)
+})
+
+test.afterAll(async () => {
+  await context.close()
+})
+
+test.beforeEach(async () => {
+  await closeTestTabs(context)
+  popupPage = await openPopup(context, extensionId)
+  await disableAutoGroup(popupPage)
+  await deleteAllRules(popupPage)
+})
+
+test.afterEach(async () => {
+  if (popupPage && !popupPage.isClosed()) {
+    await deleteAllRules(popupPage)
+    await popupPage.close()
+  }
+  await closeTestTabs(context)
+})
+
+test.describe("Rule editor title", () => {
+  test("shows the create title in the default mode", async () => {
+    const editor = await openRuleEditor()
+
+    await expect(editor.locator("#modalTitle")).toHaveText("Create Custom Rule")
+    await expect(editor.locator("#saveButton")).toHaveText("Save Rule")
+
+    await editor.close()
+  })
+
+  test("shows the blacklist title in blacklist mode", async () => {
+    const editor = await openRuleEditor("?blacklist=true")
+
+    await expect(editor.locator("#modalTitle")).toHaveText("Add to Blacklist")
+    await expect(editor.locator("#saveButton")).toHaveText("Save Rule")
+
+    await editor.close()
+  })
+
+  test("shows the edit title when editing a rule", async () => {
+    const ruleId = await addCustomRule(popupPage, { name: "Docs", domains: ["docs.google.com"] })
+    const editor = await openRuleEditor(`?edit=true&ruleId=${ruleId}`)
+
+    await expect(editor.locator("#modalTitle")).toHaveText("Edit Custom Rule")
+    await expect(editor.locator("#saveButton")).toHaveText("Update Rule")
+
+    await editor.close()
+  })
+
+  test("shows the blacklist edit title when editing a blacklist rule", async () => {
+    const ruleId = await addCustomRule(popupPage, { name: "Blocked", domains: ["blocked.com"] })
+    const editor = await openRuleEditor(`?edit=true&ruleId=${ruleId}&blacklist=true`)
+
+    await expect(editor.locator("#modalTitle")).toHaveText("Edit blacklist rule")
+    await expect(editor.locator("#saveButton")).toHaveText("Update Rule")
+
+    await editor.close()
+  })
+
+  test("shows the from-group title when created from a group", async () => {
+    const editor = await openRuleEditor("?fromGroup=true&name=Work&color=blue&domains=example.com")
+
+    await expect(editor.locator("#modalTitle")).toHaveText("Create Rule from Group")
+    await expect(editor.locator("#saveButton")).toHaveText("Save Rule")
+
+    await editor.close()
+  })
+
+  test("keeps the mode title after the locale catalog loads", async () => {
+    // The overwrite this guards against happened once the override catalog
+    // resolved, so re-assert with a non-default locale selected.
+    await popupPage.evaluate(
+      async () =>
+        await new Promise(resolve =>
+          chrome.runtime.sendMessage({ action: "setUserLocale", locale: "de" }, resolve)
+        )
+    )
+
+    try {
+      const editor = await openRuleEditor("?blacklist=true")
+      await editor.waitForTimeout(500)
+
+      await expect(editor.locator("#modalTitle")).toHaveText("Zur Sperrliste hinzufügen")
+
+      await editor.close()
+    } finally {
+      await popupPage.evaluate(
+        async () =>
+          await new Promise(resolve =>
+            chrome.runtime.sendMessage({ action: "setUserLocale", locale: "auto" }, resolve)
+          )
+      )
+    }
+  })
+})


### PR DESCRIPTION
Fixes the bug I flagged in #80.

## The bug

The rule editor always showed **"Create Custom Rule"** — when adding a blacklist rule, when editing an existing rule, and when creating a rule from a group. The save button lost its "Update Rule" text the same way.

Mode setup (`applyBlacklistMode`, `loadExistingRule`, `loadFromGroup`) wrote the title synchronously at module load. The async i18n init then ran `applyI18nToDom()`, which re-translates every `[data-i18n]` element — resetting the title to the generic create string. The async pass always won, because the sync writes had already happened before its first `await` resolved.

It turned out to be broader than the blacklist case I originally spotted: edit mode and from-group mode were both affected.

## The fix

Title and save-button text now come from a single `applyModeText()`, called after `applyI18nToDom()`. One owner, and the translation pass can no longer clobber it.

This also fixes a second-order bug at those call sites: they ran `t()` *before* `initI18n()` had resolved, so a user with a locale override got browser-locale text instead of their chosen language. `checkAiAvailability()` had the same problem and moved into the same block.

The layout work in `applyBlacklistMode()` and the field pre-population in `loadFromGroup()` stay synchronous, so nothing flashes on open.

## Test plan

- [x] New `tests/e2e/rule-editor-title.e2e.ts` — 6 tests pinning the title and button text for create, blacklist, edit, blacklist-edit, from-group, and one that re-checks with a German locale override (the exact condition under which the overwrite happened)
- [x] **Verified the tests catch the bug**: reverted just the source fix, rebuilt, and 5 of the 6 fail — every mode-specific title, with only the default create case passing. Restored the fix and all 6 pass.
- [x] `bunx vitest run` — 823 pass
- [x] `bunx playwright test tests/e2e/rule-editor-title.e2e.ts tests/e2e/rule-editor-fields.e2e.ts` — 11 pass
- [x] `bun run code:check` clean
- [x] Chrome + Firefox packages build at 3.8.1

Version bumped to 3.8.1.