### PR TITLE
feat: let users exclude groups from auto-grouping

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -25,6 +25,27 @@ if (changeInfo.pinned === false) {
 }
 ```
 
+## Groups Excluded From Auto-Grouping
+
+Auto-grouping never touches a group whose title is on the excluded list. The
+list is always explicit — the extension does not try to work out which groups
+you made yourself.
+
+- **Adding**: right-click a tab in the group → "Exclude group from auto-grouping".
+- **Removing**: the popup and sidebar list every excluded group; removing one
+  hands it straight back to auto-grouping.
+- **At install**: groups that already existed the first time the extension runs
+  are excluded automatically. A group present before the extension has ever run
+  cannot have been created by it, so this needs no guesswork — it stops a fresh
+  install from dissolving organization you built by hand.
+
+Excluded groups are skipped by automatic grouping, by the "Group Tabs" button,
+and by "Ungroup All". To dissolve one, use the browser's own right-click menu.
+
+Titles are matched with any sort-index prefix stripped, so the "Number groups"
+setting doesn't break exclusions. Renaming an excluded group ends its
+exclusion — title is identity here, as everywhere else in the extension.
+
 ## URL Patterns
 
 Custom rules support advanced URL pattern matching beyond simple domains.

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -15,6 +15,7 @@ import {
   tabGroupService,
   tabGroupState
 } from "../services"
+import { seedProtectedGroupsOnFirstRun } from "../services/FirstRunService"
 import {
   parseAiRuleResponse,
   parseAiSuggestionResponse,
@@ -40,6 +41,7 @@ export default defineBackground(() => {
     if (!stateInitialized) {
       try {
         console.log("Service worker starting - loading state from storage...")
+        await seedProtectedGroupsOnFirstRun()
         const storageData = await loadAllStorage()
         tabGroupState.updateFromStorage(storageData)
         aiService.updateFromStorage(storageData)
@@ -301,6 +303,34 @@ export default defineBackground(() => {
             await contextMenuService.rebuildMenus()
             result = { locale: tabGroupState.userLocale }
             break
+
+          case "getProtectedGroups":
+            result = { titles: tabGroupState.protectedGroupTitles }
+            break
+
+          case "addProtectedGroup": {
+            const title = msg.title.trim()
+            if (title && !tabGroupState.protectedGroupTitles.includes(title)) {
+              tabGroupState.protectedGroupTitles = [...tabGroupState.protectedGroupTitles, title]
+              await saveState()
+            }
+            result = { titles: tabGroupState.protectedGroupTitles }
+            break
+          }
+
+          case "removeProtectedGroup": {
+            tabGroupState.protectedGroupTitles = tabGroupState.protectedGroupTitles.filter(
+              title => title !== msg.title
+            )
+            await saveState()
+
+            // The group is fair game again — pick it up on the next pass
+            if (tabGroupState.autoGroupingEnabled) {
+              await tabGroupService.groupAllTabs()
+            }
+            result = { titles: tabGroupState.protectedGroupTitles }
+            break
+          }
 
           case "toggleIndexGroupTitles": {
             tabGroupState.indexGroupTitles = msg.enabled

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -82,6 +82,13 @@
             <span class="slider round"></span>
           </label>
         </div>
+        <div class="toggle-container protected-groups-container hidden" id="protectedGroupsContainer">
+          <span data-i18n="settingProtectedGroups">Groups excluded from auto-grouping</span>
+        </div>
+        <div class="protected-groups-list hidden" id="protectedGroupsList"></div>
+        <div class="help-text protected-groups-help hidden" id="protectedGroupsHelp" data-i18n="settingProtectedGroupsHelp">
+          Right-click a tab to exclude its group. Remove one to let auto-grouping manage it again
+        </div>
         <div class="toggle-container">
           <span data-i18n="settingMinimumTabsForGroup">Minimum tabs to form a group</span>
           <div class="number-input-container">

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -20,6 +20,11 @@ const expandAllButton = document.getElementById("expandAllButton") as HTMLButton
 const autoGroupToggle = document.getElementById("autoGroupToggle") as HTMLInputElement
 const groupNewTabsToggle = document.getElementById("groupNewTabsToggle") as HTMLInputElement
 const systemGroupToggle = document.getElementById("systemGroupToggle") as HTMLInputElement
+const protectedGroupsContainer = document.getElementById(
+  "protectedGroupsContainer"
+) as HTMLDivElement
+const protectedGroupsList = document.getElementById("protectedGroupsList") as HTMLDivElement
+const protectedGroupsHelp = document.getElementById("protectedGroupsHelp") as HTMLDivElement
 const groupByToggleOptions = document.querySelectorAll<HTMLButtonElement>(
   ".group-by-toggle-bar:not(.sort-direction-toggle-bar) .toggle-option"
 )
@@ -667,7 +672,48 @@ function syncGroupNewTabsAvailability(systemGroupEnabled: boolean): void {
   groupNewTabsToggle.closest(".toggle-container")?.classList.toggle("disabled", !systemGroupEnabled)
 }
 
+/**
+ * Renders the groups the user excluded from auto-grouping. The whole block
+ * stays hidden until there is something to show, so people who never use the
+ * feature never see it.
+ */
+async function renderProtectedGroups(): Promise<void> {
+  const response = await sendMessage<{ titles?: string[] }>({ action: "getProtectedGroups" })
+  const titles = response?.titles ?? []
+
+  protectedGroupsList.innerHTML = ""
+  const isEmpty = titles.length === 0
+
+  for (const element of [protectedGroupsContainer, protectedGroupsList, protectedGroupsHelp]) {
+    element.classList.toggle("hidden", isEmpty)
+  }
+
+  for (const title of titles) {
+    const chip = document.createElement("div")
+    chip.className = "protected-group-chip"
+
+    const label = document.createElement("span")
+    label.textContent = title
+    label.title = title
+
+    const remove = document.createElement("button")
+    remove.type = "button"
+    remove.textContent = "\u00d7"
+    remove.title = t("settingProtectedGroupsRemove", "Resume auto-grouping for this group")
+    remove.addEventListener("click", async () => {
+      await sendMessage({ action: "removeProtectedGroup", title })
+      await renderProtectedGroups()
+    })
+
+    chip.appendChild(label)
+    chip.appendChild(remove)
+    protectedGroupsList.appendChild(chip)
+  }
+}
+
 // Initialize toggle states
+renderProtectedGroups()
+
 sendMessage<{ enabled?: boolean }>({ action: "getAutoGroupState" }).then(response => {
   if (response?.enabled !== undefined) {
     autoGroupToggle.checked = response.enabled

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -222,6 +222,40 @@ footer {
   background-color: #3f8f6a;
 }
 
+.protected-groups-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.protected-group-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  padding: 4px 8px;
+  border-radius: 12px;
+  background: var(--secondary-color, #e5e7eb);
+  font-size: 12px;
+}
+
+.protected-group-chip span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.protected-group-chip button {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0;
+  color: inherit;
+}
+
 .toggle-container.disabled {
   opacity: 0.5;
 }
@@ -1548,4 +1582,9 @@ input:checked + .slider:before {
 [dir="rtl"] .help-text,
 [dir="rtl"] .settings-info {
   text-align: right;
+}
+
+/* Utility — declared last so it beats the layout rules above */
+.hidden {
+  display: none;
 }

--- a/entrypoints/sidebar/index.html
+++ b/entrypoints/sidebar/index.html
@@ -83,6 +83,13 @@
               <span class="slider round"></span>
             </label>
           </div>
+          <div class="toggle-container protected-groups-container hidden" id="protectedGroupsContainer">
+            <span data-i18n="settingProtectedGroups">Groups excluded from auto-grouping</span>
+          </div>
+          <div class="protected-groups-list hidden" id="protectedGroupsList"></div>
+          <div class="help-text protected-groups-help hidden" id="protectedGroupsHelp" data-i18n="settingProtectedGroupsHelp">
+            Right-click a tab to exclude its group. Remove one to let auto-grouping manage it again
+          </div>
           <div class="toggle-container">
             <span data-i18n="settingMinimumTabsForGroup">Minimum tabs to form a group</span>
             <div class="number-input-container">

--- a/entrypoints/sidebar/main.ts
+++ b/entrypoints/sidebar/main.ts
@@ -21,6 +21,11 @@ const expandAllButton = document.getElementById("expandAllButton") as HTMLButton
 const autoGroupToggle = document.getElementById("autoGroupToggle") as HTMLInputElement
 const groupNewTabsToggle = document.getElementById("groupNewTabsToggle") as HTMLInputElement
 const systemGroupToggle = document.getElementById("systemGroupToggle") as HTMLInputElement
+const protectedGroupsContainer = document.getElementById(
+  "protectedGroupsContainer"
+) as HTMLDivElement
+const protectedGroupsList = document.getElementById("protectedGroupsList") as HTMLDivElement
+const protectedGroupsHelp = document.getElementById("protectedGroupsHelp") as HTMLDivElement
 const groupByToggleOptions = document.querySelectorAll<HTMLButtonElement>(
   ".group-by-toggle-bar:not(.sort-direction-toggle-bar) .toggle-option"
 )
@@ -717,7 +722,48 @@ function syncGroupNewTabsAvailability(systemGroupEnabled: boolean): void {
   groupNewTabsToggle.closest(".toggle-container")?.classList.toggle("disabled", !systemGroupEnabled)
 }
 
+/**
+ * Renders the groups the user excluded from auto-grouping. The whole block
+ * stays hidden until there is something to show, so people who never use the
+ * feature never see it.
+ */
+async function renderProtectedGroups(): Promise<void> {
+  const response = await sendMessage<{ titles?: string[] }>({ action: "getProtectedGroups" })
+  const titles = response?.titles ?? []
+
+  protectedGroupsList.innerHTML = ""
+  const isEmpty = titles.length === 0
+
+  for (const element of [protectedGroupsContainer, protectedGroupsList, protectedGroupsHelp]) {
+    element.classList.toggle("hidden", isEmpty)
+  }
+
+  for (const title of titles) {
+    const chip = document.createElement("div")
+    chip.className = "protected-group-chip"
+
+    const label = document.createElement("span")
+    label.textContent = title
+    label.title = title
+
+    const remove = document.createElement("button")
+    remove.type = "button"
+    remove.textContent = "\u00d7"
+    remove.title = t("settingProtectedGroupsRemove", "Resume auto-grouping for this group")
+    remove.addEventListener("click", async () => {
+      await sendMessage({ action: "removeProtectedGroup", title })
+      await renderProtectedGroups()
+    })
+
+    chip.appendChild(label)
+    chip.appendChild(remove)
+    protectedGroupsList.appendChild(chip)
+  }
+}
+
 // Initialize toggle states
+renderProtectedGroups()
+
 sendMessage<{ enabled?: boolean }>({ action: "getAutoGroupState" }).then(response => {
   if (response?.enabled !== undefined) {
     autoGroupToggle.checked = response.enabled

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/public/_locales/ar/messages.json
+++ b/public/_locales/ar/messages.json
@@ -85,6 +85,22 @@
     "message": "تجميع علامات التبويب الفارغة الجديدة تحت «System»",
     "description": "Label for the toggle that groups blank/new tabs under a System group."
   },
+  "contextMenuProtectGroup": {
+    "message": "استبعاد المجموعة من التجميع التلقائي",
+    "description": "Right-click menu: stop auto-grouping from managing the clicked tab's group."
+  },
+  "settingProtectedGroups": {
+    "message": "المجموعات المستبعدة من التجميع التلقائي",
+    "description": "Label for the list of groups excluded from auto-grouping."
+  },
+  "settingProtectedGroupsHelp": {
+    "message": "انقر بزر الفأرة الأيمن على علامة تبويب لاستبعاد مجموعتها. أزل الإدخال ليعود التجميع التلقائي إلى إدارتها",
+    "description": "Help text explaining how to add and remove excluded groups."
+  },
+  "settingProtectedGroupsRemove": {
+    "message": "استئناف التجميع التلقائي لهذه المجموعة",
+    "description": "Tooltip on the button that removes a group from the excluded list."
+  },
   "settingMinimumTabsForGroup": {
     "message": "الحد الأدنى لعلامات التبويب لتكوين مجموعة",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -85,6 +85,22 @@
     "message": "Neue leere Tabs unter „System“ gruppieren",
     "description": "Label for the toggle that groups blank/new tabs under a System group."
   },
+  "contextMenuProtectGroup": {
+    "message": "Gruppe von automatischer Gruppierung ausschließen",
+    "description": "Right-click menu: stop auto-grouping from managing the clicked tab's group."
+  },
+  "settingProtectedGroups": {
+    "message": "Von automatischer Gruppierung ausgeschlossene Gruppen",
+    "description": "Label for the list of groups excluded from auto-grouping."
+  },
+  "settingProtectedGroupsHelp": {
+    "message": "Rechtsklick auf einen Tab, um dessen Gruppe auszuschließen. Entfernen, damit sie wieder automatisch gruppiert wird",
+    "description": "Help text explaining how to add and remove excluded groups."
+  },
+  "settingProtectedGroupsRemove": {
+    "message": "Automatische Gruppierung für diese Gruppe fortsetzen",
+    "description": "Tooltip on the button that removes a group from the excluded list."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Mindestanzahl an Tabs für eine Gruppe",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -85,6 +85,22 @@
     "message": "Group new empty tabs under \"System\"",
     "description": "Label for the toggle that groups blank/new tabs under a System group."
   },
+  "contextMenuProtectGroup": {
+    "message": "Exclude group from auto-grouping",
+    "description": "Right-click menu: stop auto-grouping from managing the clicked tab's group."
+  },
+  "settingProtectedGroups": {
+    "message": "Groups excluded from auto-grouping",
+    "description": "Label for the list of groups excluded from auto-grouping."
+  },
+  "settingProtectedGroupsHelp": {
+    "message": "Right-click a tab to exclude its group. Remove one to let auto-grouping manage it again",
+    "description": "Help text explaining how to add and remove excluded groups."
+  },
+  "settingProtectedGroupsRemove": {
+    "message": "Resume auto-grouping for this group",
+    "description": "Tooltip on the button that removes a group from the excluded list."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Minimum tabs to form a group",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -85,6 +85,22 @@
     "message": "Agrupar nuevas pestañas vacías en «System»",
     "description": "Label for the toggle that groups blank/new tabs under a System group."
   },
+  "contextMenuProtectGroup": {
+    "message": "Excluir grupo de la agrupación automática",
+    "description": "Right-click menu: stop auto-grouping from managing the clicked tab's group."
+  },
+  "settingProtectedGroups": {
+    "message": "Grupos excluidos de la agrupación automática",
+    "description": "Label for the list of groups excluded from auto-grouping."
+  },
+  "settingProtectedGroupsHelp": {
+    "message": "Haz clic derecho en una pestaña para excluir su grupo. Elimínalo para que la agrupación automática vuelva a gestionarlo",
+    "description": "Help text explaining how to add and remove excluded groups."
+  },
+  "settingProtectedGroupsRemove": {
+    "message": "Reanudar la agrupación automática para este grupo",
+    "description": "Tooltip on the button that removes a group from the excluded list."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Mínimo de pestañas para formar un grupo",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/he/messages.json
+++ b/public/_locales/he/messages.json
@@ -85,6 +85,22 @@
     "message": "קבץ לשוניות ריקות חדשות תחת \"System\"",
     "description": "Label for the toggle that groups blank/new tabs under a System group."
   },
+  "contextMenuProtectGroup": {
+    "message": "החרג את הקבוצה מקיבוץ אוטומטי",
+    "description": "Right-click menu: stop auto-grouping from managing the clicked tab's group."
+  },
+  "settingProtectedGroups": {
+    "message": "קבוצות שהוחרגו מקיבוץ אוטומטי",
+    "description": "Label for the list of groups excluded from auto-grouping."
+  },
+  "settingProtectedGroupsHelp": {
+    "message": "לחצו לחיצה ימנית על לשונית כדי להחריג את הקבוצה שלה. הסירו כדי שהקיבוץ האוטומטי ינהל אותה שוב",
+    "description": "Help text explaining how to add and remove excluded groups."
+  },
+  "settingProtectedGroupsRemove": {
+    "message": "חידוש קיבוץ אוטומטי עבור קבוצה זו",
+    "description": "Tooltip on the button that removes a group from the excluded list."
+  },
   "settingMinimumTabsForGroup": {
     "message": "מינימום לשוניות ליצירת קבוצה",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -85,6 +85,22 @@
     "message": "नए खाली टैब्स को \"System\" के अंतर्गत समूहित करें",
     "description": "Label for the toggle that groups blank/new tabs under a System group."
   },
+  "contextMenuProtectGroup": {
+    "message": "समूह को स्वतः-समूहन से बाहर रखें",
+    "description": "Right-click menu: stop auto-grouping from managing the clicked tab's group."
+  },
+  "settingProtectedGroups": {
+    "message": "स्वतः-समूहन से बाहर रखे गए समूह",
+    "description": "Label for the list of groups excluded from auto-grouping."
+  },
+  "settingProtectedGroupsHelp": {
+    "message": "किसी टैब पर राइट-क्लिक करके उसका समूह बाहर रखें। हटाने पर स्वतः-समूहन उसे फिर से प्रबंधित करेगा",
+    "description": "Help text explaining how to add and remove excluded groups."
+  },
+  "settingProtectedGroupsRemove": {
+    "message": "इस समूह के लिए स्वतः-समूहन फिर से शुरू करें",
+    "description": "Tooltip on the button that removes a group from the excluded list."
+  },
   "settingMinimumTabsForGroup": {
     "message": "समूह बनाने के लिए न्यूनतम टैब्स",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -85,6 +85,22 @@
     "message": "Группировать новые пустые вкладки в «System»",
     "description": "Label for the toggle that groups blank/new tabs under a System group."
   },
+  "contextMenuProtectGroup": {
+    "message": "Исключить группу из автогруппировки",
+    "description": "Right-click menu: stop auto-grouping from managing the clicked tab's group."
+  },
+  "settingProtectedGroups": {
+    "message": "Группы, исключённые из автогруппировки",
+    "description": "Label for the list of groups excluded from auto-grouping."
+  },
+  "settingProtectedGroupsHelp": {
+    "message": "Щёлкните вкладку правой кнопкой, чтобы исключить её группу. Удалите запись, чтобы вернуть группу под автогруппировку",
+    "description": "Help text explaining how to add and remove excluded groups."
+  },
+  "settingProtectedGroupsRemove": {
+    "message": "Возобновить автогруппировку для этой группы",
+    "description": "Tooltip on the button that removes a group from the excluded list."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Минимальное число вкладок для создания группы",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -85,6 +85,22 @@
     "message": "将新的空白标签页归入“System”",
     "description": "Label for the toggle that groups blank/new tabs under a System group."
   },
+  "contextMenuProtectGroup": {
+    "message": "将分组排除在自动分组之外",
+    "description": "Right-click menu: stop auto-grouping from managing the clicked tab's group."
+  },
+  "settingProtectedGroups": {
+    "message": "已排除在自动分组之外的分组",
+    "description": "Label for the list of groups excluded from auto-grouping."
+  },
+  "settingProtectedGroupsHelp": {
+    "message": "右键点击标签页可排除其分组。移除后自动分组将重新管理该分组",
+    "description": "Help text explaining how to add and remove excluded groups."
+  },
+  "settingProtectedGroupsRemove": {
+    "message": "恢复该分组的自动分组",
+    "description": "Tooltip on the button that removes a group from the excluded list."
+  },
   "settingMinimumTabsForGroup": {
     "message": "形成分组所需的最少标签页数",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/services/ContextMenuService.ts
+++ b/services/ContextMenuService.ts
@@ -7,9 +7,11 @@ import type { Browser } from "wxt/browser"
 import type { CustomRule, TabGroupColor } from "../types"
 import { extractDomain } from "../utils/DomainUtils"
 import { t } from "../utils/i18n"
+import { saveAllStorage } from "../utils/storage"
 import { rulesService } from "./RulesService"
 import { tabGroupService } from "./TabGroupService"
 import { tabGroupState } from "./TabGroupState"
+import { stripIndexPrefix } from "./TabSortService"
 
 /**
  * Data collected from a tab group for rule creation
@@ -48,6 +50,7 @@ class ContextMenuService {
   private readonly MENU_ID_CREATE_RULE = "create-rule-from-group"
   private readonly MENU_ID_ADD_TO_RULE_PARENT = "add-tab-to-rule"
   private readonly MENU_ID_ADD_TO_BLACKLIST = "add-to-blacklist"
+  private readonly MENU_ID_PROTECT_GROUP = "protect-group"
   private readonly MENU_ID_NO_RULES = "add-to-rule-none"
   private initialized = false
   private menusCreated = false
@@ -114,6 +117,12 @@ class ContextMenuService {
     await browser.contextMenus.create({
       id: this.MENU_ID_ADD_TO_BLACKLIST,
       title: t("contextMenuAddToBlacklist", "Add to Blacklist"),
+      contexts
+    })
+
+    await browser.contextMenus.create({
+      id: this.MENU_ID_PROTECT_GROUP,
+      title: t("contextMenuProtectGroup", "Exclude group from auto-grouping"),
       contexts
     })
 
@@ -243,9 +252,50 @@ class ContextMenuService {
       return
     }
 
+    if (menuId === this.MENU_ID_PROTECT_GROUP) {
+      await this.handleProtectGroup(tab)
+      return
+    }
+
     if (menuId.startsWith(ADD_TO_RULE_PREFIX)) {
       const ruleId = menuId.slice(ADD_TO_RULE_PREFIX.length)
       await this.handleAddTabToRule(ruleId, tab)
+    }
+  }
+
+  /**
+   * Handles the "Exclude group from auto-grouping" menu item.
+   * Adding is contextual — you are looking at the group. Removing lives in the
+   * popup, where every protected title is listed together.
+   */
+  private async handleProtectGroup(tab?: Browser.tabs.Tab): Promise<void> {
+    if (!tab?.id || !tab.groupId || tab.groupId === -1) {
+      console.log("[ContextMenuService] Tab is not in a group, nothing to protect")
+      return
+    }
+
+    try {
+      if (!browser.tabGroups) return
+
+      const group = await browser.tabGroups.get(tab.groupId)
+      const title = stripIndexPrefix(group?.title || "")
+
+      if (!title) {
+        console.log("[ContextMenuService] Group has no title, cannot protect it")
+        return
+      }
+
+      if (tabGroupState.protectedGroupTitles.includes(title)) {
+        console.log(`[ContextMenuService] Group "${title}" is already protected`)
+        return
+      }
+
+      tabGroupState.protectedGroupTitles = [...tabGroupState.protectedGroupTitles, title]
+      await saveAllStorage(tabGroupState.getStorageData())
+
+      console.log(`[ContextMenuService] Protected group "${title}" from auto-grouping`)
+    } catch (error) {
+      console.error("[ContextMenuService] Error protecting group:", error)
     }
   }
 

--- a/services/FirstRunService.ts
+++ b/services/FirstRunService.ts
@@ -1,0 +1,47 @@
+/**
+ * First-run setup.
+ *
+ * Everything here runs once, before the extension has ever touched the
+ * browser's tab groups.
+ */
+
+import { protectedGroupTitles } from "../utils/storage"
+
+/**
+ * Protects the tab groups that already exist when the extension first runs.
+ *
+ * A group present before the extension has ever run cannot have been created
+ * by it — that is a fact, not a heuristic, and it is the one moment we can
+ * safely say a group belongs to the user. Without this, the startup
+ * groupAllTabs() dissolves someone's manual organization seconds after
+ * install, before they have touched a single setting.
+ *
+ * An empty storage.local is what identifies a first run: an update always
+ * leaves keys behind. This must therefore run before anything writes to
+ * storage, which also means it can only ever fire once.
+ *
+ * @returns the titles that were protected, empty when this was not a first run
+ */
+export async function seedProtectedGroupsOnFirstRun(): Promise<string[]> {
+  try {
+    const existingStorage = await browser.storage.local.get(null)
+    if (Object.keys(existingStorage).length > 0) return []
+
+    if (!browser.tabGroups) return []
+
+    const groups = await browser.tabGroups.query({})
+    const titles = [...new Set(groups.map(group => group.title).filter(Boolean))] as string[]
+    if (titles.length === 0) return []
+
+    await protectedGroupTitles.setValue(titles)
+    console.log(
+      `[FirstRunService] First run — protecting ${titles.length} pre-existing group(s):`,
+      titles
+    )
+    return titles
+  } catch (error) {
+    // Never block startup over this
+    console.error("[FirstRunService] Failed to seed protected groups:", error)
+    return []
+  }
+}

--- a/services/TabGroupService.ts
+++ b/services/TabGroupService.ts
@@ -107,6 +107,14 @@ class TabGroupServiceSimplified {
         return false
       }
 
+      // Never move a tab out of a group the user marked protected. This runs
+      // before every grouping path — rules, domain, catch-all and the
+      // below-threshold ungroup — so protection holds everywhere.
+      if (await this.isInProtectedGroup(tab)) {
+        console.log(`[TabGroupService] Tab ${tabId} is in a protected group, leaving it alone`)
+        return false
+      }
+
       // Check blacklist rules — if matched, ungroup the tab and skip all grouping
       const blacklistMatch = await rulesService.findBlacklistMatch(tab.url || "")
       if (blacklistMatch) {
@@ -163,6 +171,46 @@ class TabGroupServiceSimplified {
       console.error(`[TabGroupService] Error processing tab ${tabId}:`, error)
       return false
     }
+  }
+
+  /**
+   * Whether a group title is on the user's protected list.
+   * Titles are compared with any sort-index prefix stripped, so protection
+   * survives the "number groups" setting being toggled.
+   */
+  isProtectedTitle(title: string | undefined): boolean {
+    if (tabGroupState.protectedGroupTitles.length === 0) return false
+    if (!title) return false
+    return tabGroupState.protectedGroupTitles.includes(stripIndexPrefix(title))
+  }
+
+  /**
+   * Whether a tab currently sits in a group the user marked protected.
+   * Cheap no-op when nothing is protected, which is the default.
+   */
+  private async isInProtectedGroup(tab: Browser.tabs.Tab): Promise<boolean> {
+    if (tabGroupState.protectedGroupTitles.length === 0) return false
+    if (!tab.groupId || tab.groupId === -1) return false
+    if (!browser.tabGroups) return false
+
+    try {
+      const group = await browser.tabGroups.get(tab.groupId)
+      return this.isProtectedTitle(group?.title)
+    } catch {
+      // Group vanished between reads — nothing to protect
+      return false
+    }
+  }
+
+  /**
+   * Ids of every protected group in the current window
+   */
+  private async getProtectedGroupIds(): Promise<Set<number>> {
+    if (tabGroupState.protectedGroupTitles.length === 0) return new Set()
+    if (!browser.tabGroups) return new Set()
+
+    const groups = await browser.tabGroups.query({ windowId: browser.windows.WINDOW_ID_CURRENT })
+    return new Set(groups.filter(g => this.isProtectedTitle(g.title)).map(g => g.id))
   }
 
   /**
@@ -561,7 +609,12 @@ class TabGroupServiceSimplified {
     try {
       console.log(`[TabGroupService] Ungrouping all tabs`)
       const tabs = await browser.tabs.query({ currentWindow: true })
-      const groupedTabs = tabs.filter(tab => tab.groupId && tab.groupId !== -1)
+      const allGrouped = tabs.filter(tab => tab.groupId && tab.groupId !== -1)
+
+      // "Ungroup All" is still the extension acting, so protected groups survive
+      // it. Users can dissolve one from the browser's own right-click menu.
+      const protectedGroupIds = await this.getProtectedGroupIds()
+      const groupedTabs = allGrouped.filter(tab => !protectedGroupIds.has(tab.groupId as number))
 
       if (groupedTabs.length > 0) {
         const tabIds = groupedTabs.map(tab => tab.id!).filter(id => id !== undefined)

--- a/services/TabGroupState.ts
+++ b/services/TabGroupState.ts
@@ -30,6 +30,7 @@ class TabGroupState {
   indexGroupTitles: boolean
   hideContextMenu: boolean
   userLocale: UserLocale
+  protectedGroupTitles: string[]
 
   constructor() {
     this.autoGroupingEnabled = DEFAULT_STATE.autoGroupingEnabled
@@ -47,6 +48,7 @@ class TabGroupState {
     this.indexGroupTitles = DEFAULT_STATE.indexGroupTitles
     this.hideContextMenu = DEFAULT_STATE.hideContextMenu
     this.userLocale = DEFAULT_STATE.userLocale
+    this.protectedGroupTitles = [...DEFAULT_STATE.protectedGroupTitles]
   }
 
   /**
@@ -67,6 +69,7 @@ class TabGroupState {
     this.indexGroupTitles = data.indexGroupTitles ?? this.indexGroupTitles
     this.hideContextMenu = data.hideContextMenu ?? this.hideContextMenu
     this.userLocale = data.userLocale ?? this.userLocale
+    this.protectedGroupTitles = data.protectedGroupTitles ?? this.protectedGroupTitles
 
     this.customRules.clear()
 
@@ -98,6 +101,7 @@ class TabGroupState {
       indexGroupTitles: this.indexGroupTitles,
       hideContextMenu: this.hideContextMenu,
       userLocale: this.userLocale,
+      protectedGroupTitles: this.protectedGroupTitles,
       // AI settings managed by AiService, pass defaults for storage schema
       aiEnabled: DEFAULT_STATE.aiEnabled,
       aiProvider: DEFAULT_STATE.aiProvider,

--- a/tests/FirstRunService.test.ts
+++ b/tests/FirstRunService.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { mockBrowser } from "./setup"
+
+// vi.mock is hoisted above module scope, so the spy has to be too
+const { setValue } = vi.hoisted(() => ({ setValue: vi.fn() }))
+
+vi.mock("../utils/storage", () => ({
+  protectedGroupTitles: {
+    setValue,
+    getValue: vi.fn().mockResolvedValue([])
+  }
+}))
+
+import { seedProtectedGroupsOnFirstRun } from "../services/FirstRunService"
+
+/**
+ * The seeding decides whether a run is the extension's first, which is the
+ * only moment it can tell a user's own groups from its own.
+ */
+describe("seedProtectedGroupsOnFirstRun", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setValue.mockResolvedValue(undefined)
+    mockBrowser.storage.local.get.mockResolvedValue({})
+    mockBrowser.tabGroups.query.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("should protect groups that exist on a first run", async () => {
+    mockBrowser.tabGroups.query.mockResolvedValue([
+      { id: 1, title: "Shopping" },
+      { id: 2, title: "Reading" }
+    ])
+
+    const result = await seedProtectedGroupsOnFirstRun()
+
+    expect(result).toEqual(["Shopping", "Reading"])
+    expect(setValue).toHaveBeenCalledWith(["Shopping", "Reading"])
+  })
+
+  it("should do nothing when storage already has keys", async () => {
+    mockBrowser.storage.local.get.mockResolvedValue({ autoGroupingEnabled: true })
+    mockBrowser.tabGroups.query.mockResolvedValue([{ id: 1, title: "Shopping" }])
+
+    const result = await seedProtectedGroupsOnFirstRun()
+
+    expect(result).toEqual([])
+    expect(setValue).not.toHaveBeenCalled()
+  })
+
+  it("should do nothing on a first run with no groups", async () => {
+    const result = await seedProtectedGroupsOnFirstRun()
+
+    expect(result).toEqual([])
+    expect(setValue).not.toHaveBeenCalled()
+  })
+
+  it("should skip untitled groups", async () => {
+    mockBrowser.tabGroups.query.mockResolvedValue([
+      { id: 1, title: "Shopping" },
+      { id: 2, title: "" },
+      { id: 3, title: undefined }
+    ])
+
+    await seedProtectedGroupsOnFirstRun()
+
+    expect(setValue).toHaveBeenCalledWith(["Shopping"])
+  })
+
+  it("should de-duplicate titles across windows", async () => {
+    mockBrowser.tabGroups.query.mockResolvedValue([
+      { id: 1, title: "Shopping", windowId: 1 },
+      { id: 2, title: "Shopping", windowId: 2 }
+    ])
+
+    await seedProtectedGroupsOnFirstRun()
+
+    expect(setValue).toHaveBeenCalledWith(["Shopping"])
+  })
+
+  it("should not block startup when the storage read fails", async () => {
+    mockBrowser.storage.local.get.mockRejectedValue(new Error("storage unavailable"))
+
+    await expect(seedProtectedGroupsOnFirstRun()).resolves.toEqual([])
+  })
+
+  it("should do nothing when the browser has no tab groups API", async () => {
+    const original = mockBrowser.tabGroups
+    // @ts-expect-error — simulating a browser without tabGroups
+    mockBrowser.tabGroups = undefined
+
+    try {
+      await expect(seedProtectedGroupsOnFirstRun()).resolves.toEqual([])
+      expect(setValue).not.toHaveBeenCalled()
+    } finally {
+      mockBrowser.tabGroups = original
+    }
+  })
+})

--- a/tests/ProtectedGroups.test.ts
+++ b/tests/ProtectedGroups.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { tabGroupState } from "../services/TabGroupState"
+import { DEFAULT_STATE } from "../types/storage"
+import { mockBrowser } from "./setup"
+
+vi.mock("../utils/storage", () => ({
+  saveAllStorage: vi.fn().mockResolvedValue(undefined),
+  getGroupColor: vi.fn().mockResolvedValue(null),
+  updateGroupColor: vi.fn().mockResolvedValue(undefined),
+  groupColorMapping: {
+    getValue: vi.fn().mockResolvedValue({})
+  }
+}))
+
+import { tabGroupService } from "../services/TabGroupService"
+
+/**
+ * Tests for groups the user excluded from auto-grouping.
+ *
+ * The extension never infers which groups are the user's own — protection is
+ * an explicit list of titles, so these tests are about the list being honored
+ * on every path that could otherwise move a tab.
+ */
+describe("Protected groups", () => {
+  const PROTECTED_GROUP_ID = 42
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    tabGroupState.updateFromStorage(DEFAULT_STATE)
+    tabGroupState.autoGroupingEnabled = true
+    mockBrowser.tabGroups.query.mockResolvedValue([])
+    mockBrowser.tabs.group.mockResolvedValue(100)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function protect(...titles: string[]): void {
+    tabGroupState.updateFromStorage({ ...DEFAULT_STATE, protectedGroupTitles: titles })
+    tabGroupState.autoGroupingEnabled = true
+  }
+
+  function tabInProtectedGroup(url = "https://example.com") {
+    mockBrowser.tabGroups.get.mockResolvedValue({ id: PROTECTED_GROUP_ID, title: "Shopping" })
+    mockBrowser.tabs.get.mockResolvedValue({
+      id: 1,
+      url,
+      pinned: false,
+      windowId: 1,
+      groupId: PROTECTED_GROUP_ID
+    })
+    mockBrowser.tabs.query.mockResolvedValue([
+      { id: 1, url, pinned: false, windowId: 1, groupId: PROTECTED_GROUP_ID }
+    ])
+  }
+
+  describe("isProtectedTitle", () => {
+    it("should be false when nothing is protected", () => {
+      expect(tabGroupService.isProtectedTitle("Shopping")).toBe(false)
+    })
+
+    it("should match a protected title", () => {
+      protect("Shopping")
+      expect(tabGroupService.isProtectedTitle("Shopping")).toBe(true)
+      expect(tabGroupService.isProtectedTitle("Reading")).toBe(false)
+    })
+
+    it("should ignore a sort-index prefix", () => {
+      protect("Shopping")
+      expect(tabGroupService.isProtectedTitle("3. Shopping")).toBe(true)
+    })
+
+    it("should handle an untitled group", () => {
+      protect("Shopping")
+      expect(tabGroupService.isProtectedTitle(undefined)).toBe(false)
+    })
+  })
+
+  describe("handleTabUpdate", () => {
+    it("should leave a tab in a protected group alone", async () => {
+      protect("Shopping")
+      tabInProtectedGroup()
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(false)
+      expect(mockBrowser.tabs.group).not.toHaveBeenCalled()
+      expect(mockBrowser.tabs.ungroup).not.toHaveBeenCalled()
+    })
+
+    it("should leave it alone even when a custom rule matches", async () => {
+      protect("Shopping")
+      tabGroupState.updateFromStorage({
+        ...DEFAULT_STATE,
+        protectedGroupTitles: ["Shopping"],
+        customRules: {
+          "rule-1": {
+            id: "rule-1",
+            name: "Examples",
+            domains: ["example.com"],
+            color: "blue",
+            enabled: true,
+            priority: 1,
+            createdAt: "2026-01-01T00:00:00.000Z"
+          }
+        }
+      })
+      tabGroupState.autoGroupingEnabled = true
+      tabInProtectedGroup()
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(false)
+      expect(mockBrowser.tabs.group).not.toHaveBeenCalled()
+    })
+
+    it("should leave it alone when grouping is forced", async () => {
+      protect("Shopping")
+      tabInProtectedGroup()
+
+      const result = await tabGroupService.handleTabUpdate(1, true)
+
+      expect(result).toBe(false)
+      expect(mockBrowser.tabs.group).not.toHaveBeenCalled()
+    })
+
+    it("should not ungroup it when the group is below the minimum size", async () => {
+      protect("Shopping")
+      tabGroupState.minimumTabsForGroup = 5
+      tabInProtectedGroup()
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(false)
+      expect(mockBrowser.tabs.ungroup).not.toHaveBeenCalled()
+    })
+
+    it("should still group tabs that are not in a protected group", async () => {
+      protect("Shopping")
+      mockBrowser.tabGroups.get.mockResolvedValue({ id: 7, title: "Something Else" })
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "https://example.com",
+        pinned: false,
+        windowId: 1,
+        groupId: -1
+      })
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 1, url: "https://example.com", pinned: false, windowId: 1, groupId: -1 }
+      ])
+
+      const result = await tabGroupService.handleTabUpdate(1)
+
+      expect(result).toBe(true)
+      expect(mockBrowser.tabs.group).toHaveBeenCalled()
+    })
+
+    it("should not query groups at all when nothing is protected", async () => {
+      mockBrowser.tabs.get.mockResolvedValue({
+        id: 1,
+        url: "https://example.com",
+        pinned: false,
+        windowId: 1,
+        groupId: 9
+      })
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 1, url: "https://example.com", pinned: false, windowId: 1, groupId: 9 }
+      ])
+
+      await tabGroupService.handleTabUpdate(1)
+
+      expect(mockBrowser.tabGroups.get).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("ungroupAllTabs", () => {
+    it("should skip tabs in protected groups", async () => {
+      protect("Shopping")
+      mockBrowser.tabGroups.query.mockResolvedValue([
+        { id: PROTECTED_GROUP_ID, title: "Shopping" },
+        { id: 7, title: "Example" }
+      ])
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 1, groupId: PROTECTED_GROUP_ID },
+        { id: 2, groupId: 7 }
+      ])
+
+      await tabGroupService.ungroupAllTabs()
+
+      expect(mockBrowser.tabs.ungroup).toHaveBeenCalledWith([2])
+    })
+
+    it("should ungroup everything when nothing is protected", async () => {
+      mockBrowser.tabGroups.query.mockResolvedValue([{ id: 7, title: "Example" }])
+      mockBrowser.tabs.query.mockResolvedValue([
+        { id: 1, groupId: 7 },
+        { id: 2, groupId: 7 }
+      ])
+
+      await tabGroupService.ungroupAllTabs()
+
+      expect(mockBrowser.tabs.ungroup).toHaveBeenCalledWith([1, 2])
+    })
+  })
+})

--- a/tests/e2e/protected-groups.e2e.ts
+++ b/tests/e2e/protected-groups.e2e.ts
@@ -1,0 +1,211 @@
+/**
+ * E2E Tests: Groups Excluded From Auto-Grouping
+ *
+ * Protected groups survive auto-grouping, forced grouping and "Ungroup All",
+ * and go back to being managed once removed from the list.
+ *
+ * The install-time seeding is covered in tests/FirstRunService.test.ts —
+ * chrome.runtime.reload() unloads an --load-extension extension, so a real
+ * reinstall can't be driven from here.
+ */
+
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import {
+  closeTestTabs,
+  createTab,
+  disableAutoGroup,
+  enableAutoGroup,
+  getExtensionId,
+  getTabGroups,
+  groupAllTabs,
+  openPopup,
+  sendMessage,
+  setGroupByMode,
+  setMinimumTabs,
+  TEST_URLS,
+  ungroupAllTabs
+} from "./helpers/extension-helpers"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const extensionPath = join(__dirname, "../../.output/chrome-mv3")
+
+let context: BrowserContext
+let extensionId: string
+let popupPage: Page
+
+const MANUAL_GROUP = "My Reading List"
+
+async function getProtected(page: Page): Promise<string[]> {
+  const result = (await sendMessage(page, "getProtectedGroups")) as { titles: string[] }
+  return result.titles
+}
+
+async function setProtected(page: Page, titles: string[]): Promise<void> {
+  // Goes through the background so its in-memory state matches storage —
+  // writing to storage.local directly would leave the service worker stale.
+  for (const title of await getProtected(page)) {
+    await sendMessage(page, "removeProtectedGroup", { title })
+  }
+  for (const title of titles) {
+    await sendMessage(page, "addProtectedGroup", { title })
+  }
+}
+
+/** Groups the given tabs under a title, the way a user would by hand */
+async function createManualGroup(page: Page, title: string, tabIds: number[]): Promise<number> {
+  return await page.evaluate(
+    async ({ ids, groupTitle }) => {
+      const groupId = await chrome.tabs.group({ tabIds: ids })
+      await chrome.tabGroups.update(groupId, { title: groupTitle, color: "purple" })
+      return groupId
+    },
+    { ids: tabIds, groupTitle: title }
+  )
+}
+
+async function getTabIds(page: Page, urlPart: string): Promise<number[]> {
+  return await page.evaluate(async part => {
+    const tabs = await chrome.tabs.query({})
+    return tabs.filter(tab => tab.url?.includes(part)).map(tab => tab.id as number)
+  }, urlPart)
+}
+
+test.beforeAll(async () => {
+  context = await chromium.launchPersistentContext("", {
+    headless: false,
+    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
+  })
+  extensionId = await getExtensionId(context)
+})
+
+test.afterAll(async () => {
+  await context.close()
+})
+
+test.beforeEach(async () => {
+  await closeTestTabs(context)
+  popupPage = await openPopup(context, extensionId)
+  await disableAutoGroup(popupPage)
+  await setProtected(popupPage, [])
+  await ungroupAllTabs(popupPage)
+  await setMinimumTabs(popupPage, 1)
+  await setGroupByMode(popupPage, "domain")
+})
+
+test.afterEach(async () => {
+  if (popupPage && !popupPage.isClosed()) {
+    await disableAutoGroup(popupPage)
+    await setProtected(popupPage, [])
+    await ungroupAllTabs(popupPage)
+    await popupPage.close()
+  }
+  await closeTestTabs(context)
+})
+
+test.describe("Protected groups", () => {
+  test("auto-grouping leaves a protected group alone", async () => {
+    const tab = await createTab(context, TEST_URLS.domain1)
+    const ids = await getTabIds(popupPage, "example.com")
+    await createManualGroup(popupPage, MANUAL_GROUP, ids)
+    await setProtected(popupPage, [MANUAL_GROUP])
+
+    await enableAutoGroup(popupPage)
+    await tab.reload()
+    await popupPage.waitForTimeout(1500)
+
+    const groups = await getTabGroups(popupPage)
+    expect(groups.some(group => group.title === MANUAL_GROUP)).toBe(true)
+    expect(groups.some(group => group.title === "Example")).toBe(false)
+  })
+
+  test("an explicit Group Tabs click leaves it alone too", async () => {
+    await createTab(context, TEST_URLS.domain1)
+    const ids = await getTabIds(popupPage, "example.com")
+    await createManualGroup(popupPage, MANUAL_GROUP, ids)
+    await setProtected(popupPage, [MANUAL_GROUP])
+
+    await groupAllTabs(popupPage)
+    await popupPage.waitForTimeout(1500)
+
+    const groups = await getTabGroups(popupPage)
+    expect(groups.some(group => group.title === MANUAL_GROUP)).toBe(true)
+  })
+
+  test("Ungroup All leaves it standing", async () => {
+    await createTab(context, TEST_URLS.domain1)
+    const ids = await getTabIds(popupPage, "example.com")
+    await createManualGroup(popupPage, MANUAL_GROUP, ids)
+    await setProtected(popupPage, [MANUAL_GROUP])
+
+    await popupPage.evaluate(
+      async () =>
+        await new Promise(resolve => chrome.runtime.sendMessage({ action: "ungroup" }, resolve))
+    )
+    await popupPage.waitForTimeout(1000)
+
+    const groups = await getTabGroups(popupPage)
+    expect(groups.some(group => group.title === MANUAL_GROUP)).toBe(true)
+  })
+
+  test("removing the protection hands the group back to auto-grouping", async () => {
+    await createTab(context, TEST_URLS.domain1)
+    const ids = await getTabIds(popupPage, "example.com")
+    await createManualGroup(popupPage, MANUAL_GROUP, ids)
+    await setProtected(popupPage, [MANUAL_GROUP])
+    await enableAutoGroup(popupPage)
+    await popupPage.waitForTimeout(500)
+
+    await sendMessage(popupPage, "removeProtectedGroup", { title: MANUAL_GROUP })
+    await popupPage.waitForTimeout(1500)
+
+    expect(await getProtected(popupPage)).toEqual([])
+    const groups = await getTabGroups(popupPage)
+    expect(groups.some(group => group.title === "Example")).toBe(true)
+  })
+
+  test("other tabs still get grouped normally around it", async () => {
+    await createTab(context, TEST_URLS.domain1)
+    const ids = await getTabIds(popupPage, "example.com")
+    await createManualGroup(popupPage, MANUAL_GROUP, ids)
+    await setProtected(popupPage, [MANUAL_GROUP])
+
+    await enableAutoGroup(popupPage)
+    await createTab(context, TEST_URLS.domain2)
+    await popupPage.waitForTimeout(1500)
+
+    const groups = await getTabGroups(popupPage)
+    expect(groups.some(group => group.title === MANUAL_GROUP)).toBe(true)
+    expect(groups.some(group => group.title === "Httpbin")).toBe(true)
+  })
+
+  test("the popup lists protected groups and can remove one", async () => {
+    await setProtected(popupPage, [MANUAL_GROUP])
+    const page = await openPopup(context, extensionId)
+    await page.waitForTimeout(500)
+
+    const chip = page.locator(".protected-group-chip")
+    await expect(chip).toHaveCount(1)
+    await expect(chip).toContainText(MANUAL_GROUP)
+
+    await chip.locator("button").click()
+    await page.waitForTimeout(1000)
+
+    await expect(page.locator(".protected-group-chip")).toHaveCount(0)
+    expect(await getProtected(popupPage)).toEqual([])
+
+    await page.close()
+  })
+
+  test("the list stays hidden when nothing is protected", async () => {
+    const page = await openPopup(context, extensionId)
+    await page.waitForTimeout(500)
+
+    await expect(page.locator("#protectedGroupsList")).toBeHidden()
+    await expect(page.locator("#protectedGroupsContainer")).toBeHidden()
+
+    await page.close()
+  })
+})

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -41,6 +41,9 @@ export type MessageAction =
   | "toggleHideContextMenu"
   | "getUserLocale"
   | "setUserLocale"
+  | "getProtectedGroups"
+  | "addProtectedGroup"
+  | "removeProtectedGroup"
   | "getCustomRules"
   | "addCustomRule"
   | "updateCustomRule"
@@ -84,6 +87,7 @@ export interface SimpleMessage extends BaseMessage {
     | "getIndexGroupTitles"
     | "getHideContextMenu"
     | "getUserLocale"
+    | "getProtectedGroups"
     | "getCustomRules"
     | "getRulesStats"
     | "exportRules"
@@ -118,6 +122,22 @@ export interface ToggleGroupNewTabsMessage extends BaseMessage {
 export interface ToggleSystemGroupMessage extends BaseMessage {
   action: "toggleSystemGroup"
   enabled: boolean
+}
+
+/**
+ * Add a group title to the protected list
+ */
+export interface AddProtectedGroupMessage extends BaseMessage {
+  action: "addProtectedGroup"
+  title: string
+}
+
+/**
+ * Remove a group title from the protected list
+ */
+export interface RemoveProtectedGroupMessage extends BaseMessage {
+  action: "removeProtectedGroup"
+  title: string
 }
 
 /**

--- a/types/storage.ts
+++ b/types/storage.ts
@@ -78,6 +78,12 @@ export interface StorageSchema {
   hideContextMenu: boolean
   /** User-selected UI locale override ("auto" = follow browser) */
   userLocale: UserLocale
+  /**
+   * Group titles auto-grouping must never touch. Declared by the user, never
+   * inferred — seeded once at install from groups that already existed, and
+   * edited from the group's right-click menu.
+   */
+  protectedGroupTitles: string[]
 }
 
 /**
@@ -102,7 +108,8 @@ export const DEFAULT_STATE: StorageSchema = {
   sortGroupsDirection: "asc",
   indexGroupTitles: false,
   hideContextMenu: false,
-  userLocale: "auto"
+  userLocale: "auto",
+  protectedGroupTitles: []
 }
 
 /**

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -33,6 +33,10 @@ export const systemGroupEnabled = storage.defineItem<boolean>("local:systemGroup
   fallback: DEFAULT_STATE.systemGroupEnabled
 })
 
+export const protectedGroupTitles = storage.defineItem<string[]>("local:protectedGroupTitles", {
+  fallback: DEFAULT_STATE.protectedGroupTitles
+})
+
 export const groupByMode = storage.defineItem<GroupByMode>("local:groupByMode", {
   fallback: DEFAULT_STATE.groupByMode
 })
@@ -129,7 +133,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     sortGroupsDirectionValue,
     indexGroupTitlesValue,
     hideContextMenuValue,
-    userLocaleValue
+    userLocaleValue,
+    protectedGroupTitlesValue
   ] = await Promise.all([
     autoGroupingEnabled.getValue(),
     groupNewTabs.getValue(),
@@ -149,7 +154,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     sortGroupsDirection.getValue(),
     indexGroupTitles.getValue(),
     hideContextMenu.getValue(),
-    userLocale.getValue()
+    userLocale.getValue(),
+    protectedGroupTitles.getValue()
   ])
 
   return {
@@ -171,7 +177,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     sortGroupsDirection: sortGroupsDirectionValue,
     indexGroupTitles: indexGroupTitlesValue,
     hideContextMenu: hideContextMenuValue,
-    userLocale: userLocaleValue
+    userLocale: userLocaleValue,
+    protectedGroupTitles: protectedGroupTitlesValue
   }
 }
 
@@ -237,6 +244,9 @@ export async function saveAllStorage(data: Partial<StorageSchema>): Promise<void
   }
   if (data.userLocale !== undefined) {
     promises.push(userLocale.setValue(data.userLocale))
+  }
+  if (data.protectedGroupTitles !== undefined) {
+    promises.push(protectedGroupTitles.setValue(data.protectedGroupTitles))
   }
   await Promise.all(promises)
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,7 +26,8 @@ export default defineConfig({
         "utils/UrlPatternMatcher.ts",
         "utils/WebGpuUtils.ts",
         "utils/withTabEditRetry.ts",
-        "services/TabSortService.ts"
+        "services/TabSortService.ts",
+        "services/FirstRunService.ts"
       ],
       exclude: [
         "**/node_modules/**",


### PR DESCRIPTION
Closes #23

## The approach, and what it deliberately isn't

The extension pulls tabs out of any group standing between it and its expected layout. The worst version of this is at install: [background.ts:66](entrypoints/background.ts:66) runs `groupAllTabs()` on startup with `autoGroupingEnabled` defaulting to true, so a new user's manual groups are dissolved seconds after installing, before they've touched a setting.

Two obvious fixes were both rejected:

- **Ownership tracking by group id** (the approach in `docs/manual-groups-protection.md`) — ids churn on session restore, so the stored set drifts and protection silently stops working.
- **Inferring which groups are "manual"** — unreliable by construction, and it turns an auto-grouper into a manual-group manager.

Instead this adds a list of group titles auto-grouping must not touch. It is **declared, never inferred** — the same shape as blacklist rules, which already let users carve out URLs. The extension stays a pure auto-grouper that respects a boundary the user drew.

Keying on title is not a new bet: `findGroupByTitle`, the colour mapping, the System group lookup and catch-all naming all already treat title as identity.

## How you use it

- **Add**: right-click a tab → "Exclude group from auto-grouping".
- **Remove**: the popup and sidebar list every exclusion as a chip; removing one hands the group straight back to auto-grouping. The whole block stays hidden when the list is empty.
- **At install**: groups that already exist are excluded automatically. A group present before the extension has ever run cannot have been created by it — a fact, not a heuristic. An empty `storage.local` identifies that first run, and the check happens before anything writes, so it can only fire once.

## Scope of the guard

One check, ahead of every grouping path, so exclusions hold for automatic grouping, forced grouping, the catch-all fallback and the below-threshold ungroup. "Ungroup All" respects them too — the browser's own right-click menu dissolves one by hand.

It costs nothing when unused: with an empty list the guard returns before querying the browser at all, which one of the tests asserts directly.

## Honest limitations

- **Renaming an excluded group ends its exclusion.** Title is identity here as everywhere else in the extension.
- **A title that collides with a domain name** ("Example") means that domain stops being auto-managed. Explicit user choice, but worth knowing.
- **Uninstall/reinstall re-seeds** from whatever groups exist at that moment, including ones the extension itself created before the uninstall. Explainable, and removing them is one click each.
- Excluded groups are still sorted and still get index prefixes when those settings are on. Only membership is protected. Easy to extend later if it feels wrong.

## Test plan

- [x] `bunx vitest run` — 842 pass, including 12 new tests in `tests/ProtectedGroups.test.ts` (every grouping path, the no-op fast path, "Ungroup All") and 7 in `tests/FirstRunService.test.ts` (seeding conditions, dedupe across windows, untitled groups, storage failure, no tabGroups API)
- [x] `bunx playwright test tests/e2e/protected-groups.e2e.ts` — 7 new tests driving real manual groups and the popup chips
- [x] `bun run code:check` clean
- [x] Popup rendering checked by screenshot
- [x] Chrome + Firefox packages build at 3.9.0

The seeding lives in its own `services/FirstRunService.ts` rather than inline in the background, because `chrome.runtime.reload()` unloads an `--load-extension` extension and a real reinstall therefore can't be driven from Playwright. Extracting it made the logic unit-testable, which is where those conditions are now covered.

Full E2E run fails one test, a different one each run, passing in isolation — the pre-existing flakiness I measured on unmodified `master` earlier. Fixing it is next on the debt list.

## Docs & i18n

`docs/FEATURES.md` gains a section covering the behaviour and its limits. 4 new keys across all 8 locales.

Version bumped to 3.9.0.