### PR TITLE
feat: match rules against query strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ for those.
 
 ## [Unreleased]
 
+## [3.11.0]
+
+### Added
+
+- Rules can match query strings. A pattern containing `?` is matched against
+  the query as well as the host and path, so tabs on one domain can be split by
+  a parameter — `domain.cz/?ticket={ticket}` puts each ticket in its own group,
+  and a regex capture does the same. Patterns written before this behave
+  exactly as they did ([#87], closes [#27]).
+
 ## [3.10.0]
 
 ### Added
@@ -100,7 +110,8 @@ for those.
 - Tab groups for internationalized domains showed punycode — `Xn--mnchen-3ya`
   instead of `München` ([#75], closes [#74]).
 
-[unreleased]: https://github.com/nitzanpap/auto-tab-groups/compare/v3.10.0...HEAD
+[unreleased]: https://github.com/nitzanpap/auto-tab-groups/compare/v3.11.0...HEAD
+[3.11.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.11.0
 [3.10.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.10.0
 [3.9.1]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.9.1
 [3.9.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.9.0
@@ -112,6 +123,7 @@ for those.
 [3.5.2]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.5.2
 [#23]: https://github.com/nitzanpap/auto-tab-groups/issues/23
 [#25]: https://github.com/nitzanpap/auto-tab-groups/issues/25
+[#27]: https://github.com/nitzanpap/auto-tab-groups/issues/27
 [#29]: https://github.com/nitzanpap/auto-tab-groups/issues/29
 [#31]: https://github.com/nitzanpap/auto-tab-groups/issues/31
 [#74]: https://github.com/nitzanpap/auto-tab-groups/issues/74
@@ -125,3 +137,4 @@ for those.
 [#82]: https://github.com/nitzanpap/auto-tab-groups/pull/82
 [#84]: https://github.com/nitzanpap/auto-tab-groups/pull/84
 [#86]: https://github.com/nitzanpap/auto-tab-groups/pull/86
+[#87]: https://github.com/nitzanpap/auto-tab-groups/pull/87

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -79,6 +79,8 @@ Custom rules support advanced URL pattern matching beyond simple domains.
 | TLD Wildcard | `google.**/forms` | `google.com/forms`, `google.org/forms` |
 | Path Wildcard | `site.com/**/admin` | `site.com/any/path/admin` |
 | Catch-All | `*` | everything no other rule took |
+| Query String | `site.com/?ticket=VZ01` | that exact query |
+| Query Extraction | `site.com/?ticket={ticket}` | a group per ticket value |
 
 ### Catch-All Rules
 
@@ -116,6 +118,23 @@ Two caveats:
   auto-subdomain, even if the latter has a higher priority.
 - Priority has no UI yet. Set it the same way as `minimumTabs`: export your
   rules, edit the JSON, re-import.
+
+### Query Strings
+
+A pattern that contains `?` is matched against the query string as well as the
+host and path, so tabs on one domain can be split by a parameter:
+
+```txt
+domain.cz/?ticket={ticket}          -> a group per ticket value
+domain.cz/?ticket=VZ01              -> only that ticket
+/.*domain\.cz.*ticket=([a-z0-9-]+)/ -> same, via regex; the capture names the group
+```
+
+With `{variable}` or a regex capture, the captured value becomes the group
+title — so `?ticket=VZ01` and `?ticket=VZ02` land in separate groups.
+
+The query is only consulted after host and path have failed to match, so
+patterns written before this existed behave exactly as they did.
 
 ### Limitations
 

--- a/entrypoints/rules-modal.unlisted/index.html
+++ b/entrypoints/rules-modal.unlisted/index.html
@@ -54,7 +54,7 @@ example.com/admin/*
 192.168.1.*"
             required
           ></textarea>
-          <div class="help-text pattern-help" data-i18n="ruleModalPatternsHelp">Supports: domains, wildcards (*.example.com), paths (example.com/api/*), IP addresses, and * on its own for everything else</div>
+          <div class="help-text pattern-help" data-i18n="ruleModalPatternsHelp">Supports: domains, wildcards (*.example.com), paths (example.com/api/*), query strings (site.com/?id={id}), IP addresses, and * on its own for everything else</div>
           <div id="patternFeedback" class="pattern-feedback"></div>
         </div>
         <div class="form-group" id="colorGroup">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/public/_locales/ar/messages.json
+++ b/public/_locales/ar/messages.json
@@ -595,7 +595,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "يدعم: النطاقات، الرموز البدل (*.example.com)، المسارات (example.com/api/*)، عناوين IP، و * بمفردها لكل ما تبقى",
+    "message": "يدعم: النطاقات، الرموز البدل (*.example.com)، المسارات (example.com/api/*)، سلاسل الاستعلام (site.com/?id={id})، عناوين IP، و * بمفردها لكل ما تبقى",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -595,7 +595,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "Unterstützt: Domains, Platzhalter (*.example.com), Pfade (example.com/api/*), IP-Adressen und * allein für alles Übrige",
+    "message": "Unterstützt: Domains, Platzhalter (*.example.com), Pfade (example.com/api/*), Query-Strings (site.com/?id={id}), IP-Adressen und * allein für alles Übrige",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -595,7 +595,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "Supports: domains, wildcards (*.example.com), paths (example.com/api/*), IP addresses, and * on its own for everything else",
+    "message": "Supports: domains, wildcards (*.example.com), paths (example.com/api/*), query strings (site.com/?id={id}), IP addresses, and * on its own for everything else",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -595,7 +595,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "Admite: dominios, comodines (*.example.com), rutas (example.com/api/*), direcciones IP y * por sí solo para todo lo demás",
+    "message": "Admite: dominios, comodines (*.example.com), rutas (example.com/api/*), cadenas de consulta (site.com/?id={id}), direcciones IP y * por sí solo para todo lo demás",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/he/messages.json
+++ b/public/_locales/he/messages.json
@@ -595,7 +595,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "תומך ב: דומיינים, תווים כלליים (*.example.com), נתיבים (example.com/api/*), כתובות IP, ו-* לבד עבור כל השאר",
+    "message": "תומך ב: דומיינים, תווים כלליים (*.example.com), נתיבים (example.com/api/*), מחרוזות שאילתה (site.com/?id={id}), כתובות IP, ו-* לבד עבור כל השאר",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -595,7 +595,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "समर्थित है: डोमेन, वाइल्डकार्ड (*.example.com), पथ (example.com/api/*), IP पते, और बाकी सब के लिए अकेला *",
+    "message": "समर्थित है: डोमेन, वाइल्डकार्ड (*.example.com), पथ (example.com/api/*), क्वेरी स्ट्रिंग (site.com/?id={id}), IP पते, और बाकी सब के लिए अकेला *",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -595,7 +595,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "Поддерживаются: домены, подстановки (*.example.com), пути (example.com/api/*), IP-адреса и одиночная * для всего остального",
+    "message": "Поддерживаются: домены, подстановки (*.example.com), пути (example.com/api/*), строки запроса (site.com/?id={id}), IP-адреса и одиночная * для всего остального",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -595,7 +595,7 @@
     "description": "Label for the patterns textarea."
   },
   "ruleModalPatternsHelp": {
-    "message": "支持:域名、通配符 (*.example.com)、路径 (example.com/api/*)、IP 地址,以及单独的 * 表示其余全部",
+    "message": "支持:域名、通配符 (*.example.com)、路径 (example.com/api/*)、查询字符串 (site.com/?id={id})、IP 地址,以及单独的 * 表示其余全部",
     "description": "Help text for the patterns textarea."
   },
   "ruleModalColorLabel": {

--- a/tests/UrlPatternMatcher.test.ts
+++ b/tests/UrlPatternMatcher.test.ts
@@ -905,4 +905,94 @@ describe("UrlPatternMatcher", () => {
       expect(urlPatternMatcher.splitDomainPort("example.co").portPattern).toBeNull()
     })
   })
+  describe("query string matching", () => {
+    const TICKET_REGEX = "/.*domain\\.cz.*ticket=([a-z0-9-]+)/"
+
+    it("should match a regex against the query string", () => {
+      const result = urlPatternMatcher.match("https://domain.cz/?ticket=VZ01", TICKET_REGEX)
+      expect(result.matched).toBe(true)
+    })
+
+    it("should name the group from the captured value", () => {
+      // The point of the feature: one group per ticket, not one per domain
+      expect(
+        urlPatternMatcher.match("https://domain.cz/?ticket=VZ01", TICKET_REGEX).groupName
+      ).toBe("VZ01")
+      expect(
+        urlPatternMatcher.match("https://domain.cz/?a=1&ticket=VZ02&b=2", TICKET_REGEX).groupName
+      ).toBe("VZ02")
+    })
+
+    it("should not match when the query is absent", () => {
+      expect(urlPatternMatcher.match("https://domain.cz/", TICKET_REGEX).matched).toBe(false)
+    })
+
+    it("should extract a query value with a segment pattern", () => {
+      const result = urlPatternMatcher.match(
+        "https://domain.cz/?ticket=VZ03",
+        "domain.cz/?ticket={ticket}"
+      )
+
+      expect(result.matched).toBe(true)
+      expect(result.extractedValues.ticket).toBe("VZ03")
+      expect(result.groupName).toBe("VZ03")
+    })
+
+    it("should match a literal query with a simple pattern", () => {
+      expect(
+        urlPatternMatcher.match("https://domain.cz/?ticket=VZ01", "domain.cz/?ticket=VZ01").matched
+      ).toBe(true)
+      expect(
+        urlPatternMatcher.match("https://domain.cz/?ticket=VZ02", "domain.cz/?ticket=VZ01").matched
+      ).toBe(false)
+    })
+
+    it("should support a wildcard inside the query", () => {
+      expect(
+        urlPatternMatcher.match("https://domain.cz/?ticket=VZ09", "domain.cz/?ticket=*").matched
+      ).toBe(true)
+    })
+
+    it("should match a query on a path as well as a root", () => {
+      expect(
+        urlPatternMatcher.match("https://shop.com/list?page=2", "shop.com/list?page=2").matched
+      ).toBe(true)
+    })
+
+    it("should accept query characters when validating", () => {
+      expect(urlPatternMatcher.validatePattern("domain.cz/?ticket=VZ01").isValid).toBe(true)
+      expect(urlPatternMatcher.validatePattern("domain.cz/?ticket={ticket}").isValid).toBe(true)
+      expect(urlPatternMatcher.validatePattern("shop.com/list?a=1&b=2").isValid).toBe(true)
+    })
+
+    describe("existing patterns are unaffected", () => {
+      it("should still match a domain pattern on a URL carrying a query", () => {
+        expect(urlPatternMatcher.match("https://example.com/?q=1", "example.com").matched).toBe(
+          true
+        )
+      })
+
+      it("should still match path patterns unchanged", () => {
+        expect(
+          urlPatternMatcher.match("https://example.com/admin/x", "example.com/admin/*").matched
+        ).toBe(true)
+        expect(urlPatternMatcher.match("https://example.com/a/b", "example.com/a/**").matched).toBe(
+          true
+        )
+      })
+
+      it("should not let a query satisfy a path pattern", () => {
+        // ?admin=1 must not be mistaken for the /admin path
+        expect(
+          urlPatternMatcher.match("https://example.com/?admin=1", "example.com/admin").matched
+        ).toBe(false)
+      })
+
+      it("should keep a path-anchored regex from matching only the query", () => {
+        expect(
+          urlPatternMatcher.match("https://example.com/?x=/admin", "/example\\.com/admin/").matched
+        ).toBe(false)
+      })
+    })
+  })
 })

--- a/tests/e2e/query-string-rules.e2e.ts
+++ b/tests/e2e/query-string-rules.e2e.ts
@@ -1,0 +1,137 @@
+/**
+ * E2E Tests: Grouping by Query String
+ *
+ * The scenario from issue #27: several tabs on one domain that should be split
+ * into a group per ticket id, taken from a query parameter.
+ */
+
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
+import {
+  addCustomRule,
+  closeTestTabs,
+  createTab,
+  deleteCustomRule,
+  disableAutoGroup,
+  enableAutoGroup,
+  getCustomRules,
+  getExtensionId,
+  getTabGroups,
+  launchExtensionContext,
+  openPopup,
+  setGroupByMode,
+  setMinimumTabs,
+  ungroupAllTabs,
+  waitForGroup
+} from "./helpers/extension-helpers"
+
+let context: BrowserContext
+let extensionId: string
+let popupPage: Page
+
+const TICKET_URL = (id: string) => `https://domain.cz/?ticket=${id}`
+
+async function deleteAllRules(page: Page): Promise<void> {
+  for (const ruleId of Object.keys(await getCustomRules(page))) {
+    await deleteCustomRule(page, ruleId)
+  }
+}
+
+test.beforeAll(async () => {
+  context = await launchExtensionContext()
+  extensionId = await getExtensionId(context)
+})
+
+test.afterAll(async () => {
+  await context.close()
+})
+
+test.beforeEach(async () => {
+  await closeTestTabs(context)
+  popupPage = await openPopup(context, extensionId)
+  await disableAutoGroup(popupPage)
+  await ungroupAllTabs(popupPage)
+  await deleteAllRules(popupPage)
+  await setMinimumTabs(popupPage, 1)
+  await setGroupByMode(popupPage, "domain")
+})
+
+test.afterEach(async () => {
+  if (popupPage && !popupPage.isClosed()) {
+    await disableAutoGroup(popupPage)
+    await ungroupAllTabs(popupPage)
+    await deleteAllRules(popupPage)
+    await popupPage.close()
+  }
+  await closeTestTabs(context)
+})
+
+test.describe("Grouping by query string", () => {
+  test("splits one domain into a group per ticket via regex", async () => {
+    await addCustomRule(popupPage, {
+      name: "Tickets",
+      domains: ["/.*domain\\.cz.*ticket=([a-z0-9-]+)/"],
+      color: "blue"
+    })
+    await enableAutoGroup(popupPage)
+
+    await createTab(context, TICKET_URL("VZ01"))
+    await createTab(context, TICKET_URL("VZ02"))
+
+    await waitForGroup(popupPage, "VZ01")
+    await waitForGroup(popupPage, "VZ02")
+
+    const titles = (await getTabGroups(popupPage)).map(group => group.title)
+    expect(titles).toContain("VZ01")
+    expect(titles).toContain("VZ02")
+  })
+
+  test("keeps tabs sharing a ticket together", async () => {
+    await addCustomRule(popupPage, {
+      name: "Tickets",
+      domains: ["/.*domain\\.cz.*ticket=([a-z0-9-]+)/"],
+      color: "blue"
+    })
+    await enableAutoGroup(popupPage)
+
+    await createTab(context, TICKET_URL("VZ01"))
+    await createTab(context, `https://domain.cz/detail?ticket=VZ01&view=full`)
+
+    const group = await waitForGroup(popupPage, "VZ01")
+    const tabs = await popupPage.evaluate(
+      async groupId => (await chrome.tabs.query({ groupId })).length,
+      group.id
+    )
+
+    expect(tabs).toBe(2)
+  })
+
+  test("extracts a query value with a segment pattern", async () => {
+    await addCustomRule(popupPage, {
+      name: "Tickets",
+      domains: ["domain.cz/?ticket={ticket}"],
+      color: "green"
+    })
+    await enableAutoGroup(popupPage)
+
+    await createTab(context, TICKET_URL("VZ03"))
+
+    await waitForGroup(popupPage, "VZ03")
+  })
+
+  test("matches one specific query value with a plain pattern", async () => {
+    await addCustomRule(popupPage, {
+      name: "Just VZ01",
+      domains: ["domain.cz/?ticket=VZ01"],
+      color: "red"
+    })
+    await enableAutoGroup(popupPage)
+
+    await createTab(context, TICKET_URL("VZ01"))
+    await createTab(context, TICKET_URL("VZ02"))
+
+    await waitForGroup(popupPage, "Just VZ01")
+
+    // VZ02 doesn't match the rule, so it falls through to domain grouping
+    await waitForGroup(popupPage, "Domain")
+  })
+})

--- a/utils/UrlPatternMatcher.ts
+++ b/utils/UrlPatternMatcher.ts
@@ -114,6 +114,23 @@ class UrlPatternMatcher {
   }
 
   /**
+   * Candidate strings to match a pattern against, query string last.
+   *
+   * The query is tried only after the plain hostname/path has failed, which
+   * keeps this purely additive: a pattern that matched before still matches the
+   * same text with the same capture groups, and only patterns that need the
+   * query see it. Case is preserved so extracted values (a ticket id, say) keep
+   * theirs when they become a group name.
+   */
+  private matchTargets(urlObj: URL, base: string, lowercaseQuery = false): string[] {
+    // The wildcard matcher lowercases its pattern and path, so its query has to
+    // be lowercased too. The extraction matchers keep case, because their
+    // captures become group titles.
+    const search = lowercaseQuery ? urlObj.search.toLowerCase() : urlObj.search
+    return search ? [base, base + search] : [base]
+  }
+
+  /**
    * Matches using simple wildcard patterns
    */
   matchSimpleWildcard(url: string, pattern: string, options: MatchOptions = {}): MatchResult {
@@ -145,8 +162,11 @@ class UrlPatternMatcher {
       }
 
       // Match path part if specified
-      if (hasPath && !this.matchPathWildcard(pathname, pathPattern)) {
-        return { matched: false, extractedValues: {}, groupName: null }
+      if (hasPath) {
+        const targets = this.matchTargets(urlObj, pathname, true)
+        if (!targets.some(target => this.matchPathWildcard(target, pathPattern))) {
+          return { matched: false, extractedValues: {}, groupName: null }
+        }
       }
 
       return {
@@ -283,13 +303,14 @@ class UrlPatternMatcher {
         return { matched: false, extractedValues: {}, groupName: null }
       }
 
-      let targetString = hostname
-      if (pattern.includes("/")) {
-        targetString = hostname + pathname
-      }
-
+      const base = pattern.includes("/") ? hostname + pathname : hostname
       const regex = this.buildSegmentRegex(patternInfo)
-      const match = targetString.match(regex)
+
+      let match: RegExpMatchArray | null = null
+      for (const target of this.matchTargets(urlObj, base)) {
+        match = target.match(regex)
+        if (match) break
+      }
 
       if (!match) {
         return { matched: false, extractedValues: {}, groupName: null }
@@ -430,9 +451,13 @@ class UrlPatternMatcher {
       const regex = new RegExp(regexStr, "i")
 
       const urlObj = new URL(url)
-      const fullUrl = urlObj.hostname + urlObj.pathname
 
-      const match = fullUrl.match(regex)
+      let match: RegExpMatchArray | null = null
+      for (const target of this.matchTargets(urlObj, urlObj.hostname + urlObj.pathname)) {
+        match = target.match(regex)
+        if (match) break
+      }
+
       if (!match) {
         return { matched: false, extractedValues: {}, groupName: null }
       }
@@ -610,7 +635,8 @@ class UrlPatternMatcher {
       }
     }
 
-    if (hasPath && pathPattern && !/^[a-zA-Z0-9._/*-]*$/.test(pathPattern)) {
+    // ?, = and & are allowed so a pattern can address a query string
+    if (hasPath && pathPattern && !/^[a-zA-Z0-9._/*?=&%+~:,-]*$/.test(pathPattern)) {
       return {
         isValid: false,
         error: "Path pattern contains invalid characters",


### PR DESCRIPTION
Closes #27

## Why the reporter's attempt couldn't have worked

@FrKochan tried `(.*domain\.cz.*ticket=([a-z0-9\-]+))` and concluded rules "only work with domains". They were right about the symptom: the matcher built its target from `hostname + pathname` and dropped the query string entirely, so no pattern could ever see `?ticket=…`.

Their regex now works exactly as written.

## What this adds

A pattern containing `?` is matched against the query as well as the host and path. With a `{variable}` or a regex capture, the captured value becomes the group title — so one domain splits into a group per ticket, which is what the issue asked for:

```txt
domain.cz/?ticket={ticket}           -> a group per ticket value
/.*domain\.cz.*ticket=([a-z0-9-]+)/  -> same, via regex
domain.cz/?ticket=VZ01               -> only that ticket
domain.cz/?ticket=*                  -> any ticket, one shared group
```

## Backwards compatible by construction

This was the part worth getting right, since it touches the matcher every tab goes through.

The query is tried **only after** the host/path target has failed. So a pattern that matched before still matches the same text with the same capture groups, and only patterns that actually need the query ever see it. There's no flag, no mode, and nothing to migrate.

Four tests pin that down, including two cases I specifically wanted to fail: `?admin=1` must not satisfy a `/admin` path pattern, and a path-anchored regex must not be satisfied by a query alone.

## Two things found while implementing

- **Validation rejected the syntax.** `?`, `=` and `&` were "invalid path characters", so a user typing `domain.cz/?ticket=VZ01` got an error before matching was ever reached. Widened to accept query characters.
- **The wildcard matcher lowercases its pattern and path**, so appending the raw query broke case-sensitively — `?ticket=VZ01` never matched. Its query is lowercased to match; the extraction matchers keep case, because their captures become group titles and `VZ01` should stay uppercase.

## Test plan

- [x] `bunx vitest run` — 862 pass, including 13 new matcher tests covering all four pattern styles, group naming from captures, validation, and the backwards-compatibility cases
- [x] `bunx playwright test --fail-on-flaky-tests` — 72 pass (was 68), no retries, including an E2E of the reporter's exact scenario: two tabs on one domain landing in `VZ01` and `VZ02`, and two tabs sharing a ticket staying together
- [x] `bun run code:check` clean
- [x] Chrome + Firefox packages build at 3.11.0

Version 3.11.0, changelog and `docs/FEATURES.md` updated, pattern help text updated across all 8 locales.