### PR TITLE
docs: add a changelog, and cover the sidebar in E2E

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,114 @@
+# Changelog
+
+All notable changes to Auto Tab Groups are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Releases before 3.5.2 predate this file; see the
+[commit history](https://github.com/nitzanpap/auto-tab-groups/commits/master)
+for those.
+
+## [Unreleased]
+
+## [3.9.1]
+
+### Fixed
+
+- The first-run setup could fire long after install. Storage stays empty until
+  you change a setting, and the browser shuts down idle service workers — so a
+  later restart looked like a fresh install and excluded whatever groups existed
+  by then, including ones the extension had created itself. Auto-grouping then
+  silently stopped managing them ([#84]).
+
+## [3.9.0]
+
+### Added
+
+- Groups can be excluded from auto-grouping. Right-click a tab to exclude its
+  group; the popup and sidebar list every exclusion and let you remove one.
+  Groups that already exist when the extension is first installed are excluded
+  automatically, so installing no longer dissolves organization you built by
+  hand ([#82], closes [#23]).
+
+## [3.8.1]
+
+### Fixed
+
+- The rule editor always showed "Create Custom Rule", even when adding a
+  blacklist rule, editing a rule, or creating one from a group. The translation
+  pass overwrote the title that mode setup had already applied ([#81]).
+
+## [3.8.0]
+
+### Added
+
+- Rule priority and per-rule minimum tabs are editable in the rule editor.
+  Both fields existed and were honoured, but could only be set by exporting
+  rules, editing the JSON and re-importing ([#80]).
+
+### Fixed
+
+- Clearing a per-rule minimum had no effect — the previous value was kept.
+
+## [3.7.1]
+
+### Fixed
+
+- Rule priority is honoured when matching tabs. It was documented as
+  "higher = more priority" and validated on import, but never read: overlapping
+  rules resolved by creation order instead. Rules that share a priority keep
+  their existing order, so nothing changes unless you set one ([#79],
+  closes [#78]).
+
+## [3.7.0]
+
+### Added
+
+- Catch-all rules. A rule whose pattern is a lone `*` collects tabs nothing else
+  claimed — every unmatched tab in rules-only mode, or tabs that can't form
+  their own group in domain mode. Browser pages and blacklisted tabs are never
+  collected ([#77], closes [#29]).
+
+## [3.6.0]
+
+### Added
+
+- Opt-in setting to remove the "System" group. Off by default; turning it on
+  keeps browser pages and new empty tabs ungrouped and dissolves any existing
+  System group ([#76], closes [#31]).
+
+### Fixed
+
+- Dissolving the System group only affected the current window, and missed
+  groups carrying a sort-index prefix.
+
+## [3.5.2]
+
+### Fixed
+
+- Tab groups for internationalized domains showed punycode — `Xn--mnchen-3ya`
+  instead of `München` ([#75], closes [#74]).
+
+[unreleased]: https://github.com/nitzanpap/auto-tab-groups/compare/v3.9.1...HEAD
+[3.9.1]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.9.1
+[3.9.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.9.0
+[3.8.1]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.8.1
+[3.8.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.8.0
+[3.7.1]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.7.1
+[3.7.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.7.0
+[3.6.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.6.0
+[3.5.2]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.5.2
+[#23]: https://github.com/nitzanpap/auto-tab-groups/issues/23
+[#29]: https://github.com/nitzanpap/auto-tab-groups/issues/29
+[#31]: https://github.com/nitzanpap/auto-tab-groups/issues/31
+[#74]: https://github.com/nitzanpap/auto-tab-groups/issues/74
+[#75]: https://github.com/nitzanpap/auto-tab-groups/pull/75
+[#76]: https://github.com/nitzanpap/auto-tab-groups/pull/76
+[#77]: https://github.com/nitzanpap/auto-tab-groups/pull/77
+[#78]: https://github.com/nitzanpap/auto-tab-groups/issues/78
+[#79]: https://github.com/nitzanpap/auto-tab-groups/pull/79
+[#80]: https://github.com/nitzanpap/auto-tab-groups/pull/80
+[#81]: https://github.com/nitzanpap/auto-tab-groups/pull/81
+[#82]: https://github.com/nitzanpap/auto-tab-groups/pull/82
+[#84]: https://github.com/nitzanpap/auto-tab-groups/pull/84

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -41,6 +41,14 @@ bun run dev
 | `bun run code:check` | Run Biome check and typecheck |
 | `bun run code:fix` | Fix lint and formatting issues |
 
+## Releasing
+
+1. Bump `version` in `package.json` (WXT reads it for both manifests).
+2. Add an entry to `CHANGELOG.md` under the new version — what changed for
+   users, not what changed in the code.
+3. `bun run zip && bun run zip:firefox` produces the store packages in
+   `.output/`, including the sources zip AMO requires.
+
 ## Continuous Integration
 
 Every push to `master` and every pull request runs `.github/workflows/ci.yml`:

--- a/tests/e2e/sidebar.e2e.ts
+++ b/tests/e2e/sidebar.e2e.ts
@@ -1,0 +1,166 @@
+/**
+ * E2E Tests: Sidebar
+ *
+ * The sidebar is a near-copy of the popup — same element ids, same wiring,
+ * duplicated in a second file. Every test here targets that duplication: a
+ * control added to one and forgotten in the other, or wired up in the markup
+ * but never connected to the background.
+ */
+
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
+import {
+  closeTestTabs,
+  createTab,
+  disableAutoGroup,
+  getExtensionId,
+  getTabGroups,
+  launchExtensionContext,
+  openPopup,
+  openSidebar,
+  sendMessage,
+  setGroupByMode,
+  setMinimumTabs,
+  TEST_URLS,
+  ungroupAllTabs,
+  waitForGroup
+} from "./helpers/extension-helpers"
+
+let context: BrowserContext
+let extensionId: string
+let popupPage: Page
+let sidebarPage: Page
+
+/**
+ * Controls that are deliberately not in both surfaces. Empty today — if you
+ * add a sidebar-only or popup-only control, list it here so the divergence is
+ * a decision rather than an accident.
+ */
+const KNOWN_DIFFERENCES = new Set<string>([])
+
+async function elementIds(page: Page): Promise<string[]> {
+  return await page.evaluate(() =>
+    Array.from(document.querySelectorAll("[id]"))
+      .map(element => element.id)
+      .sort()
+  )
+}
+
+test.beforeAll(async () => {
+  context = await launchExtensionContext()
+  extensionId = await getExtensionId(context)
+})
+
+test.afterAll(async () => {
+  await context.close()
+})
+
+test.beforeEach(async () => {
+  await closeTestTabs(context)
+  popupPage = await openPopup(context, extensionId)
+  await disableAutoGroup(popupPage)
+  await ungroupAllTabs(popupPage)
+  await setMinimumTabs(popupPage, 1)
+  await setGroupByMode(popupPage, "domain")
+  sidebarPage = await openSidebar(context, extensionId)
+})
+
+test.afterEach(async () => {
+  if (sidebarPage && !sidebarPage.isClosed()) await sidebarPage.close()
+  if (popupPage && !popupPage.isClosed()) {
+    await disableAutoGroup(popupPage)
+    await ungroupAllTabs(popupPage)
+    await popupPage.close()
+  }
+  await closeTestTabs(context)
+})
+
+test.describe("Sidebar", () => {
+  test("exposes the same controls as the popup", async () => {
+    const [popupIds, sidebarIds] = await Promise.all([
+      elementIds(popupPage),
+      elementIds(sidebarPage)
+    ])
+
+    const missingFromSidebar = popupIds.filter(
+      id => !sidebarIds.includes(id) && !KNOWN_DIFFERENCES.has(id)
+    )
+    const missingFromPopup = sidebarIds.filter(
+      id => !popupIds.includes(id) && !KNOWN_DIFFERENCES.has(id)
+    )
+
+    expect(missingFromSidebar).toEqual([])
+    expect(missingFromPopup).toEqual([])
+  })
+
+  test("auto-group toggle round-trips through the background", async () => {
+    const toggle = sidebarPage.locator("#autoGroupToggle")
+
+    // The sidebar fills its toggles asynchronously, so wait for it to agree
+    // with the background before touching anything
+    await expect(toggle).not.toBeChecked()
+
+    await toggle.locator("xpath=ancestor::label").click()
+    await expect(toggle).toBeChecked()
+
+    const state = (await sendMessage(popupPage, "getAutoGroupState")) as { enabled: boolean }
+    expect(state.enabled).toBe(true)
+  })
+
+  test("groups and ungroups real tabs from its buttons", async () => {
+    await createTab(context, TEST_URLS.domain1)
+
+    await sidebarPage.locator("#group").click()
+    await waitForGroup(popupPage, "Example")
+
+    await sidebarPage.locator("#ungroup").click()
+    await expect(async () => {
+      expect(await getTabGroups(popupPage)).toEqual([])
+    }).toPass()
+  })
+
+  test("System group toggle disables the dependent new-empty-tabs toggle", async () => {
+    const systemToggle = sidebarPage.locator("#systemGroupToggle")
+    const newTabsToggle = sidebarPage.locator("#groupNewTabsToggle")
+
+    await expect(systemToggle).toBeChecked()
+    await expect(newTabsToggle).toBeEnabled()
+
+    await systemToggle.locator("xpath=ancestor::label").click()
+
+    await expect(systemToggle).not.toBeChecked()
+    await expect(newTabsToggle).toBeDisabled()
+
+    // and the background actually heard about it
+    const state = (await sendMessage(popupPage, "getSystemGroupEnabled")) as { enabled: boolean }
+    expect(state.enabled).toBe(false)
+
+    await sendMessage(popupPage, "toggleSystemGroup", { enabled: true })
+  })
+
+  test("lists excluded groups and removes one", async () => {
+    await sendMessage(popupPage, "addProtectedGroup", { title: "My Reading List" })
+
+    const sidebar = await openSidebar(context, extensionId)
+    const chip = sidebar.locator(".protected-group-chip")
+    await expect(chip).toHaveCount(1)
+    await expect(chip).toContainText("My Reading List")
+
+    await chip.locator("button").click()
+    await expect(sidebar.locator(".protected-group-chip")).toHaveCount(0)
+
+    const remaining = (await sendMessage(popupPage, "getProtectedGroups")) as { titles: string[] }
+    expect(remaining.titles).toEqual([])
+
+    await sidebar.close()
+  })
+
+  test("keeps the minimum tabs input in sync with the background", async () => {
+    await setMinimumTabs(popupPage, 3)
+
+    const sidebar = await openSidebar(context, extensionId)
+    await expect(sidebar.locator("#minimumTabsInput")).toHaveValue("3")
+
+    await sidebar.close()
+    await setMinimumTabs(popupPage, 1)
+  })
+})


### PR DESCRIPTION
The last two items on the debt list.

## Changelog

`CHANGELOG.md` covers 3.5.2 onward, in Keep a Changelog format. Entries are reconstructed from the version bumps in git history — not invented — and describe what changed for users rather than what changed in the code. Releases before 3.5.2 predate the file and are left to the commit log rather than being back-filled from guesswork.

`docs/CONTRIB.md` gains the release steps (bump, changelog entry, zip both targets), so the entry is part of cutting a version instead of something remembered afterwards.

## Sidebar coverage

The sidebar had exactly one E2E test asserting its elements exist — despite being a 1400-line near-copy of the popup with identical element ids and its own duplicated wiring. Every setting I added this session was implemented twice and verified once.

So the new tests target that duplication rather than re-testing logic the popup tests already cover:

- **A parity check** that diffs the element ids of both surfaces. Copy-paste drift is the actual failure mode here, and this catches a control added to one and forgotten in the other. There's a `KNOWN_DIFFERENCES` set — empty today — so a deliberate divergence is a one-line decision rather than a mysterious red test.
- **Round-trips for the controls added most recently in two places**: the System group toggle and its dependent new-empty-tabs toggle, the excluded-groups chips, the minimum tabs input, and the group/ungroup buttons — each asserting the background actually heard about it, not just that the DOM changed.

### Verified the parity test isn't decorative

Renamed `systemGroupToggle` to `systemGroupToggleTYPO` in the sidebar markup, rebuilt, and confirmed the test fails with the id diff. Restored afterwards.

## Test plan

- [x] `bunx vitest run` — 844 pass
- [x] `bunx playwright test --fail-on-flaky-tests` — 63 pass (was 57), 57.8s, no retries
- [x] `bun run code:check` clean

No version bump — nothing ships to users.

Depends on #84 for the `launchExtensionContext` helper and `--fail-on-flaky-tests`.