### PR TITLE
test: make the E2E suite deterministic and run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,34 @@ jobs:
 
       - name: Build Firefox
         run: bun run build:firefox
+
+  e2e:
+    name: End-to-end tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: bunx playwright install chromium --with-deps
+
+      - name: Build Chrome extension
+        run: bun run build:chrome
+
+      # Extensions can't be loaded headlessly, so the suite needs a display
+      - name: End-to-end tests
+        run: xvfb-run --auto-servernum -- bunx playwright test
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,9 @@ jobs:
 
       # Extensions can't be loaded headlessly, so the suite needs a display
       - name: End-to-end tests
-        run: xvfb-run --auto-servernum -- bunx playwright test
+        # --fail-on-flaky-tests: a test that only passes on retry is a bug we
+        # want to see, not a green tick
+        run: xvfb-run --auto-servernum -- bunx playwright test --fail-on-flaky-tests
 
       - name: Upload report on failure
         if: failure()

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -44,13 +44,33 @@ bun run dev
 ## Continuous Integration
 
 Every push to `master` and every pull request runs `.github/workflows/ci.yml`:
-`bun install --frozen-lockfile`, `bun run code:check`, `bun run test`, then a
-Chrome and a Firefox build. Running `bun run code:check && bun run test` locally
-reproduces it exactly.
 
-E2E tests are not in CI yet — the suite fails roughly one test per full run
-(a different one each time, passing in isolation), so it would report noise
-rather than signal. It goes in once that is fixed.
+- **check** — `bun install --frozen-lockfile`, `bun run code:check`,
+  `bun run test`, then a Chrome and a Firefox build
+- **e2e** — builds the Chrome extension and runs Playwright under `xvfb`,
+  since an extension cannot be loaded headlessly. The HTML report is uploaded
+  as an artifact when the job fails.
+
+## Writing E2E tests
+
+Two rules keep the suite deterministic:
+
+- **Launch through `launchExtensionContext()`** rather than calling
+  `chromium.launchPersistentContext` directly. It loads the built extension and
+  installs the fixture routes described below.
+- **Never sleep before an assertion.** The extension applies changes
+  asynchronously, so a fixed `waitForTimeout` either flakes on a slow machine or
+  wastes time on a fast one. Use `waitForGroup`, `waitForGroups`,
+  `waitForTabInGroup` and friends, which poll until the condition holds. A fixed
+  wait is only acceptable before asserting that something did *not* happen.
+
+### Fixtures
+
+`serveFixtures()` fulfils every http(s) request from memory. Grouping is keyed
+on the hostname, so tests need several distinct domains — but none of them need
+to be real, and depending on third-party uptime inside a timing-sensitive suite
+was the main source of flakiness. `TEST_URLS` hostnames stay as they are; only
+the network round trip disappears.
 
 ## Development Workflow
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/services/FirstRunService.ts
+++ b/services/FirstRunService.ts
@@ -18,7 +18,7 @@ import { protectedGroupTitles } from "../utils/storage"
  *
  * An empty storage.local is what identifies a first run: an update always
  * leaves keys behind. This must therefore run before anything writes to
- * storage, which also means it can only ever fire once.
+ * storage.
  *
  * @returns the titles that were protected, empty when this was not a first run
  */
