### PR TITLE
feat: add keyboard shortcuts, with no keys bound by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ for those.
 
 ## [Unreleased]
 
+## [3.10.0]
+
+### Added
+
+- Keyboard shortcuts for turning auto-grouping on or off, grouping all tabs,
+  ungrouping all tabs, and collapsing or expanding every group. No keys are
+  assigned by default — installing takes none of your existing shortcuts, and
+  nothing fires until you assign keys in the browser's own shortcut settings.
+  Advanced → Keyboard shortcuts opens that page ([#86], closes [#25]).
+
 ## [3.9.1]
 
 ### Fixed
@@ -90,7 +100,8 @@ for those.
 - Tab groups for internationalized domains showed punycode — `Xn--mnchen-3ya`
   instead of `München` ([#75], closes [#74]).
 
-[unreleased]: https://github.com/nitzanpap/auto-tab-groups/compare/v3.9.1...HEAD
+[unreleased]: https://github.com/nitzanpap/auto-tab-groups/compare/v3.10.0...HEAD
+[3.10.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.10.0
 [3.9.1]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.9.1
 [3.9.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.9.0
 [3.8.1]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.8.1
@@ -100,6 +111,7 @@ for those.
 [3.6.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.6.0
 [3.5.2]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.5.2
 [#23]: https://github.com/nitzanpap/auto-tab-groups/issues/23
+[#25]: https://github.com/nitzanpap/auto-tab-groups/issues/25
 [#29]: https://github.com/nitzanpap/auto-tab-groups/issues/29
 [#31]: https://github.com/nitzanpap/auto-tab-groups/issues/31
 [#74]: https://github.com/nitzanpap/auto-tab-groups/issues/74
@@ -112,3 +124,4 @@ for those.
 [#81]: https://github.com/nitzanpap/auto-tab-groups/pull/81
 [#82]: https://github.com/nitzanpap/auto-tab-groups/pull/82
 [#84]: https://github.com/nitzanpap/auto-tab-groups/pull/84
+[#86]: https://github.com/nitzanpap/auto-tab-groups/pull/86

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -46,6 +46,25 @@ Titles are matched with any sort-index prefix stripped, so the "Number groups"
 setting doesn't break exclusions. Renaming an excluded group ends its
 exclusion — title is identity here, as everywhere else in the extension.
 
+## Keyboard Shortcuts
+
+The extension registers four commands, plus the browser's built-in "open the
+popup":
+
+| Command | Does |
+| ------- | ---- |
+| Turn auto-grouping on or off | Same as the Auto-Group Mode toggle |
+| Group all tabs now | Same as the Group Tabs button |
+| Ungroup all tabs | Same as the Ungroup All button |
+| Collapse or expand all groups | Same as Collapse All / Expand All |
+
+**No keys are assigned.** The manifest suggests none deliberately, so installing
+the extension never takes a shortcut you already use, and nothing fires until
+you assign keys yourself. Advanced → Keyboard shortcuts → "Set up" opens the
+browser's own shortcut settings (`chrome://extensions/shortcuts` in Chrome,
+Add-ons Manager in Firefox), which is the only place keys can be bound —
+extensions cannot assign them for you.
+
 ## URL Patterns
 
 Custom rules support advanced URL pattern matching beyond simple domains.

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -15,6 +15,7 @@ import {
   tabGroupService,
   tabGroupState
 } from "../services"
+import { handleCommand } from "../services/CommandService"
 import { seedProtectedGroupsOnFirstRun } from "../services/FirstRunService"
 import {
   parseAiRuleResponse,
@@ -87,6 +88,17 @@ export default defineBackground(() => {
     .catch(error => {
       console.error("Critical error: Failed to load state on service worker start:", error)
     })
+
+  // Keyboard commands. Inert until the user assigns keys in the browser's
+  // shortcuts page — the manifest suggests none.
+  browser.commands?.onCommand.addListener(async command => {
+    try {
+      await ensureStateLoaded()
+      await handleCommand(command)
+    } catch (error) {
+      console.error(`Error handling command "${command}":`, error)
+    }
+  })
 
   // Message handler for popup communication
   browser.runtime.onMessage.addListener((msg, _sender, sendResponse) => {

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -328,6 +328,13 @@
         </button>
         <div class="advanced-content">
           <div class="toggle-container">
+            <span data-i18n="settingKeyboardShortcuts">Keyboard shortcuts</span>
+            <button type="button" class="shortcuts-button" id="openShortcutsButton" data-i18n="settingKeyboardShortcutsOpen">Set up</button>
+          </div>
+          <div class="help-text advanced-help" data-i18n="settingKeyboardShortcutsHelp">
+            No keys are assigned by default. Choose your own in the browser's shortcut settings
+          </div>
+          <div class="toggle-container">
             <span data-i18n="advancedHideContextMenu">Hide right-click context menu</span>
             <label class="switch">
               <input type="checkbox" id="hideContextMenuToggle" />

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -711,6 +711,28 @@ async function renderProtectedGroups(): Promise<void> {
   }
 }
 
+/**
+ * Opens the browser's own keyboard shortcut settings.
+ *
+ * Assigning keys can only happen there — an extension cannot bind them for
+ * you, which is also why nothing is bound until someone visits this page.
+ */
+const openShortcutsButton = document.getElementById("openShortcutsButton") as HTMLButtonElement
+
+openShortcutsButton.addEventListener("click", async () => {
+  const url =
+    import.meta.env.BROWSER === "firefox" ? "about:addons" : "chrome://extensions/shortcuts"
+
+  try {
+    await browser.tabs.create({ url })
+  } catch (error) {
+    // Firefox refuses about: pages from an extension in some versions; fall
+    // back to telling the user where to go rather than failing silently
+    console.error("[Popup] Could not open the shortcuts page:", error)
+    openShortcutsButton.textContent = url
+  }
+})
+
 // Initialize toggle states
 renderProtectedGroups()
 

--- a/entrypoints/popup/style.css
+++ b/entrypoints/popup/style.css
@@ -1584,6 +1584,21 @@ input:checked + .slider:before {
   text-align: right;
 }
 
+.shortcuts-button {
+  padding: 6px 14px;
+  border: 1px solid var(--secondary-color, #ccc);
+  border-radius: 8px;
+  background: #fff;
+  color: #374151;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.shortcuts-button:hover {
+  background: var(--secondary-color-dark, #e5e7eb);
+}
+
 /* Utility — declared last so it beats the layout rules above */
 .hidden {
   display: none;

--- a/entrypoints/sidebar/index.html
+++ b/entrypoints/sidebar/index.html
@@ -329,6 +329,13 @@
           </button>
           <div class="advanced-content">
             <div class="toggle-container">
+              <span data-i18n="settingKeyboardShortcuts">Keyboard shortcuts</span>
+              <button type="button" class="shortcuts-button" id="openShortcutsButton" data-i18n="settingKeyboardShortcutsOpen">Set up</button>
+            </div>
+            <div class="help-text advanced-help" data-i18n="settingKeyboardShortcutsHelp">
+              No keys are assigned by default. Choose your own in the browser's shortcut settings
+            </div>
+            <div class="toggle-container">
               <span data-i18n="advancedHideContextMenu">Hide right-click context menu</span>
               <label class="switch">
                 <input type="checkbox" id="hideContextMenuToggle" />

--- a/entrypoints/sidebar/main.ts
+++ b/entrypoints/sidebar/main.ts
@@ -761,6 +761,28 @@ async function renderProtectedGroups(): Promise<void> {
   }
 }
 
+/**
+ * Opens the browser's own keyboard shortcut settings.
+ *
+ * Assigning keys can only happen there — an extension cannot bind them for
+ * you, which is also why nothing is bound until someone visits this page.
+ */
+const openShortcutsButton = document.getElementById("openShortcutsButton") as HTMLButtonElement
+
+openShortcutsButton.addEventListener("click", async () => {
+  const url =
+    import.meta.env.BROWSER === "firefox" ? "about:addons" : "chrome://extensions/shortcuts"
+
+  try {
+    await browser.tabs.create({ url })
+  } catch (error) {
+    // Firefox refuses about: pages from an extension in some versions; fall
+    // back to telling the user where to go rather than failing silently
+    console.error("[Popup] Could not open the shortcuts page:", error)
+    openShortcutsButton.textContent = url
+  }
+})
+
 // Initialize toggle states
 renderProtectedGroups()
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.9.1",
+  "version": "3.10.0",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/public/_locales/ar/messages.json
+++ b/public/_locales/ar/messages.json
@@ -101,6 +101,38 @@
     "message": "استئناف التجميع التلقائي لهذه المجموعة",
     "description": "Tooltip on the button that removes a group from the excluded list."
   },
+  "commandOpenPopup": {
+    "message": "فتح Auto Tab Groups",
+    "description": "Keyboard command description: open the extension popup."
+  },
+  "commandToggleAutoGrouping": {
+    "message": "تشغيل أو إيقاف التجميع التلقائي",
+    "description": "Keyboard command description: turn automatic grouping on or off."
+  },
+  "commandGroupAllTabs": {
+    "message": "تجميع كل علامات التبويب الآن",
+    "description": "Keyboard command description: group every open tab now."
+  },
+  "commandUngroupAllTabs": {
+    "message": "إلغاء تجميع كل علامات التبويب",
+    "description": "Keyboard command description: remove every tab group."
+  },
+  "commandToggleCollapse": {
+    "message": "طي أو توسيع كل المجموعات",
+    "description": "Keyboard command description: collapse or expand every group."
+  },
+  "settingKeyboardShortcuts": {
+    "message": "اختصارات لوحة المفاتيح",
+    "description": "Label for the keyboard shortcuts row in advanced settings."
+  },
+  "settingKeyboardShortcutsHelp": {
+    "message": "لا توجد مفاتيح معيّنة افتراضيًا. اختر مفاتيحك من إعدادات اختصارات المتصفح",
+    "description": "Help text explaining that shortcuts are unassigned until the user sets them."
+  },
+  "settingKeyboardShortcutsOpen": {
+    "message": "إعداد",
+    "description": "Button that opens the browser's keyboard shortcut settings page."
+  },
   "settingMinimumTabsForGroup": {
     "message": "الحد الأدنى لعلامات التبويب لتكوين مجموعة",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -101,6 +101,38 @@
     "message": "Automatische Gruppierung für diese Gruppe fortsetzen",
     "description": "Tooltip on the button that removes a group from the excluded list."
   },
+  "commandOpenPopup": {
+    "message": "Auto Tab Groups öffnen",
+    "description": "Keyboard command description: open the extension popup."
+  },
+  "commandToggleAutoGrouping": {
+    "message": "Automatische Gruppierung ein-/ausschalten",
+    "description": "Keyboard command description: turn automatic grouping on or off."
+  },
+  "commandGroupAllTabs": {
+    "message": "Alle Tabs jetzt gruppieren",
+    "description": "Keyboard command description: group every open tab now."
+  },
+  "commandUngroupAllTabs": {
+    "message": "Gruppierung aller Tabs aufheben",
+    "description": "Keyboard command description: remove every tab group."
+  },
+  "commandToggleCollapse": {
+    "message": "Alle Gruppen ein-/ausklappen",
+    "description": "Keyboard command description: collapse or expand every group."
+  },
+  "settingKeyboardShortcuts": {
+    "message": "Tastenkürzel",
+    "description": "Label for the keyboard shortcuts row in advanced settings."
+  },
+  "settingKeyboardShortcutsHelp": {
+    "message": "Standardmäßig sind keine Tasten belegt. Lege eigene in den Tastenkürzel-Einstellungen des Browsers fest",
+    "description": "Help text explaining that shortcuts are unassigned until the user sets them."
+  },
+  "settingKeyboardShortcutsOpen": {
+    "message": "Einrichten",
+    "description": "Button that opens the browser's keyboard shortcut settings page."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Mindestanzahl an Tabs für eine Gruppe",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -101,6 +101,38 @@
     "message": "Resume auto-grouping for this group",
     "description": "Tooltip on the button that removes a group from the excluded list."
   },
+  "commandOpenPopup": {
+    "message": "Open Auto Tab Groups",
+    "description": "Keyboard command description: open the extension popup."
+  },
+  "commandToggleAutoGrouping": {
+    "message": "Turn auto-grouping on or off",
+    "description": "Keyboard command description: turn automatic grouping on or off."
+  },
+  "commandGroupAllTabs": {
+    "message": "Group all tabs now",
+    "description": "Keyboard command description: group every open tab now."
+  },
+  "commandUngroupAllTabs": {
+    "message": "Ungroup all tabs",
+    "description": "Keyboard command description: remove every tab group."
+  },
+  "commandToggleCollapse": {
+    "message": "Collapse or expand all groups",
+    "description": "Keyboard command description: collapse or expand every group."
+  },
+  "settingKeyboardShortcuts": {
+    "message": "Keyboard shortcuts",
+    "description": "Label for the keyboard shortcuts row in advanced settings."
+  },
+  "settingKeyboardShortcutsHelp": {
+    "message": "No keys are assigned by default. Choose your own in the browser's shortcut settings",
+    "description": "Help text explaining that shortcuts are unassigned until the user sets them."
+  },
+  "settingKeyboardShortcutsOpen": {
+    "message": "Set up",
+    "description": "Button that opens the browser's keyboard shortcut settings page."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Minimum tabs to form a group",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -101,6 +101,38 @@
     "message": "Reanudar la agrupación automática para este grupo",
     "description": "Tooltip on the button that removes a group from the excluded list."
   },
+  "commandOpenPopup": {
+    "message": "Abrir Auto Tab Groups",
+    "description": "Keyboard command description: open the extension popup."
+  },
+  "commandToggleAutoGrouping": {
+    "message": "Activar o desactivar la agrupación automática",
+    "description": "Keyboard command description: turn automatic grouping on or off."
+  },
+  "commandGroupAllTabs": {
+    "message": "Agrupar todas las pestañas ahora",
+    "description": "Keyboard command description: group every open tab now."
+  },
+  "commandUngroupAllTabs": {
+    "message": "Desagrupar todas las pestañas",
+    "description": "Keyboard command description: remove every tab group."
+  },
+  "commandToggleCollapse": {
+    "message": "Contraer o expandir todos los grupos",
+    "description": "Keyboard command description: collapse or expand every group."
+  },
+  "settingKeyboardShortcuts": {
+    "message": "Atajos de teclado",
+    "description": "Label for the keyboard shortcuts row in advanced settings."
+  },
+  "settingKeyboardShortcutsHelp": {
+    "message": "No hay teclas asignadas de forma predeterminada. Elige las tuyas en los ajustes de atajos del navegador",
+    "description": "Help text explaining that shortcuts are unassigned until the user sets them."
+  },
+  "settingKeyboardShortcutsOpen": {
+    "message": "Configurar",
+    "description": "Button that opens the browser's keyboard shortcut settings page."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Mínimo de pestañas para formar un grupo",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/he/messages.json
+++ b/public/_locales/he/messages.json
@@ -101,6 +101,38 @@
     "message": "חידוש קיבוץ אוטומטי עבור קבוצה זו",
     "description": "Tooltip on the button that removes a group from the excluded list."
   },
+  "commandOpenPopup": {
+    "message": "פתח את Auto Tab Groups",
+    "description": "Keyboard command description: open the extension popup."
+  },
+  "commandToggleAutoGrouping": {
+    "message": "הפעלה או כיבוי של קיבוץ אוטומטי",
+    "description": "Keyboard command description: turn automatic grouping on or off."
+  },
+  "commandGroupAllTabs": {
+    "message": "קבץ את כל הלשוניות עכשיו",
+    "description": "Keyboard command description: group every open tab now."
+  },
+  "commandUngroupAllTabs": {
+    "message": "בטל קיבוץ של כל הלשוניות",
+    "description": "Keyboard command description: remove every tab group."
+  },
+  "commandToggleCollapse": {
+    "message": "כווץ או הרחב את כל הקבוצות",
+    "description": "Keyboard command description: collapse or expand every group."
+  },
+  "settingKeyboardShortcuts": {
+    "message": "קיצורי מקלדת",
+    "description": "Label for the keyboard shortcuts row in advanced settings."
+  },
+  "settingKeyboardShortcutsHelp": {
+    "message": "כברירת מחדל לא מוגדרים מקשים. בחרו משלכם בהגדרות קיצורי המקלדת של הדפדפן",
+    "description": "Help text explaining that shortcuts are unassigned until the user sets them."
+  },
+  "settingKeyboardShortcutsOpen": {
+    "message": "הגדרה",
+    "description": "Button that opens the browser's keyboard shortcut settings page."
+  },
   "settingMinimumTabsForGroup": {
     "message": "מינימום לשוניות ליצירת קבוצה",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -101,6 +101,38 @@
     "message": "इस समूह के लिए स्वतः-समूहन फिर से शुरू करें",
     "description": "Tooltip on the button that removes a group from the excluded list."
   },
+  "commandOpenPopup": {
+    "message": "Auto Tab Groups खोलें",
+    "description": "Keyboard command description: open the extension popup."
+  },
+  "commandToggleAutoGrouping": {
+    "message": "स्वतः-समूहन चालू या बंद करें",
+    "description": "Keyboard command description: turn automatic grouping on or off."
+  },
+  "commandGroupAllTabs": {
+    "message": "सभी टैब्स को अभी समूहित करें",
+    "description": "Keyboard command description: group every open tab now."
+  },
+  "commandUngroupAllTabs": {
+    "message": "सभी टैब्स का समूह हटाएं",
+    "description": "Keyboard command description: remove every tab group."
+  },
+  "commandToggleCollapse": {
+    "message": "सभी समूह संक्षिप्त या विस्तृत करें",
+    "description": "Keyboard command description: collapse or expand every group."
+  },
+  "settingKeyboardShortcuts": {
+    "message": "कीबोर्ड शॉर्टकट",
+    "description": "Label for the keyboard shortcuts row in advanced settings."
+  },
+  "settingKeyboardShortcutsHelp": {
+    "message": "डिफ़ॉल्ट रूप से कोई कुंजी असाइन नहीं है। ब्राउज़र की शॉर्टकट सेटिंग्स में अपनी चुनें",
+    "description": "Help text explaining that shortcuts are unassigned until the user sets them."
+  },
+  "settingKeyboardShortcutsOpen": {
+    "message": "सेट अप करें",
+    "description": "Button that opens the browser's keyboard shortcut settings page."
+  },
   "settingMinimumTabsForGroup": {
     "message": "समूह बनाने के लिए न्यूनतम टैब्स",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -101,6 +101,38 @@
     "message": "Возобновить автогруппировку для этой группы",
     "description": "Tooltip on the button that removes a group from the excluded list."
   },
+  "commandOpenPopup": {
+    "message": "Открыть Auto Tab Groups",
+    "description": "Keyboard command description: open the extension popup."
+  },
+  "commandToggleAutoGrouping": {
+    "message": "Включить или выключить автогруппировку",
+    "description": "Keyboard command description: turn automatic grouping on or off."
+  },
+  "commandGroupAllTabs": {
+    "message": "Сгруппировать все вкладки сейчас",
+    "description": "Keyboard command description: group every open tab now."
+  },
+  "commandUngroupAllTabs": {
+    "message": "Разгруппировать все вкладки",
+    "description": "Keyboard command description: remove every tab group."
+  },
+  "commandToggleCollapse": {
+    "message": "Свернуть или развернуть все группы",
+    "description": "Keyboard command description: collapse or expand every group."
+  },
+  "settingKeyboardShortcuts": {
+    "message": "Сочетания клавиш",
+    "description": "Label for the keyboard shortcuts row in advanced settings."
+  },
+  "settingKeyboardShortcutsHelp": {
+    "message": "По умолчанию клавиши не назначены. Задайте свои в настройках сочетаний клавиш браузера",
+    "description": "Help text explaining that shortcuts are unassigned until the user sets them."
+  },
+  "settingKeyboardShortcutsOpen": {
+    "message": "Настроить",
+    "description": "Button that opens the browser's keyboard shortcut settings page."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Минимальное число вкладок для создания группы",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -101,6 +101,38 @@
     "message": "恢复该分组的自动分组",
     "description": "Tooltip on the button that removes a group from the excluded list."
   },
+  "commandOpenPopup": {
+    "message": "打开 Auto Tab Groups",
+    "description": "Keyboard command description: open the extension popup."
+  },
+  "commandToggleAutoGrouping": {
+    "message": "开启或关闭自动分组",
+    "description": "Keyboard command description: turn automatic grouping on or off."
+  },
+  "commandGroupAllTabs": {
+    "message": "立即分组所有标签页",
+    "description": "Keyboard command description: group every open tab now."
+  },
+  "commandUngroupAllTabs": {
+    "message": "取消所有标签页分组",
+    "description": "Keyboard command description: remove every tab group."
+  },
+  "commandToggleCollapse": {
+    "message": "折叠或展开所有分组",
+    "description": "Keyboard command description: collapse or expand every group."
+  },
+  "settingKeyboardShortcuts": {
+    "message": "键盘快捷键",
+    "description": "Label for the keyboard shortcuts row in advanced settings."
+  },
+  "settingKeyboardShortcutsHelp": {
+    "message": "默认不分配任何按键。请在浏览器的快捷键设置中自行选择",
+    "description": "Help text explaining that shortcuts are unassigned until the user sets them."
+  },
+  "settingKeyboardShortcutsOpen": {
+    "message": "设置",
+    "description": "Button that opens the browser's keyboard shortcut settings page."
+  },
   "settingMinimumTabsForGroup": {
     "message": "形成分组所需的最少标签页数",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/services/CommandService.ts
+++ b/services/CommandService.ts
@@ -1,0 +1,64 @@
+/**
+ * Keyboard command handling.
+ *
+ * The manifest declares these commands without a suggested_key, so the browser
+ * binds nothing on install: they show up unassigned in the browser's own
+ * shortcuts page and stay inert until the user assigns a key. Nothing here runs
+ * unless someone deliberately opted in.
+ */
+
+import { saveAllStorage } from "../utils/storage"
+import { tabGroupService } from "./TabGroupService"
+import { tabGroupState } from "./TabGroupState"
+
+/** Command ids, mirrored in wxt.config.ts */
+export const COMMANDS = {
+  TOGGLE_AUTO_GROUPING: "toggle-auto-grouping",
+  GROUP_ALL_TABS: "group-all-tabs",
+  UNGROUP_ALL_TABS: "ungroup-all-tabs",
+  TOGGLE_COLLAPSE: "toggle-collapse"
+} as const
+
+export type CommandId = (typeof COMMANDS)[keyof typeof COMMANDS]
+
+/**
+ * Runs the action bound to a keyboard command.
+ *
+ * Deliberately routed through the same service calls as the popup buttons, so
+ * a shortcut and a click can never drift apart.
+ *
+ * @returns whether the command was recognised
+ */
+export async function handleCommand(command: string): Promise<boolean> {
+  console.log(`[CommandService] Received command: ${command}`)
+
+  switch (command) {
+    case COMMANDS.TOGGLE_AUTO_GROUPING: {
+      tabGroupState.autoGroupingEnabled = !tabGroupState.autoGroupingEnabled
+      await saveAllStorage(tabGroupState.getStorageData())
+
+      if (tabGroupState.autoGroupingEnabled) {
+        await tabGroupService.groupAllTabs()
+      }
+      return true
+    }
+
+    case COMMANDS.GROUP_ALL_TABS:
+      await tabGroupService.groupAllTabsManually()
+      return true
+
+    case COMMANDS.UNGROUP_ALL_TABS:
+      await tabGroupService.ungroupAllTabs()
+      return true
+
+    case COMMANDS.TOGGLE_COLLAPSE:
+      await tabGroupService.toggleAllGroupsCollapse()
+      return true
+
+    default:
+      // _execute_action and anything the browser adds later are handled by the
+      // browser itself, not here
+      console.log(`[CommandService] No handler for command: ${command}`)
+      return false
+  }
+}

--- a/tests/CommandService.test.ts
+++ b/tests/CommandService.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { tabGroupState } from "../services/TabGroupState"
+import { DEFAULT_STATE } from "../types/storage"
+
+const { saveAllStorage } = vi.hoisted(() => ({ saveAllStorage: vi.fn() }))
+
+vi.mock("../utils/storage", () => ({
+  saveAllStorage,
+  getGroupColor: vi.fn().mockResolvedValue(null),
+  updateGroupColor: vi.fn().mockResolvedValue(undefined),
+  groupColorMapping: { getValue: vi.fn().mockResolvedValue({}) }
+}))
+
+const { groupAllTabs, groupAllTabsManually, ungroupAllTabs, toggleAllGroupsCollapse } = vi.hoisted(
+  () => ({
+    groupAllTabs: vi.fn(),
+    groupAllTabsManually: vi.fn(),
+    ungroupAllTabs: vi.fn(),
+    toggleAllGroupsCollapse: vi.fn()
+  })
+)
+
+vi.mock("../services/TabGroupService", () => ({
+  tabGroupService: {
+    groupAllTabs,
+    groupAllTabsManually,
+    ungroupAllTabs,
+    toggleAllGroupsCollapse
+  }
+}))
+
+import { COMMANDS, handleCommand } from "../services/CommandService"
+
+/**
+ * Keyboard commands run the same service calls as the popup buttons, so a
+ * shortcut and a click cannot drift apart.
+ */
+describe("CommandService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    saveAllStorage.mockResolvedValue(undefined)
+    groupAllTabs.mockResolvedValue(true)
+    groupAllTabsManually.mockResolvedValue(true)
+    ungroupAllTabs.mockResolvedValue(true)
+    toggleAllGroupsCollapse.mockResolvedValue({ isCollapsed: true })
+    tabGroupState.updateFromStorage(DEFAULT_STATE)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("should group all tabs", async () => {
+    expect(await handleCommand(COMMANDS.GROUP_ALL_TABS)).toBe(true)
+    expect(groupAllTabsManually).toHaveBeenCalledTimes(1)
+  })
+
+  it("should ungroup all tabs", async () => {
+    expect(await handleCommand(COMMANDS.UNGROUP_ALL_TABS)).toBe(true)
+    expect(ungroupAllTabs).toHaveBeenCalledTimes(1)
+  })
+
+  it("should toggle collapse", async () => {
+    expect(await handleCommand(COMMANDS.TOGGLE_COLLAPSE)).toBe(true)
+    expect(toggleAllGroupsCollapse).toHaveBeenCalledTimes(1)
+  })
+
+  describe("toggle auto-grouping", () => {
+    it("should turn it off and persist that", async () => {
+      tabGroupState.autoGroupingEnabled = true
+
+      await handleCommand(COMMANDS.TOGGLE_AUTO_GROUPING)
+
+      expect(tabGroupState.autoGroupingEnabled).toBe(false)
+      expect(saveAllStorage).toHaveBeenCalledWith(
+        expect.objectContaining({ autoGroupingEnabled: false })
+      )
+      expect(groupAllTabs).not.toHaveBeenCalled()
+    })
+
+    it("should turn it on and group straight away", async () => {
+      tabGroupState.autoGroupingEnabled = false
+
+      await handleCommand(COMMANDS.TOGGLE_AUTO_GROUPING)
+
+      expect(tabGroupState.autoGroupingEnabled).toBe(true)
+      expect(saveAllStorage).toHaveBeenCalledWith(
+        expect.objectContaining({ autoGroupingEnabled: true })
+      )
+      expect(groupAllTabs).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("should ignore commands it does not own", async () => {
+    expect(await handleCommand("_execute_action")).toBe(false)
+    expect(await handleCommand("something-else")).toBe(false)
+
+    expect(groupAllTabsManually).not.toHaveBeenCalled()
+    expect(ungroupAllTabs).not.toHaveBeenCalled()
+    expect(toggleAllGroupsCollapse).not.toHaveBeenCalled()
+    expect(saveAllStorage).not.toHaveBeenCalled()
+  })
+})

--- a/tests/e2e/keyboard-shortcuts.e2e.ts
+++ b/tests/e2e/keyboard-shortcuts.e2e.ts
@@ -1,0 +1,89 @@
+/**
+ * E2E Tests: Keyboard Shortcuts
+ *
+ * The point of these is the opt-in guarantee: the extension declares commands
+ * but suggests no keys, so a fresh install takes none of the user's existing
+ * shortcuts and nothing fires until they assign keys themselves.
+ */
+
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
+import {
+  closeTestTabs,
+  getExtensionId,
+  launchExtensionContext,
+  openPopup,
+  openSidebar
+} from "./helpers/extension-helpers"
+
+let context: BrowserContext
+let extensionId: string
+let popupPage: Page
+
+const OWN_COMMANDS = [
+  "toggle-auto-grouping",
+  "group-all-tabs",
+  "ungroup-all-tabs",
+  "toggle-collapse"
+]
+
+test.beforeAll(async () => {
+  context = await launchExtensionContext()
+  extensionId = await getExtensionId(context)
+})
+
+test.afterAll(async () => {
+  await context.close()
+})
+
+test.beforeEach(async () => {
+  await closeTestTabs(context)
+  popupPage = await openPopup(context, extensionId)
+})
+
+test.afterEach(async () => {
+  if (popupPage && !popupPage.isClosed()) await popupPage.close()
+  await closeTestTabs(context)
+})
+
+test.describe("Keyboard shortcuts", () => {
+  test("registers every command with the browser", async () => {
+    const commands = await popupPage.evaluate(async () => await chrome.commands.getAll())
+    const names = commands.map(command => command.name)
+
+    for (const command of OWN_COMMANDS) {
+      expect(names).toContain(command)
+    }
+  })
+
+  test("ships no key bindings, so nothing is taken on install", async () => {
+    const commands = await popupPage.evaluate(async () => await chrome.commands.getAll())
+
+    // This is the opt-in guarantee. If a suggested_key ever gets added, a fresh
+    // install would silently claim that combination from the user.
+    const bound = commands.filter(command => command.shortcut && command.shortcut.length > 0)
+    expect(bound.map(command => `${command.name}: ${command.shortcut}`)).toEqual([])
+  })
+
+  test("describes each command for the browser's shortcut list", async () => {
+    const commands = await popupPage.evaluate(async () => await chrome.commands.getAll())
+
+    for (const name of OWN_COMMANDS) {
+      const command = commands.find(entry => entry.name === name)
+      expect(command?.description).toBeTruthy()
+      // A raw __MSG_ placeholder here means the manifest string was never localized
+      expect(command?.description).not.toContain("__MSG_")
+    }
+  })
+
+  test("offers a way into the browser's shortcut settings from the popup", async () => {
+    await expect(popupPage.locator("#openShortcutsButton")).toBeAttached()
+  })
+
+  test("offers the same from the sidebar", async () => {
+    const sidebar = await openSidebar(context, extensionId)
+
+    await expect(sidebar.locator("#openShortcutsButton")).toBeAttached()
+
+    await sidebar.close()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,7 +27,8 @@ export default defineConfig({
         "utils/WebGpuUtils.ts",
         "utils/withTabEditRetry.ts",
         "services/TabSortService.ts",
-        "services/FirstRunService.ts"
+        "services/FirstRunService.ts",
+        "services/CommandService.ts"
       ],
       exclude: [
         "**/node_modules/**",

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -39,6 +39,27 @@ export default defineConfig({
       default_locale: "en",
       author: "Nitzan Papini",
       permissions: ["tabs", "storage", "tabGroups", "contextMenus"],
+      // No suggested_key anywhere on purpose: the browser then binds nothing on
+      // install and these sit unassigned in its shortcuts page until the user
+      // picks keys. Opting in is the user's move, and no existing shortcut of
+      // theirs gets taken.
+      commands: {
+        _execute_action: {
+          description: "__MSG_commandOpenPopup__"
+        },
+        "toggle-auto-grouping": {
+          description: "__MSG_commandToggleAutoGrouping__"
+        },
+        "group-all-tabs": {
+          description: "__MSG_commandGroupAllTabs__"
+        },
+        "ungroup-all-tabs": {
+          description: "__MSG_commandUngroupAllTabs__"
+        },
+        "toggle-collapse": {
+          description: "__MSG_commandToggleCollapse__"
+        }
+      },
       icons: {
         16: "icon/16.png",
         48: "icon/48.png",


### PR DESCRIPTION
Closes #25

## Opt-in by construction

Four commands are declared — and **none of them ship a `suggested_key`**. That's the whole design, not an omission.

With no suggested keys, the browser binds nothing on install. The commands appear *unassigned* in the browser's own shortcuts page and stay completely inert until the user picks keys themselves. So:

- Installing or updating never claims a shortcut someone already relies on.
- Nothing fires until a deliberate action by the user, in the browser's own UI.
- There's no way for this to activate "automatically".

Assigning keys is only possible on that page anyway — an extension cannot bind them on a user's behalf — so **Advanced → Keyboard shortcuts → "Set up"** opens it (`chrome://extensions/shortcuts` in Chrome, the Add-ons Manager in Firefox), with help text saying no keys are assigned by default.

I considered adding an in-extension on/off toggle on top of this. I left it out on purpose: it would create a trap where a user assigns a key, presses it, and nothing happens with no visible reason. The browser's own assignment step already *is* the opt-in. Say the word if you want the extra toggle anyway and I'll add it.

## Commands

| Command | Equivalent to |
| --- | --- |
| Turn auto-grouping on or off | the Auto-Group Mode toggle |
| Group all tabs now | the Group Tabs button |
| Ungroup all tabs | the Ungroup All button |
| Collapse or expand all groups | Collapse All / Expand All |
| Open Auto Tab Groups | (`_execute_action`, handled by the browser) |

Handling lives in `services/CommandService.ts` rather than inline in the background, so it can be unit tested, and it routes through the same service calls as the popup buttons — a shortcut and a click can't drift apart.

## Worth knowing

The issue asked about Firefox specifically, but there were **no shortcuts in either browser**: `wxt.config.ts` had no `commands` key at all. This adds them for both.

## Test plan

- [x] `bunx vitest run` — 850 pass, including 6 new tests covering each command, the auto-grouping toggle persisting and regrouping, and unknown commands being ignored
- [x] `bunx playwright test --fail-on-flaky-tests` — 68 pass (was 63), no retries
- [x] **The opt-in guarantee is a test**: an E2E case reads `chrome.commands.getAll()` and asserts no command has a shortcut bound. If a `suggested_key` is ever added, that test fails rather than silently claiming a key combination.
- [x] Also asserted the descriptions resolve — a raw `__MSG_` in the browser's shortcut list would mean an unlocalized manifest string
- [x] Verified both built manifests carry the commands with no `suggested_key`
- [x] Popup rendering checked by screenshot (the first attempt reused a modal-only button class and rendered an invisible label; the row has its own style now)
- [x] Chrome + Firefox packages build at 3.10.0

Version bumped to 3.10.0, changelog and `docs/FEATURES.md` updated.