### PR TITLE
ci: run lint, typecheck, tests and both builds on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# A newer push to the same branch makes the in-flight run irrelevant
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, typecheck, test, build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      # --frozen-lockfile fails the run if bun.lock is out of date with
+      # package.json, rather than silently resolving something else
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint, format and typecheck
+        run: bun run code:check
+
+      - name: Unit tests
+        run: bun run test
+
+      # Both targets, because they build differently: Firefox swaps WebLLM for a
+      # stub to stay under the add-on store's 5 MB parse limit
+      - name: Build Chrome
+        run: bun run build:chrome
+
+      - name: Build Firefox
+        run: bun run build:firefox

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🔖 Auto Tab Groups (Cross-Browser Extension)
 
+[![CI](https://github.com/nitzanpap/auto-tab-groups/actions/workflows/ci.yml/badge.svg)](https://github.com/nitzanpap/auto-tab-groups/actions/workflows/ci.yml)
+
 A lightweight cross-browser extension that automatically groups open tabs by domain, with intelligent domain name handling for better organization. Works on both Chrome and Firefox!
 
 ## 📦 Downloads

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -41,6 +41,17 @@ bun run dev
 | `bun run code:check` | Run Biome check and typecheck |
 | `bun run code:fix` | Fix lint and formatting issues |
 
+## Continuous Integration
+
+Every push to `master` and every pull request runs `.github/workflows/ci.yml`:
+`bun install --frozen-lockfile`, `bun run code:check`, `bun run test`, then a
+Chrome and a Firefox build. Running `bun run code:check && bun run test` locally
+reproduces it exactly.
+
+E2E tests are not in CI yet — the suite fails roughly one test per full run
+(a different one each time, passing in isolation), so it would report noise
+rather than signal. It goes in once that is fixed.
+
 ## Development Workflow
 
 ### 1. Start Development Server


### PR DESCRIPTION
First half of the untracked debt. Nothing gated a merge before this — every check I've reported over the last several PRs ran on my laptop.

## What runs

On every push to `master` and every pull request:

1. `bun install --frozen-lockfile` — a stale `bun.lock` fails the run instead of silently resolving something else
2. `bun run code:check` — Biome + `tsc --noEmit`
3. `bun run test` — the 842 unit tests
4. `bun run build:chrome` and `bun run build:firefox`

Both browsers are built deliberately: Firefox swaps WebLLM for a stub to stay under the add-on store's 5 MB parse limit, so a green Chrome build says nothing about whether Firefox still compiles.

One job rather than four parallel ones — the whole sequence takes seconds with bun, and splitting it would cost more in runner startup than it saves.

`concurrency` cancels an in-flight run when you push again to the same branch.

## Verified

Cloned the repo to a clean directory and ran the exact sequence from scratch:

- `bun install --frozen-lockfile` → 421 packages, 2.1s
- `bun run code:check` → clean
- `bun run test` → 842 passed
- `bun run build:chrome` → 6.27 MB, `bun run build:firefox` → 735 KB

So the first run on GitHub should be green rather than a round of fixing CI-only breakage.

## E2E is deliberately not here yet

The Playwright suite fails roughly one test per full run — a different one each time, each passing in isolation. I confirmed this reproduces on unmodified `master`, so it predates the recent work. Wiring it in now would report noise instead of signal.

Two things I noticed that likely feed it, for when I pick up the flakiness next:

- The tests hit **real external sites** (`example.com`, `httpbin.org`). Network variance in a timing-sensitive suite is an obvious suspect, and `httpbin.org` in particular is not reliably up.
- They run with `headless: false` and a persistent context, so putting them on `ubuntu-latest` will also need `xvfb`.

## Also

- CI badge in the README
- A Continuous Integration section in `docs/CONTRIB.md` noting how to reproduce CI locally (`bun run code:check && bun run test`) and why E2E is excluded

No version bump — this ships nothing to users.