@@ -31,13 +31,19 @@ export async function seedProtectedGroupsOnFirstRun(): Promise<string[]> {
 
     const groups = await browser.tabGroups.query({})
     const titles = [...new Set(groups.map(group => group.title).filter(Boolean))] as string[]
-    if (titles.length === 0) return []
 
+    // Write even when there is nothing to protect. Storage stays empty until the
+    // user changes a setting, and MV3 shuts down idle service workers — so
+    // without this marker a restart hours later would look like a fresh install
+    // all over again and protect groups the extension created itself.
     await protectedGroupTitles.setValue(titles)
-    console.log(
-      `[FirstRunService] First run — protecting ${titles.length} pre-existing group(s):`,
-      titles
-    )
+
+    if (titles.length > 0) {
+      console.log(
+        `[FirstRunService] First run — protecting ${titles.length} pre-existing group(s):`,
+        titles
+      )
+    }
     return titles
   } catch (error) {
     // Never block startup over this

--- a/tests/FirstRunService.test.ts
+++ b/tests/FirstRunService.test.ts
@@ -51,7 +51,29 @@ describe("seedProtectedGroupsOnFirstRun", () => {
     expect(setValue).not.toHaveBeenCalled()
   })
 
-  it("should do nothing on a first run with no groups", async () => {
+  it("should protect nothing on a first run with no groups", async () => {
+    const result = await seedProtectedGroupsOnFirstRun()
+
+    expect(result).toEqual([])
+  })
+
+  it("should mark the first run as done even when there was nothing to protect", async () => {
+    // MV3 shuts down idle service workers, and storage stays empty until the
+    // user changes a setting. Without this marker the next restart looks like a
+    // fresh install and protects groups the extension created itself.
+    await seedProtectedGroupsOnFirstRun()
+
+    expect(setValue).toHaveBeenCalledWith([])
+  })
+
+  it("should not seed again once the first run has been marked", async () => {
+    await seedProtectedGroupsOnFirstRun()
+
+    // Second start: the marker written above means storage is no longer empty
+    mockBrowser.storage.local.get.mockResolvedValue({ protectedGroupTitles: [] })
+    mockBrowser.tabGroups.query.mockResolvedValue([{ id: 1, title: "Example" }])
+    setValue.mockClear()
+
     const result = await seedProtectedGroupsOnFirstRun()
 
     expect(result).toEqual([])

--- a/tests/e2e/auto-collapse.e2e.ts
+++ b/tests/e2e/auto-collapse.e2e.ts
@@ -5,9 +5,7 @@
  * inactive tab groups when switching tabs.
  */
 
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
 import {
   activateTab,
   closeTestTabs,
@@ -21,27 +19,22 @@ import {
   getAutoCollapseState,
   getExtensionId,
   getTabGroups,
+  launchExtensionContext,
   openPopup,
   setGroupByMode,
   setMinimumTabs,
   TEST_URLS,
   ungroupAllTabs,
-  waitForGroup
+  waitForGroup,
+  waitForGroups
 } from "./helpers/extension-helpers"
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const extensionPath = join(__dirname, "../../.output/chrome-mv3")
 
 let context: BrowserContext
 let extensionId: string
 let popupPage: Page
 
 test.beforeAll(async () => {
-  context = await chromium.launchPersistentContext("", {
-    headless: false,
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-  })
+  context = await launchExtensionContext()
   extensionId = await getExtensionId(context)
 })
 
@@ -110,25 +103,22 @@ test.describe("Auto-Collapse Feature", () => {
 
     // Expand all groups first
     await expandAllGroups(popupPage)
-    await popupPage.waitForTimeout(300)
-
-    // Verify all groups are expanded
-    let groups = await getTabGroups(popupPage)
-    expect(groups.every(g => !g.collapsed)).toBe(true)
+    let groups = await waitForGroups(popupPage, gs => gs.every(g => !g.collapsed))
 
     // Enable auto-collapse with immediate mode (0ms delay)
     await enableAutoCollapse(popupPage, 0)
 
     // Activate a tab in domain1 group
     await activateTab(popupPage, "example.com")
-    await popupPage.waitForTimeout(500)
 
     // Get the active tab's group
     const activeTab = await getActiveTab(popupPage)
     expect(activeTab).not.toBeNull()
 
-    // Verify other groups collapsed
-    groups = await getTabGroups(popupPage)
+    // Wait for the collapse to land rather than guessing how long it takes
+    groups = await waitForGroups(popupPage, gs =>
+      gs.filter(g => g.id !== activeTab?.groupId).some(g => g.collapsed)
+    )
     const activeGroup = groups.find(g => g.id === activeTab?.groupId)
 
     if (activeGroup) {

--- a/tests/e2e/auto-grouping.e2e.ts
+++ b/tests/e2e/auto-grouping.e2e.ts
@@ -8,9 +8,7 @@
  * - Ungroup all functionality
  */
 
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
 import {
   closeTestTabs,
   createTab,
@@ -21,6 +19,7 @@ import {
   getTabGroups,
   getTabs,
   groupAllTabs,
+  launchExtensionContext,
   openPopup,
   setGroupByMode,
   setMinimumTabs,
@@ -31,19 +30,12 @@ import {
   waitForTabInGroup
 } from "./helpers/extension-helpers"
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const extensionPath = join(__dirname, "../../.output/chrome-mv3")
-
 let context: BrowserContext
 let extensionId: string
 let popupPage: Page
 
 test.beforeAll(async () => {
-  context = await chromium.launchPersistentContext("", {
-    headless: false,
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-  })
+  context = await launchExtensionContext()
   extensionId = await getExtensionId(context)
 })
 

--- a/tests/e2e/catch-all-rules.e2e.ts
+++ b/tests/e2e/catch-all-rules.e2e.ts
@@ -7,9 +7,7 @@
  * - Normal rules and blacklist rules still take priority
  */
 
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
 import {
   addCustomRule,
   closeTestTabs,
@@ -20,6 +18,7 @@ import {
   getCustomRules,
   getExtensionId,
   getTabGroups,
+  launchExtensionContext,
   openPopup,
   setGroupByMode,
   setMinimumTabs,
@@ -27,10 +26,6 @@ import {
   ungroupAllTabs,
   waitForGroup
 } from "./helpers/extension-helpers"
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const extensionPath = join(__dirname, "../../.output/chrome-mv3")
 
 let context: BrowserContext
 let extensionId: string
@@ -46,10 +41,7 @@ async function deleteAllRules(page: Page): Promise<void> {
 }
 
 test.beforeAll(async () => {
-  context = await chromium.launchPersistentContext("", {
-    headless: false,
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-  })
+  context = await launchExtensionContext()
   extensionId = await getExtensionId(context)
 })
 

--- a/tests/e2e/custom-rules.e2e.ts
+++ b/tests/e2e/custom-rules.e2e.ts
@@ -8,9 +8,7 @@
  * - Delete rule regroups tabs by domain
  */
 
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
 import {
   addCustomRule,
   closeTestTabs,
@@ -22,6 +20,7 @@ import {
   getExtensionId,
   getTabGroups,
   getTabs,
+  launchExtensionContext,
   openPopup,
   setGroupByMode,
   setMinimumTabs,
@@ -30,19 +29,12 @@ import {
   waitForGroup
 } from "./helpers/extension-helpers"
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const extensionPath = join(__dirname, "../../.output/chrome-mv3")
-
 let context: BrowserContext
 let extensionId: string
 let popupPage: Page
 
 test.beforeAll(async () => {
-  context = await chromium.launchPersistentContext("", {
-    headless: false,
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-  })
+  context = await launchExtensionContext()
   extensionId = await getExtensionId(context)
 })
 

--- a/tests/e2e/extension.e2e.ts
+++ b/tests/e2e/extension.e2e.ts
@@ -1,39 +1,11 @@
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { type BrowserContext, chromium, expect, test } from "@playwright/test"
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const extensionPath = join(__dirname, "../../.output/chrome-mv3")
+import { type BrowserContext, expect, test } from "@playwright/test"
+import { getExtensionId, launchExtensionContext } from "./helpers/extension-helpers"
 
 let context: BrowserContext
 let extensionId: string
 
-/**
- * Wait for and retrieve the extension ID from service workers
- */
-async function getExtensionId(ctx: BrowserContext): Promise<string> {
-  return new Promise<string>(resolve => {
-    const checkServiceWorker = () => {
-      const workers = ctx.serviceWorkers()
-      for (const worker of workers) {
-        const url = worker.url()
-        if (url.includes("chrome-extension://")) {
-          resolve(url.split("/")[2])
-          return
-        }
-      }
-      setTimeout(checkServiceWorker, 100)
-    }
-    checkServiceWorker()
-  })
-}
-
 test.beforeAll(async () => {
-  context = await chromium.launchPersistentContext("", {
-    headless: false,
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-  })
+  context = await launchExtensionContext()
 
   // Get extension ID once and reuse across all tests
   extensionId = await getExtensionId(context)
@@ -80,19 +52,11 @@ test.describe("Auto Tab Groups Extension", () => {
 
     // Click the label (visible toggle) to change checkbox state
     await page.locator("label.switch").first().click()
-    await page.waitForTimeout(500)
-
-    // Verify state changed
-    const newState = await toggle.isChecked()
-    expect(newState).toBe(!initialState)
+    await expect(toggle).toBeChecked({ checked: !initialState })
 
     // Toggle back
     await page.locator("label.switch").first().click()
-    await page.waitForTimeout(500)
-
-    // Verify state restored
-    const restoredState = await toggle.isChecked()
-    expect(restoredState).toBe(initialState)
+    await expect(toggle).toBeChecked({ checked: initialState })
 
     await page.close()
   })

--- a/tests/e2e/extension.e2e.ts
+++ b/tests/e2e/extension.e2e.ts
@@ -1,5 +1,9 @@
 import { type BrowserContext, expect, test } from "@playwright/test"
-import { getExtensionId, launchExtensionContext } from "./helpers/extension-helpers"
+import {
+  getAutoGroupState,
+  getExtensionId,
+  launchExtensionContext
+} from "./helpers/extension-helpers"
 
 let context: BrowserContext
 let extensionId: string
@@ -48,7 +52,13 @@ test.describe("Auto Tab Groups Extension", () => {
     await page.goto(popupUrl)
 
     const toggle = page.locator("#autoGroupToggle")
-    const initialState = await toggle.isChecked()
+
+    // The popup fills its toggles from the background asynchronously. Reading
+    // the checkbox before that lands returns the markup default rather than the
+    // stored setting, so "initial state" would be a lie and the assertions below
+    // would flip-flop — which is exactly how this failed on a slower CI runner.
+    const initialState = await getAutoGroupState(page)
+    await expect(toggle).toBeChecked({ checked: initialState })
 
     // Click the label (visible toggle) to change checkbox state
     await page.locator("label.switch").first().click()

--- a/tests/e2e/group-operations.e2e.ts
+++ b/tests/e2e/group-operations.e2e.ts
@@ -7,9 +7,7 @@
  * - Toggle collapse state
  */
 
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
 import {
   closeTestTabs,
   collapseAllGroups,
@@ -19,28 +17,23 @@ import {
   expandAllGroups,
   getExtensionId,
   getTabGroups,
+  launchExtensionContext,
   openPopup,
   setGroupByMode,
   setMinimumTabs,
   TEST_URLS,
   toggleCollapseGroups,
   ungroupAllTabs,
-  waitForGroup
+  waitForGroup,
+  waitForGroups
 } from "./helpers/extension-helpers"
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const extensionPath = join(__dirname, "../../.output/chrome-mv3")
 
 let context: BrowserContext
 let extensionId: string
 let popupPage: Page
 
 test.beforeAll(async () => {
-  context = await chromium.launchPersistentContext("", {
-    headless: false,
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-  })
+  context = await launchExtensionContext()
   extensionId = await getExtensionId(context)
 })
 
@@ -84,7 +77,7 @@ test.describe("Group Operations - Collapse/Expand", () => {
     await waitForGroup(popupPage, "Typicode")
 
     // Verify expected groups exist
-    let groups = await getTabGroups(popupPage)
+    const groups = await getTabGroups(popupPage)
     expect(groups.some(g => g.title === "Example")).toBe(true)
     expect(groups.some(g => g.title === "Httpbin")).toBe(true)
     expect(groups.some(g => g.title === "Typicode")).toBe(true)
@@ -92,21 +85,12 @@ test.describe("Group Operations - Collapse/Expand", () => {
 
     // Expand all first to have a known state
     await expandAllGroups(popupPage)
-    await popupPage.waitForTimeout(300)
-
-    // Verify groups are expanded
-    groups = await getTabGroups(popupPage)
-    expect(groups.every(g => !g.collapsed)).toBe(true)
+    await waitForGroups(popupPage, gs => gs.every(g => !g.collapsed))
 
     // Collapse all groups
+    // Most groups should be collapsed (the active tab's group may stay expanded)
     await collapseAllGroups(popupPage)
-    await popupPage.waitForTimeout(300)
-
-    // Verify most groups are collapsed (active tab's group may stay expanded)
-    groups = await getTabGroups(popupPage)
-    const collapsedCount = groups.filter(g => g.collapsed).length
-    // Most groups should be collapsed (allow 1 active tab group to stay expanded)
-    expect(collapsedCount).toBeGreaterThanOrEqual(groups.length - 1)
+    await waitForGroups(popupPage, gs => gs.filter(g => g.collapsed).length >= gs.length - 1)
 
     // Cleanup
     await tab1.close()
@@ -127,20 +111,11 @@ test.describe("Group Operations - Collapse/Expand", () => {
 
     // Collapse all first
     await collapseAllGroups(popupPage)
-    await popupPage.waitForTimeout(300)
-
-    // Verify some groups are collapsed
-    let groups = await getTabGroups(popupPage)
-    const initialCollapsed = groups.filter(g => g.collapsed).length
-    expect(initialCollapsed).toBeGreaterThan(0)
+    await waitForGroups(popupPage, gs => gs.some(g => g.collapsed))
 
     // Expand all groups
     await expandAllGroups(popupPage)
-    await popupPage.waitForTimeout(300)
-
-    // Verify all groups are expanded
-    groups = await getTabGroups(popupPage)
-    expect(groups.every(g => !g.collapsed)).toBe(true)
+    await waitForGroups(popupPage, gs => gs.every(g => !g.collapsed))
 
     // Cleanup
     await tab1.close()

--- a/tests/e2e/helpers/extension-helpers.ts
+++ b/tests/e2e/helpers/extension-helpers.ts
@@ -313,7 +313,9 @@ export async function waitForTabUngrouped(
 export async function waitForNoGroups(popupPage: Page, timeout = DEFAULT_WAIT_MS): Promise<void> {
   await expect(async () => {
     const groups = await getTabGroups(popupPage)
-    expect(groups.length).toBe(0)
+    // Compare titles rather than a count: when this fails, the message names
+    // the group that survived instead of just saying "expected 0, got 1"
+    expect(groups.map(group => `${group.title} (#${group.id})`)).toEqual([])
   }).toPass({ timeout })
 }
 
@@ -335,8 +337,14 @@ export async function waitForGroupCount(
  * Ungroup all tabs via the extension
  */
 export async function ungroupAllTabs(popupPage: Page): Promise<void> {
-  await sendMessage(popupPage, "ungroup")
-  await waitForNoGroups(popupPage)
+  // Re-send on every attempt rather than asking once and waiting. A grouping
+  // operation already in flight when the first request lands can regroup a tab
+  // just after it is ungrouped, which a single request can never recover from.
+  await expect(async () => {
+    await sendMessage(popupPage, "ungroup")
+    const groups = await getTabGroups(popupPage)
+    expect(groups.map(group => `${group.title} (#${group.id})`)).toEqual([])
+  }).toPass({ timeout: DEFAULT_WAIT_MS })
 }
 
 /**

--- a/tests/e2e/helpers/extension-helpers.ts
+++ b/tests/e2e/helpers/extension-helpers.ts
@@ -5,8 +5,15 @@
  * through the extension popup and background service worker.
  */
 
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
 import type { BrowserContext, Page } from "@playwright/test"
-import { expect } from "@playwright/test"
+import { chromium, expect } from "@playwright/test"
+
+const EXTENSION_PATH = join(dirname(fileURLToPath(import.meta.url)), "../../../.output/chrome-mv3")
+
+/** CI runners are slower than a dev machine, so the polls get more room there */
+const DEFAULT_WAIT_MS = process.env.CI ? 15000 : 5000
 
 /**
  * Test domain URLs for isolation
@@ -43,6 +50,43 @@ export interface TabInfo {
   groupId: number
   pinned: boolean
   windowId: number
+}
+
+/**
+ * Serves every http(s) request from memory instead of the network.
+ *
+ * Grouping is keyed on the hostname, so the tests need several distinct
+ * domains — but nothing about them needs to be real. Fulfilling the requests
+ * locally keeps the hostnames while removing DNS, TLS and third-party uptime
+ * (httpbin.org in particular) from a suite whose assertions are timing
+ * sensitive. Extension pages are left alone; only http/https is intercepted.
+ */
+export async function serveFixtures(context: BrowserContext): Promise<void> {
+  await context.route(
+    url => url.protocol === "http:" || url.protocol === "https:",
+    async route => {
+      const url = new URL(route.request().url())
+      await route.fulfill({
+        status: 200,
+        contentType: "text/html; charset=utf-8",
+        body: `<!doctype html><html><head><title>${url.hostname}${url.pathname}</title></head><body><h1>${url.hostname}</h1></body></html>`
+      })
+    }
+  )
+}
+
+/**
+ * Launches a browser with the built extension loaded and fixtures served.
+ * Every spec file used to repeat this block; keeping it in one place means
+ * changes like the fixture routing apply everywhere at once.
+ */
+export async function launchExtensionContext(): Promise<BrowserContext> {
+  const context = await chromium.launchPersistentContext("", {
+    headless: false,
+    args: [`--disable-extensions-except=${EXTENSION_PATH}`, `--load-extension=${EXTENSION_PATH}`]
+  })
+  await serveFixtures(context)
+  return context
 }
 
 /**
@@ -186,7 +230,7 @@ export async function createTabs(
 export async function waitForGroup(
   popupPage: Page,
   expectedTitle: string,
-  timeout = 5000
+  timeout = DEFAULT_WAIT_MS
 ): Promise<TabGroupInfo> {
   let group: TabGroupInfo | undefined
 
@@ -200,13 +244,35 @@ export async function waitForGroup(
 }
 
 /**
+ * Wait until the current groups satisfy a predicate.
+ *
+ * Prefer this over sleeping before an assertion: the extension applies changes
+ * asynchronously, so a fixed wait either flakes on a slow machine or wastes
+ * time on a fast one.
+ */
+export async function waitForGroups(
+  popupPage: Page,
+  predicate: (groups: TabGroupInfo[]) => boolean,
+  timeout = DEFAULT_WAIT_MS
+): Promise<TabGroupInfo[]> {
+  let groups: TabGroupInfo[] = []
+
+  await expect(async () => {
+    groups = await getTabGroups(popupPage)
+    expect(predicate(groups)).toBe(true)
+  }).toPass({ timeout })
+
+  return groups
+}
+
+/**
  * Wait for a tab to be in a specific group
  */
 export async function waitForTabInGroup(
   popupPage: Page,
   tabUrl: string,
   expectedGroupTitle: string,
-  timeout = 5000
+  timeout = DEFAULT_WAIT_MS
 ): Promise<void> {
   await expect(async () => {
     const tabs = await getTabs(popupPage)
@@ -231,7 +297,7 @@ export async function waitForTabInGroup(
 export async function waitForTabUngrouped(
   popupPage: Page,
   tabUrl: string,
-  timeout = 5000
+  timeout = DEFAULT_WAIT_MS
 ): Promise<void> {
   await expect(async () => {
     const tabs = await getTabs(popupPage)
@@ -244,7 +310,7 @@ export async function waitForTabUngrouped(
 /**
  * Wait for no groups to exist
  */
-export async function waitForNoGroups(popupPage: Page, timeout = 5000): Promise<void> {
+export async function waitForNoGroups(popupPage: Page, timeout = DEFAULT_WAIT_MS): Promise<void> {
   await expect(async () => {
     const groups = await getTabGroups(popupPage)
     expect(groups.length).toBe(0)
@@ -257,7 +323,7 @@ export async function waitForNoGroups(popupPage: Page, timeout = 5000): Promise<
 export async function waitForGroupCount(
   popupPage: Page,
   count: number,
-  timeout = 5000
+  timeout = DEFAULT_WAIT_MS
 ): Promise<void> {
   await expect(async () => {
     const groups = await getTabGroups(popupPage)
@@ -439,7 +505,10 @@ export async function getCollapseState(popupPage: Page): Promise<boolean> {
 /**
  * Wait for all groups to be collapsed
  */
-export async function waitForGroupsCollapsed(popupPage: Page, timeout = 5000): Promise<void> {
+export async function waitForGroupsCollapsed(
+  popupPage: Page,
+  timeout = DEFAULT_WAIT_MS
+): Promise<void> {
   await expect(async () => {
     const groups = await getTabGroups(popupPage)
     const _nonActiveGroups = groups.filter(g => !g.collapsed === false)
@@ -450,7 +519,10 @@ export async function waitForGroupsCollapsed(popupPage: Page, timeout = 5000): P
 /**
  * Wait for all groups to be expanded
  */
-export async function waitForGroupsExpanded(popupPage: Page, timeout = 5000): Promise<void> {
+export async function waitForGroupsExpanded(
+  popupPage: Page,
+  timeout = DEFAULT_WAIT_MS
+): Promise<void> {
   await expect(async () => {
     const groups = await getTabGroups(popupPage)
     expect(groups.every(g => !g.collapsed)).toBe(true)
@@ -592,7 +664,7 @@ export async function getActiveTab(popupPage: Page): Promise<TabInfo | null> {
 export async function waitForOtherGroupsCollapsed(
   popupPage: Page,
   activeGroupId: number,
-  timeout = 5000
+  timeout = DEFAULT_WAIT_MS
 ): Promise<void> {
   await expect(async () => {
     const groups = await getTabGroups(popupPage)

--- a/tests/e2e/minimum-tabs.e2e.ts
+++ b/tests/e2e/minimum-tabs.e2e.ts
@@ -7,9 +7,7 @@
  * - Ungroups when below threshold after tab close
  */
 
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
 import {
   closeTestTabs,
   createTab,
@@ -19,6 +17,7 @@ import {
   getMinimumTabs,
   getTabGroups,
   getTabs,
+  launchExtensionContext,
   openPopup,
   setGroupByMode,
   setMinimumTabs,
@@ -27,10 +26,6 @@ import {
   waitForGroup
 } from "./helpers/extension-helpers"
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const extensionPath = join(__dirname, "../../.output/chrome-mv3")
-
 let context: BrowserContext
 let extensionId: string
 let popupPage: Page
@@ -38,18 +33,12 @@ let popupPage: Page
 test.beforeAll(async () => {
   // Create a fresh browser context for this test suite
   try {
-    context = await chromium.launchPersistentContext("", {
-      headless: false,
-      args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-    })
+    context = await launchExtensionContext()
     extensionId = await getExtensionId(context)
   } catch (error) {
     console.error("Failed to create context, retrying...", error)
     // Retry once
-    context = await chromium.launchPersistentContext("", {
-      headless: false,
-      args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-    })
+    context = await launchExtensionContext()
     extensionId = await getExtensionId(context)
   }
 })
@@ -76,10 +65,7 @@ test.beforeEach(async () => {
   if (needsRecreation) {
     // Context was closed or invalid, recreate it
     console.log("Recreating browser context for minimum-tabs tests...")
-    context = await chromium.launchPersistentContext("", {
-      headless: false,
-      args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-    })
+    context = await launchExtensionContext()
     extensionId = await getExtensionId(context)
   }
 

--- a/tests/e2e/protected-groups.e2e.ts
+++ b/tests/e2e/protected-groups.e2e.ts
@@ -9,9 +9,7 @@
  * reinstall can't be driven from here.
  */
 
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
 import {
   closeTestTabs,
   createTab,
@@ -20,6 +18,7 @@ import {
   getExtensionId,
   getTabGroups,
   groupAllTabs,
+  launchExtensionContext,
   openPopup,
   sendMessage,
   setGroupByMode,
@@ -27,10 +26,6 @@ import {
   TEST_URLS,
   ungroupAllTabs
 } from "./helpers/extension-helpers"
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const extensionPath = join(__dirname, "../../.output/chrome-mv3")
 
 let context: BrowserContext
 let extensionId: string
@@ -74,10 +69,7 @@ async function getTabIds(page: Page, urlPart: string): Promise<number[]> {
 }
 
 test.beforeAll(async () => {
-  context = await chromium.launchPersistentContext("", {
-    headless: false,
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-  })
+  context = await launchExtensionContext()
   extensionId = await getExtensionId(context)
 })
 

--- a/tests/e2e/rule-editor-fields.e2e.ts
+++ b/tests/e2e/rule-editor-fields.e2e.ts
@@ -9,22 +9,17 @@
  * - Blacklist mode hides the minimum-tabs field
  */
 
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
 import {
   closeTestTabs,
   deleteCustomRule,
   disableAutoGroup,
   getCustomRules,
   getExtensionId,
+  launchExtensionContext,
   openPopup,
   ungroupAllTabs
 } from "./helpers/extension-helpers"
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const extensionPath = join(__dirname, "../../.output/chrome-mv3")
 
 let context: BrowserContext
 let extensionId: string
@@ -62,10 +57,7 @@ async function findRule(name: string): Promise<StoredRule | undefined> {
 }
 
 test.beforeAll(async () => {
-  context = await chromium.launchPersistentContext("", {
-    headless: false,
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-  })
+  context = await launchExtensionContext()
   extensionId = await getExtensionId(context)
 })
 

--- a/tests/e2e/rule-editor-title.e2e.ts
+++ b/tests/e2e/rule-editor-title.e2e.ts
@@ -7,9 +7,7 @@
  * overwrite it again.
  */
 
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
 import {
   addCustomRule,
   closeTestTabs,
@@ -17,12 +15,9 @@ import {
   disableAutoGroup,
   getCustomRules,
   getExtensionId,
+  launchExtensionContext,
   openPopup
 } from "./helpers/extension-helpers"
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const extensionPath = join(__dirname, "../../.output/chrome-mv3")
 
 let context: BrowserContext
 let extensionId: string
@@ -43,10 +38,7 @@ async function openRuleEditor(query = ""): Promise<Page> {
 }
 
 test.beforeAll(async () => {
-  context = await chromium.launchPersistentContext("", {
-    headless: false,
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-  })
+  context = await launchExtensionContext()
   extensionId = await getExtensionId(context)
 })
 

--- a/tests/e2e/system-group.e2e.ts
+++ b/tests/e2e/system-group.e2e.ts
@@ -7,9 +7,7 @@
  * - The dependent "group new empty tabs" toggle follows it in the UI
  */
 
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
 import {
   closeTestTabs,
   createTab,
@@ -18,6 +16,7 @@ import {
   getExtensionId,
   getTabGroups,
   groupAllTabs,
+  launchExtensionContext,
   openPopup,
   sendMessage,
   setGroupByMode,
@@ -25,10 +24,6 @@ import {
   TEST_URLS,
   ungroupAllTabs
 } from "./helpers/extension-helpers"
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const extensionPath = join(__dirname, "../../.output/chrome-mv3")
 
 let context: BrowserContext
 let extensionId: string
@@ -47,10 +42,7 @@ async function hasSystemGroup(page: Page): Promise<boolean> {
 }
 
 test.beforeAll(async () => {
-  context = await chromium.launchPersistentContext("", {
-    headless: false,
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-  })
+  context = await launchExtensionContext()
   extensionId = await getExtensionId(context)
 })
 

--- a/tests/e2e/tab-grouping.e2e.ts
+++ b/tests/e2e/tab-grouping.e2e.ts
@@ -9,9 +9,7 @@
  * - Subdomain mode
  */
 
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { type BrowserContext, chromium, expect, type Page, test } from "@playwright/test"
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
 import {
   closeTestTabs,
   createTab,
@@ -20,6 +18,7 @@ import {
   getExtensionId,
   getTabGroups,
   getTabs,
+  launchExtensionContext,
   openPopup,
   pinTab,
   setGroupByMode,
@@ -31,19 +30,12 @@ import {
   waitForTabInGroup
 } from "./helpers/extension-helpers"
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const extensionPath = join(__dirname, "../../.output/chrome-mv3")
-
 let context: BrowserContext
 let extensionId: string
 let popupPage: Page
 
 test.beforeAll(async () => {
-  context = await chromium.launchPersistentContext("", {
-    headless: false,
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`]
-  })
+  context = await launchExtensionContext()
   extensionId = await getExtensionId(context)
 })
 


### PR DESCRIPTION
Second half of the debt. The suite failed roughly one test per full run — a different one each time, each passing in isolation — which is why it was left out of #83.

**This PR also contains a user-facing bug fix that CI found (see "The bug CI caught"), so it bumps the version to 3.9.1.**

## Cause 1: the tests loaded real websites

Grouping is keyed on the hostname, so the suite genuinely needs several distinct domains. But nothing about them needed to be **real** — it was paying DNS, TLS and third-party uptime on every navigation, inside assertions that are timing sensitive. `httpbin.org` is `domain2` throughout, and "separates tabs from different domains" failing on a `waitForGroup` timeout is precisely what a slow third party looks like from the inside.

`serveFixtures()` now fulfils every http(s) request from memory, preserving the hostname. Extension pages are untouched.

## Cause 2: fixed sleeps standing in for conditions

Mostly `waitForTimeout(500)` then asserting the groups had collapsed. Those now poll, via a new `waitForGroups(page, predicate)` helper. Sleeps before a *negative* assertion are deliberately left: there a short wait can only cause a false pass, never a flake.

## Cause 3: helpers that asked once and hoped

`ungroupAllTabs` sent one "ungroup" and then waited. A grouping operation already in flight when that request lands can regroup a tab immediately after it is ungrouped, and waiting cannot recover — nothing asks again. It now re-sends on each poll attempt. This was the cause of three separate CI failures that all looked like different tests.

Failures also compare group titles rather than counts, so "a group survived" names the group instead of saying "expected 0, received 1".

## Cause 4: a test whose expected value was wrong

`auto-group toggle works` read the checkbox immediately after opening the popup, but the popup fills its toggles from the background asynchronously. On a slower runner it read the markup default instead of the stored setting, so "initial state" was wrong and every later assertion inverted. Polling can't rescue a wrong expected value; it now waits for the UI to agree with the background first.

## The bug CI caught

The first red run was not a test problem. `seedProtectedGroupsOnFirstRun` (from #82) treats an empty `storage.local` as "fresh install" — but storage stays empty until the user changes a setting, since WXT's `defineItem` fallbacks never write, and MV3 shuts down idle service workers. A restart hours after install therefore looked like a fresh install again and protected whatever groups existed by then, **including ones the extension had created itself**. Auto-grouping then silently stopped managing them.

The first run now writes `protectedGroupTitles` even when there is nothing to protect, marking it done. Two unit tests cover the marker and the second-start no-op.

Eight green local runs could never have found this: it needs a slower machine. The first CI run then *hid* it behind a retry, which is why the workflow runs with `--fail-on-flaky-tests` — a retry-pass reports red instead of banking a green tick. Retries stay for the traces they leave behind.

## Measured

| | before | after |
| --- | --- | --- |
| failures | ~1 per full run | 0 in 9 consecutive local runs |
| duration | 1.2–5 min | 54–58s |
| CI (Linux) | n/a | 57 passed, 0 flaky, 57.1s |

Before-numbers include a run on unmodified `master`, confirming it predated the recent work.

## Also

- Twelve copies of the launch block collapse into `launchExtensionContext()`, so the fixture routing applies everywhere and the next change of this kind lands in one place.
- Polling timeouts scale to 15s when `CI` is set — runners are slower than a laptop. This raises the ceiling rather than papering over a race; conditions are still polled.
- `docs/CONTRIB.md` gains the rules that keep it deterministic: launch through the shared helper, never sleep before a positive assertion.

Version bumped to 3.9.1 for the first-run fix.