### PR TITLE
feat: optionally wait until a tab is viewed before grouping it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ for those.
 
 ## [Unreleased]
 
+## [3.12.0]
+
+### Added
+
+- Optional "wait until I view a new tab before grouping it". Off by default.
+  When on, a tab opened in the background from another tab stays next to the
+  tab it came from until you switch to it, instead of being filed away before
+  you have seen it. Foreground tabs, tabs with no opener, and the "Group Tabs"
+  button are unaffected ([#89], addresses [#68] / [#88]).
+
 ## [3.11.0]
 
 ### Added
@@ -110,7 +120,8 @@ for those.
 - Tab groups for internationalized domains showed punycode — `Xn--mnchen-3ya`
   instead of `München` ([#75], closes [#74]).
 
-[unreleased]: https://github.com/nitzanpap/auto-tab-groups/compare/v3.11.0...HEAD
+[unreleased]: https://github.com/nitzanpap/auto-tab-groups/compare/v3.12.0...HEAD
+[3.12.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.12.0
 [3.11.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.11.0
 [3.10.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.10.0
 [3.9.1]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.9.1
@@ -124,6 +135,8 @@ for those.
 [#23]: https://github.com/nitzanpap/auto-tab-groups/issues/23
 [#25]: https://github.com/nitzanpap/auto-tab-groups/issues/25
 [#27]: https://github.com/nitzanpap/auto-tab-groups/issues/27
+[#68]: https://github.com/nitzanpap/auto-tab-groups/issues/68
+[#88]: https://github.com/nitzanpap/auto-tab-groups/issues/88
 [#29]: https://github.com/nitzanpap/auto-tab-groups/issues/29
 [#31]: https://github.com/nitzanpap/auto-tab-groups/issues/31
 [#74]: https://github.com/nitzanpap/auto-tab-groups/issues/74
@@ -138,3 +151,4 @@ for those.
 [#84]: https://github.com/nitzanpap/auto-tab-groups/pull/84
 [#86]: https://github.com/nitzanpap/auto-tab-groups/pull/86
 [#87]: https://github.com/nitzanpap/auto-tab-groups/pull/87
+[#89]: https://github.com/nitzanpap/auto-tab-groups/pull/89

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -46,6 +46,24 @@ Titles are matched with any sort-index prefix stripped, so the "Number groups"
 setting doesn't break exclusions. Renaming an excluded group ends its
 exclusion — title is identity here, as everywhere else in the extension.
 
+## Waiting Until a Tab Is Viewed
+
+Off by default. When on, a tab opened **in the background from another tab**
+stays next to the tab it came from until you switch to it — then it is grouped
+as usual.
+
+This exists because filing a tab the instant it appears is what makes it seem
+to vanish: you middle-click a search result, look away, and it has already been
+moved to a group elsewhere in a long tab strip.
+
+- Tabs opened in the foreground are unaffected — they are active immediately,
+  so they group exactly as before.
+- Tabs with no opener (address bar, bookmarks, restored sessions) are unaffected.
+- "Group Tabs" files everything, including tabs still waiting to be viewed.
+
+The grouping decision itself is unchanged — still purely a function of the URL.
+Only its timing moves.
+
 ## Keyboard Shortcuts
 
 The extension registers four commands, plus the browser's built-in "open the

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -316,6 +316,16 @@ export default defineBackground(() => {
             result = { locale: tabGroupState.userLocale }
             break
 
+          case "getDeferGroupingUntilSeen":
+            result = { enabled: tabGroupState.deferGroupingUntilSeen }
+            break
+
+          case "toggleDeferGroupingUntilSeen":
+            tabGroupState.deferGroupingUntilSeen = msg.enabled
+            await saveState()
+            result = { enabled: tabGroupState.deferGroupingUntilSeen }
+            break
+
           case "getProtectedGroups":
             result = { titles: tabGroupState.protectedGroupTitles }
             break
@@ -931,6 +941,11 @@ export default defineBackground(() => {
   browser.tabs.onActivated.addListener(async activeInfo => {
     try {
       await ensureStateLoaded()
+
+      // A tab that was left alone until first view gets grouped now
+      if (tabGroupState.deferGroupingUntilSeen && tabGroupState.autoGroupingEnabled) {
+        await tabGroupService.handleTabUpdate(activeInfo.tabId)
+      }
 
       if (!tabGroupState.autoCollapseEnabled) return
 

--- a/entrypoints/popup/index.html
+++ b/entrypoints/popup/index.html
@@ -134,6 +134,14 @@
             <span class="slider round"></span>
           </label>
         </div>
+        <div class="toggle-container">
+          <span data-i18n="settingDeferGrouping">Wait until I view a new tab before grouping it</span>
+          <label class="switch">
+            <input type="checkbox" id="deferGroupingToggle" />
+            <span class="slider round"></span>
+          </label>
+        </div>
+        <div class="help-text" data-i18n="settingDeferGroupingHelp">Tabs opened in the background stay next to the tab they came from until you switch to them</div>
         <div class="settings-info">
           <span class="info-icon">&#128204;</span>
           <span data-i18n="settingPinnedTabsNote">Pinned tabs are never grouped automatically</span>

--- a/entrypoints/popup/main.ts
+++ b/entrypoints/popup/main.ts
@@ -20,6 +20,7 @@ const expandAllButton = document.getElementById("expandAllButton") as HTMLButton
 const autoGroupToggle = document.getElementById("autoGroupToggle") as HTMLInputElement
 const groupNewTabsToggle = document.getElementById("groupNewTabsToggle") as HTMLInputElement
 const systemGroupToggle = document.getElementById("systemGroupToggle") as HTMLInputElement
+const deferGroupingToggle = document.getElementById("deferGroupingToggle") as HTMLInputElement
 const protectedGroupsContainer = document.getElementById(
   "protectedGroupsContainer"
 ) as HTMLDivElement
@@ -731,6 +732,19 @@ openShortcutsButton.addEventListener("click", async () => {
     console.error("[Popup] Could not open the shortcuts page:", error)
     openShortcutsButton.textContent = url
   }
+})
+
+sendMessage<{ enabled?: boolean }>({ action: "getDeferGroupingUntilSeen" }).then(response => {
+  if (response?.enabled !== undefined) {
+    deferGroupingToggle.checked = response.enabled
+  }
+})
+
+deferGroupingToggle.addEventListener("change", event => {
+  sendMessage({
+    action: "toggleDeferGroupingUntilSeen",
+    enabled: (event.target as HTMLInputElement).checked
+  })
 })
 
 // Initialize toggle states

--- a/entrypoints/sidebar/index.html
+++ b/entrypoints/sidebar/index.html
@@ -135,6 +135,14 @@
               <span class="slider round"></span>
             </label>
           </div>
+          <div class="toggle-container">
+            <span data-i18n="settingDeferGrouping">Wait until I view a new tab before grouping it</span>
+            <label class="switch">
+              <input type="checkbox" id="deferGroupingToggle" />
+              <span class="slider round"></span>
+            </label>
+          </div>
+          <div class="help-text" data-i18n="settingDeferGroupingHelp">Tabs opened in the background stay next to the tab they came from until you switch to them</div>
           <div class="settings-info">
             <span class="info-icon">&#128204;</span>
             <span data-i18n="settingPinnedTabsNote">Pinned tabs are never grouped automatically</span>

--- a/entrypoints/sidebar/main.ts
+++ b/entrypoints/sidebar/main.ts
@@ -21,6 +21,7 @@ const expandAllButton = document.getElementById("expandAllButton") as HTMLButton
 const autoGroupToggle = document.getElementById("autoGroupToggle") as HTMLInputElement
 const groupNewTabsToggle = document.getElementById("groupNewTabsToggle") as HTMLInputElement
 const systemGroupToggle = document.getElementById("systemGroupToggle") as HTMLInputElement
+const deferGroupingToggle = document.getElementById("deferGroupingToggle") as HTMLInputElement
 const protectedGroupsContainer = document.getElementById(
   "protectedGroupsContainer"
 ) as HTMLDivElement
@@ -781,6 +782,19 @@ openShortcutsButton.addEventListener("click", async () => {
     console.error("[Popup] Could not open the shortcuts page:", error)
     openShortcutsButton.textContent = url
   }
+})
+
+sendMessage<{ enabled?: boolean }>({ action: "getDeferGroupingUntilSeen" }).then(response => {
+  if (response?.enabled !== undefined) {
+    deferGroupingToggle.checked = response.enabled
+  }
+})
+
+deferGroupingToggle.addEventListener("change", event => {
+  sendMessage({
+    action: "toggleDeferGroupingUntilSeen",
+    enabled: (event.target as HTMLInputElement).checked
+  })
 })
 
 // Initialize toggle states

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/public/_locales/ar/messages.json
+++ b/public/_locales/ar/messages.json
@@ -133,6 +133,14 @@
     "message": "إعداد",
     "description": "Button that opens the browser's keyboard shortcut settings page."
   },
+  "settingDeferGrouping": {
+    "message": "الانتظار حتى أعرض علامة التبويب الجديدة قبل تجميعها",
+    "description": "Label for the toggle that waits until a new tab is viewed before grouping it."
+  },
+  "settingDeferGroupingHelp": {
+    "message": "علامات التبويب التي تُفتح في الخلفية تبقى بجوار علامة التبويب التي فُتحت منها حتى تنتقل إليها",
+    "description": "Help text for the wait-until-viewed toggle."
+  },
   "settingMinimumTabsForGroup": {
     "message": "الحد الأدنى لعلامات التبويب لتكوين مجموعة",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -133,6 +133,14 @@
     "message": "Einrichten",
     "description": "Button that opens the browser's keyboard shortcut settings page."
   },
+  "settingDeferGrouping": {
+    "message": "Neue Tabs erst gruppieren, wenn ich sie ansehe",
+    "description": "Label for the toggle that waits until a new tab is viewed before grouping it."
+  },
+  "settingDeferGroupingHelp": {
+    "message": "Im Hintergrund geöffnete Tabs bleiben neben dem Ursprungstab, bis du zu ihnen wechselst",
+    "description": "Help text for the wait-until-viewed toggle."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Mindestanzahl an Tabs für eine Gruppe",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -133,6 +133,14 @@
     "message": "Set up",
     "description": "Button that opens the browser's keyboard shortcut settings page."
   },
+  "settingDeferGrouping": {
+    "message": "Wait until I view a new tab before grouping it",
+    "description": "Label for the toggle that waits until a new tab is viewed before grouping it."
+  },
+  "settingDeferGroupingHelp": {
+    "message": "Tabs opened in the background stay next to the tab they came from until you switch to them",
+    "description": "Help text for the wait-until-viewed toggle."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Minimum tabs to form a group",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -133,6 +133,14 @@
     "message": "Configurar",
     "description": "Button that opens the browser's keyboard shortcut settings page."
   },
+  "settingDeferGrouping": {
+    "message": "Esperar a que vea una pestaña nueva antes de agruparla",
+    "description": "Label for the toggle that waits until a new tab is viewed before grouping it."
+  },
+  "settingDeferGroupingHelp": {
+    "message": "Las pestañas abiertas en segundo plano permanecen junto a la pestaña de origen hasta que cambies a ellas",
+    "description": "Help text for the wait-until-viewed toggle."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Mínimo de pestañas para formar un grupo",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/he/messages.json
+++ b/public/_locales/he/messages.json
@@ -133,6 +133,14 @@
     "message": "הגדרה",
     "description": "Button that opens the browser's keyboard shortcut settings page."
   },
+  "settingDeferGrouping": {
+    "message": "המתן שאצפה בלשונית חדשה לפני שתקובץ",
+    "description": "Label for the toggle that waits until a new tab is viewed before grouping it."
+  },
+  "settingDeferGroupingHelp": {
+    "message": "לשוניות שנפתחות ברקע נשארות ליד הלשונית שממנה נפתחו עד שתעברו אליהן",
+    "description": "Help text for the wait-until-viewed toggle."
+  },
   "settingMinimumTabsForGroup": {
     "message": "מינימום לשוניות ליצירת קבוצה",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -133,6 +133,14 @@
     "message": "सेट अप करें",
     "description": "Button that opens the browser's keyboard shortcut settings page."
   },
+  "settingDeferGrouping": {
+    "message": "नया टैब देखने तक उसे समूहित न करें",
+    "description": "Label for the toggle that waits until a new tab is viewed before grouping it."
+  },
+  "settingDeferGroupingHelp": {
+    "message": "पृष्ठभूमि में खुले टैब्स उसी टैब के पास रहते हैं जहाँ से खुले थे, जब तक आप उन पर नहीं जाते",
+    "description": "Help text for the wait-until-viewed toggle."
+  },
   "settingMinimumTabsForGroup": {
     "message": "समूह बनाने के लिए न्यूनतम टैब्स",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -133,6 +133,14 @@
     "message": "Настроить",
     "description": "Button that opens the browser's keyboard shortcut settings page."
   },
+  "settingDeferGrouping": {
+    "message": "Группировать новую вкладку только после её открытия",
+    "description": "Label for the toggle that waits until a new tab is viewed before grouping it."
+  },
+  "settingDeferGroupingHelp": {
+    "message": "Вкладки, открытые в фоне, остаются рядом с исходной, пока вы на них не перейдёте",
+    "description": "Help text for the wait-until-viewed toggle."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Минимальное число вкладок для создания группы",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -133,6 +133,14 @@
     "message": "设置",
     "description": "Button that opens the browser's keyboard shortcut settings page."
   },
+  "settingDeferGrouping": {
+    "message": "先查看新标签页后再分组",
+    "description": "Label for the toggle that waits until a new tab is viewed before grouping it."
+  },
+  "settingDeferGroupingHelp": {
+    "message": "在后台打开的标签页会留在来源标签页旁边,直到你切换过去",
+    "description": "Help text for the wait-until-viewed toggle."
+  },
   "settingMinimumTabsForGroup": {
     "message": "形成分组所需的最少标签页数",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/services/TabGroupService.ts
+++ b/services/TabGroupService.ts
@@ -34,6 +34,28 @@ class TabGroupServiceSimplified {
   }
 
   /**
+   * Whether this tab was opened in the background and the user hasn't switched
+   * to it yet, with the "wait until I view it" setting on.
+   *
+   * Filing a tab the moment it appears is what makes it seem to vanish: you
+   * middle-click a search result, look away, and it has been moved to a group
+   * elsewhere in the strip before you ever saw it. Waiting until the tab is
+   * activated leaves it next to the tab it came from, where you expect it, and
+   * changes nothing for tabs that open in the foreground — those are active
+   * immediately, so they group exactly as before.
+   *
+   * Only applies to tabs opened from another tab (openerTabId) that this
+   * service saw created, so restored sessions and address-bar tabs are
+   * untouched.
+   */
+  private shouldWaitForFirstView(tab: Browser.tabs.Tab): boolean {
+    if (!tabGroupState.deferGroupingUntilSeen) return false
+    if (tab.active) return false
+    if (!tab.openerTabId) return false
+    return tab.id !== undefined && this.recentlyCreatedTabIds.has(tab.id)
+  }
+
+  /**
    * Checks if a URL is a new tab URL
    */
   isNewTabUrl(url: string): boolean {
@@ -112,6 +134,13 @@ class TabGroupServiceSimplified {
       // below-threshold ungroup — so protection holds everywhere.
       if (await this.isInProtectedGroup(tab)) {
         console.log(`[TabGroupService] Tab ${tabId} is in a protected group, leaving it alone`)
+        return false
+      }
+
+      // Leave a background tab where it was opened until the user looks at it.
+      // forceGrouping bypasses this, so "Group Tabs" still files everything.
+      if (!forceGrouping && this.shouldWaitForFirstView(tab)) {
+        console.log(`[TabGroupService] Tab ${tabId} not viewed yet, leaving it next to its opener`)
         return false
       }
 

--- a/services/TabGroupState.ts
+++ b/services/TabGroupState.ts
@@ -25,6 +25,7 @@ class TabGroupState {
   autoCollapseEnabled: boolean
   autoCollapseDelayMs: number
   openTabNextToCurrent: boolean
+  deferGroupingUntilSeen: boolean
   sortGroupsAlphabetically: boolean
   sortGroupsDirection: SortDirection
   indexGroupTitles: boolean
@@ -43,6 +44,7 @@ class TabGroupState {
     this.autoCollapseEnabled = DEFAULT_STATE.autoCollapseEnabled
     this.autoCollapseDelayMs = DEFAULT_STATE.autoCollapseDelayMs
     this.openTabNextToCurrent = DEFAULT_STATE.openTabNextToCurrent
+    this.deferGroupingUntilSeen = DEFAULT_STATE.deferGroupingUntilSeen
     this.sortGroupsAlphabetically = DEFAULT_STATE.sortGroupsAlphabetically
     this.sortGroupsDirection = DEFAULT_STATE.sortGroupsDirection
     this.indexGroupTitles = DEFAULT_STATE.indexGroupTitles
@@ -64,6 +66,7 @@ class TabGroupState {
     this.autoCollapseEnabled = data.autoCollapseEnabled ?? this.autoCollapseEnabled
     this.autoCollapseDelayMs = data.autoCollapseDelayMs ?? this.autoCollapseDelayMs
     this.openTabNextToCurrent = data.openTabNextToCurrent ?? this.openTabNextToCurrent
+    this.deferGroupingUntilSeen = data.deferGroupingUntilSeen ?? this.deferGroupingUntilSeen
     this.sortGroupsAlphabetically = data.sortGroupsAlphabetically ?? this.sortGroupsAlphabetically
     this.sortGroupsDirection = data.sortGroupsDirection ?? this.sortGroupsDirection
     this.indexGroupTitles = data.indexGroupTitles ?? this.indexGroupTitles
@@ -96,6 +99,7 @@ class TabGroupState {
       autoCollapseEnabled: this.autoCollapseEnabled,
       autoCollapseDelayMs: this.autoCollapseDelayMs,
       openTabNextToCurrent: this.openTabNextToCurrent,
+      deferGroupingUntilSeen: this.deferGroupingUntilSeen,
       sortGroupsAlphabetically: this.sortGroupsAlphabetically,
       sortGroupsDirection: this.sortGroupsDirection,
       indexGroupTitles: this.indexGroupTitles,

--- a/tests/DeferGrouping.test.ts
+++ b/tests/DeferGrouping.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { tabGroupState } from "../services/TabGroupState"
+import { DEFAULT_STATE } from "../types/storage"
+import { mockBrowser } from "./setup"
+
+vi.mock("../utils/storage", () => ({
+  saveAllStorage: vi.fn().mockResolvedValue(undefined),
+  getGroupColor: vi.fn().mockResolvedValue(null),
+  updateGroupColor: vi.fn().mockResolvedValue(undefined),
+  groupColorMapping: { getValue: vi.fn().mockResolvedValue({}) }
+}))
+
+import { tabGroupService } from "../services/TabGroupService"
+
+/**
+ * "Wait until I view a new tab before grouping it".
+ *
+ * Filing a background tab the moment it appears is what makes it seem to
+ * vanish — you middle-click a search result and it is moved elsewhere in the
+ * strip before you ever see it.
+ */
+describe("Deferred grouping until first view", () => {
+  const OPENER_ID = 9
+
+  // The service keeps its new-tab flags in memory for the life of the process,
+  // so each test uses a fresh tab id rather than leaking state into the next
+  let nextTabId = 1
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    tabGroupState.updateFromStorage(DEFAULT_STATE)
+    tabGroupState.autoGroupingEnabled = true
+    tabGroupState.deferGroupingUntilSeen = true
+    mockBrowser.tabGroups.query.mockResolvedValue([])
+    mockBrowser.tabs.group.mockResolvedValue(100)
+    nextTabId += 1
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function tab(overrides: Record<string, unknown> = {}) {
+    return {
+      id: nextTabId,
+      url: "https://example.com",
+      pinned: false,
+      windowId: 1,
+      groupId: -1,
+      active: false,
+      openerTabId: OPENER_ID,
+      ...overrides
+    }
+  }
+
+  function stageTab(overrides: Record<string, unknown> = {}) {
+    const value = tab(overrides)
+    mockBrowser.tabs.get.mockResolvedValue(value)
+    mockBrowser.tabs.query.mockResolvedValue([value])
+    return value
+  }
+
+  it("should leave a freshly opened background tab alone", async () => {
+    tabGroupService.markAsNewTab(nextTabId)
+    stageTab()
+
+    const result = await tabGroupService.handleTabUpdate(nextTabId)
+
+    expect(result).toBe(false)
+    expect(mockBrowser.tabs.group).not.toHaveBeenCalled()
+  })
+
+  it("should group it once it becomes active", async () => {
+    tabGroupService.markAsNewTab(nextTabId)
+    stageTab({ active: true })
+
+    const result = await tabGroupService.handleTabUpdate(nextTabId)
+
+    expect(result).toBe(true)
+    expect(mockBrowser.tabs.group).toHaveBeenCalled()
+  })
+
+  it("should group a foreground tab immediately, as before", async () => {
+    tabGroupService.markAsNewTab(nextTabId)
+    stageTab({ active: true, openerTabId: OPENER_ID })
+
+    expect(await tabGroupService.handleTabUpdate(nextTabId)).toBe(true)
+  })
+
+  it("should still group everything when grouping is forced", async () => {
+    // "Group Tabs" is an explicit request, so nothing is held back
+    tabGroupService.markAsNewTab(nextTabId)
+    stageTab()
+
+    const result = await tabGroupService.handleTabUpdate(nextTabId, true)
+
+    expect(result).toBe(true)
+    expect(mockBrowser.tabs.group).toHaveBeenCalled()
+  })
+
+  it("should not defer a tab that was not opened from another tab", async () => {
+    // Address-bar and restored tabs have no opener and are grouped as usual
+    tabGroupService.markAsNewTab(nextTabId)
+    stageTab({ openerTabId: undefined })
+
+    expect(await tabGroupService.handleTabUpdate(nextTabId)).toBe(true)
+  })
+
+  it("should not defer a tab this service never saw created", async () => {
+    // e.g. a background tab that navigates long after it was opened
+    stageTab()
+
+    expect(await tabGroupService.handleTabUpdate(nextTabId)).toBe(true)
+  })
+
+  it("should change nothing while the setting is off", async () => {
+    tabGroupState.deferGroupingUntilSeen = false
+    tabGroupService.markAsNewTab(nextTabId)
+    stageTab()
+
+    expect(await tabGroupService.handleTabUpdate(nextTabId)).toBe(true)
+    expect(mockBrowser.tabs.group).toHaveBeenCalled()
+  })
+
+  it("should keep deferring across repeated updates until the tab is viewed", async () => {
+    tabGroupService.markAsNewTab(nextTabId)
+    stageTab()
+
+    // onCreated, then onUpdated when the real URL arrives
+    expect(await tabGroupService.handleTabUpdate(nextTabId)).toBe(false)
+    expect(await tabGroupService.handleTabUpdate(nextTabId)).toBe(false)
+
+    stageTab({ active: true })
+    expect(await tabGroupService.handleTabUpdate(nextTabId)).toBe(true)
+  })
+})

--- a/tests/e2e/defer-grouping.e2e.ts
+++ b/tests/e2e/defer-grouping.e2e.ts
@@ -1,0 +1,168 @@
+/**
+ * E2E Tests: Wait Until Viewed Before Grouping
+ *
+ * The scenario from issues #68 / #88: you middle-click a search result, the
+ * extension files the tab into a group elsewhere in the strip, and it seems to
+ * have vanished before you ever looked at it. With the setting on, the tab
+ * stays put until you switch to it.
+ */
+
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
+import {
+  closeTestTabs,
+  createTab,
+  disableAutoGroup,
+  enableAutoGroup,
+  getExtensionId,
+  getTabGroups,
+  groupAllTabs,
+  launchExtensionContext,
+  openPopup,
+  sendMessage,
+  setGroupByMode,
+  setMinimumTabs,
+  TEST_URLS,
+  ungroupAllTabs,
+  waitForGroup
+} from "./helpers/extension-helpers"
+
+let context: BrowserContext
+let extensionId: string
+let popupPage: Page
+
+async function setDefer(page: Page, enabled: boolean): Promise<void> {
+  await sendMessage(page, "toggleDeferGroupingUntilSeen", { enabled })
+}
+
+/**
+ * Opens a background tab from another tab, the way a middle-click does.
+ *
+ * Driven from the popup because only an extension page can call chrome.tabs —
+ * the opener itself is an ordinary web page.
+ */
+async function openBackgroundTabFrom(openerUrlPart: string, url: string): Promise<number> {
+  return await popupPage.evaluate(
+    async ({ part, targetUrl }) => {
+      const tabs = await chrome.tabs.query({})
+      const opener = tabs.find(tab => tab.url?.includes(part))
+      const created = await chrome.tabs.create({
+        url: targetUrl,
+        active: false,
+        openerTabId: opener?.id
+      })
+      return created.id as number
+    },
+    { part: openerUrlPart, targetUrl: url }
+  )
+}
+
+async function groupTitleOf(page: Page, tabId: number): Promise<string | null> {
+  return await page.evaluate(async id => {
+    const tab = await chrome.tabs.get(id)
+    if (!tab.groupId || tab.groupId === -1) return null
+    const group = await chrome.tabGroups.get(tab.groupId)
+    return group.title ?? null
+  }, tabId)
+}
+
+test.beforeAll(async () => {
+  context = await launchExtensionContext()
+  extensionId = await getExtensionId(context)
+})
+
+test.afterAll(async () => {
+  await context.close()
+})
+
+test.beforeEach(async () => {
+  await closeTestTabs(context)
+  popupPage = await openPopup(context, extensionId)
+  await disableAutoGroup(popupPage)
+  await ungroupAllTabs(popupPage)
+  await setMinimumTabs(popupPage, 1)
+  await setGroupByMode(popupPage, "domain")
+  await setDefer(popupPage, false)
+})
+
+test.afterEach(async () => {
+  if (popupPage && !popupPage.isClosed()) {
+    await disableAutoGroup(popupPage)
+    await setDefer(popupPage, false)
+    await ungroupAllTabs(popupPage)
+    await popupPage.close()
+  }
+  await closeTestTabs(context)
+})
+
+test.describe("Wait until viewed before grouping", () => {
+  test("is off by default", async () => {
+    const result = (await sendMessage(popupPage, "getDeferGroupingUntilSeen")) as {
+      enabled: boolean
+    }
+    expect(result.enabled).toBe(false)
+  })
+
+  test("groups a background tab immediately while off", async () => {
+    await createTab(context, TEST_URLS.domain2)
+    await enableAutoGroup(popupPage)
+
+    await openBackgroundTabFrom("httpbin.org", TEST_URLS.domain1)
+
+    await waitForGroup(popupPage, "Example")
+  })
+
+  test("leaves a background tab alone while on", async () => {
+    await createTab(context, TEST_URLS.domain2)
+    await setDefer(popupPage, true)
+    await enableAutoGroup(popupPage)
+
+    const tabId = await openBackgroundTabFrom("httpbin.org", TEST_URLS.domain1)
+    await popupPage.waitForTimeout(1500)
+
+    expect(await groupTitleOf(popupPage, tabId)).toBeNull()
+    const titles = (await getTabGroups(popupPage)).map(group => group.title)
+    expect(titles).not.toContain("Example")
+  })
+
+  test("groups it as soon as you switch to it", async () => {
+    await createTab(context, TEST_URLS.domain2)
+    await setDefer(popupPage, true)
+    await enableAutoGroup(popupPage)
+
+    const tabId = await openBackgroundTabFrom("httpbin.org", TEST_URLS.domain1)
+    await popupPage.waitForTimeout(1000)
+    expect(await groupTitleOf(popupPage, tabId)).toBeNull()
+
+    await popupPage.evaluate(async id => await chrome.tabs.update(id, { active: true }), tabId)
+
+    await waitForGroup(popupPage, "Example")
+    await expect(async () => {
+      expect(await groupTitleOf(popupPage, tabId)).toBe("Example")
+    }).toPass()
+  })
+
+  test("still groups a waiting tab when Group Tabs is clicked", async () => {
+    await createTab(context, TEST_URLS.domain2)
+    await setDefer(popupPage, true)
+    await enableAutoGroup(popupPage)
+
+    const tabId = await openBackgroundTabFrom("httpbin.org", TEST_URLS.domain1)
+    await popupPage.waitForTimeout(1000)
+    expect(await groupTitleOf(popupPage, tabId)).toBeNull()
+
+    await groupAllTabs(popupPage)
+
+    await expect(async () => {
+      expect(await groupTitleOf(popupPage, tabId)).toBe("Example")
+    }).toPass()
+  })
+
+  test("groups a foreground tab straight away even while on", async () => {
+    await setDefer(popupPage, true)
+    await enableAutoGroup(popupPage)
+
+    await createTab(context, TEST_URLS.domain1)
+
+    await waitForGroup(popupPage, "Example")
+  })
+})

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -31,6 +31,8 @@ export type MessageAction =
   | "setMinimumTabsForGroup"
   | "getOpenTabNextToCurrent"
   | "toggleOpenTabNextToCurrent"
+  | "getDeferGroupingUntilSeen"
+  | "toggleDeferGroupingUntilSeen"
   | "getSortGroupsAlphabetically"
   | "toggleSortGroupsAlphabetically"
   | "getSortGroupsDirection"
@@ -82,6 +84,7 @@ export interface SimpleMessage extends BaseMessage {
     | "getGroupByMode"
     | "getMinimumTabsForGroup"
     | "getOpenTabNextToCurrent"
+    | "getDeferGroupingUntilSeen"
     | "getSortGroupsAlphabetically"
     | "getSortGroupsDirection"
     | "getIndexGroupTitles"
@@ -161,6 +164,14 @@ export interface SetMinimumTabsMessage extends BaseMessage {
  */
 export interface ToggleOpenTabNextToCurrentMessage extends BaseMessage {
   action: "toggleOpenTabNextToCurrent"
+  enabled: boolean
+}
+
+/**
+ * Toggle deferring grouping until a tab is first viewed
+ */
+export interface ToggleDeferGroupingMessage extends BaseMessage {
+  action: "toggleDeferGroupingUntilSeen"
   enabled: boolean
 }
 

--- a/types/storage.ts
+++ b/types/storage.ts
@@ -68,6 +68,11 @@ export interface StorageSchema {
   aiModelId: string
   /** Whether to open new tabs next to the current tab (opt-in, default off) */
   openTabNextToCurrent: boolean
+  /**
+   * Whether a tab opened in the background waits until you switch to it before
+   * being grouped, so it stays next to the tab it came from (opt-in, default off)
+   */
+  deferGroupingUntilSeen: boolean
   /** Whether to keep tab groups sorted alphabetically */
   sortGroupsAlphabetically: boolean
   /** Sort direction when alphabetical sorting is enabled ("asc" = A-Z, "desc" = Z-A) */
@@ -104,6 +109,7 @@ export const DEFAULT_STATE: StorageSchema = {
   aiProvider: "webllm",
   aiModelId: "Qwen2.5-3B-Instruct-q4f16_1-MLC",
   openTabNextToCurrent: false,
+  deferGroupingUntilSeen: false,
   sortGroupsAlphabetically: false,
   sortGroupsDirection: "asc",
   indexGroupTitles: false,

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -37,6 +37,10 @@ export const protectedGroupTitles = storage.defineItem<string[]>("local:protecte
   fallback: DEFAULT_STATE.protectedGroupTitles
 })
 
+export const deferGroupingUntilSeen = storage.defineItem<boolean>("local:deferGroupingUntilSeen", {
+  fallback: DEFAULT_STATE.deferGroupingUntilSeen
+})
+
 export const groupByMode = storage.defineItem<GroupByMode>("local:groupByMode", {
   fallback: DEFAULT_STATE.groupByMode
 })
@@ -134,7 +138,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     indexGroupTitlesValue,
     hideContextMenuValue,
     userLocaleValue,
-    protectedGroupTitlesValue
+    protectedGroupTitlesValue,
+    deferGroupingUntilSeenValue
   ] = await Promise.all([
     autoGroupingEnabled.getValue(),
     groupNewTabs.getValue(),
@@ -155,7 +160,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     indexGroupTitles.getValue(),
     hideContextMenu.getValue(),
     userLocale.getValue(),
-    protectedGroupTitles.getValue()
+    protectedGroupTitles.getValue(),
+    deferGroupingUntilSeen.getValue()
   ])
 
   return {
@@ -178,7 +184,8 @@ export async function loadAllStorage(): Promise<StorageSchema> {
     indexGroupTitles: indexGroupTitlesValue,
     hideContextMenu: hideContextMenuValue,
     userLocale: userLocaleValue,
-    protectedGroupTitles: protectedGroupTitlesValue
+    protectedGroupTitles: protectedGroupTitlesValue,
+    deferGroupingUntilSeen: deferGroupingUntilSeenValue
   }
 }
 
@@ -247,6 +254,9 @@ export async function saveAllStorage(data: Partial<StorageSchema>): Promise<void
   }
   if (data.protectedGroupTitles !== undefined) {
     promises.push(protectedGroupTitles.setValue(data.protectedGroupTitles))
+  }
+  if (data.deferGroupingUntilSeen !== undefined) {
+    promises.push(deferGroupingUntilSeen.setValue(data.deferGroupingUntilSeen))
   }
   await Promise.all(promises)
 }


### PR DESCRIPTION
Addresses #68 and #88.

## The problem underneath both issues

@robertmaxton42 opened #68 asking to move tabs between windows, then #88 proposing that a tab be grouped together with whatever opened it. Reading their follow-up, both are routes around one underlying complaint:

> I open a Wikipedia page in a new tab while clicking through relevant-looking search results, [and] it teleports away under you to wherever your main Wikipedia group is.

Filing a tab the instant it appears is what makes it seem to vanish. The window and the opener-based grouping were both ways of getting the tab somewhere findable.

## What this does instead

When the setting is on, a tab opened **in the background from another tab** stays next to the tab it came from. It gets grouped when you switch to it.

Deliberately narrow, so it changes almost nothing else:

- **Foreground tabs are unaffected** — they're active immediately, so they group exactly as before.
- **Tabs with no opener are unaffected** — address bar, bookmarks, restored sessions.
- **"Group Tabs" still files everything**, including tabs not yet viewed.
- **The grouping decision is unchanged** — still a pure function of the URL. Only its *timing* moves, so nothing about service-worker restarts or regrouping is affected.

Off by default, as with the other behaviour-changing settings.

## Why not build what the issues literally asked for

Both would have imported path-dependence into a stateless design:

- **#88 (group a tab with its opener)** makes a tab's group depend on how you got there, so two identical Google tabs could belong to different groups — and after a service-worker restart there's no way to recompute it, since the child tab that justified it may be closed. It also has no answer when one search opens tabs for two different categories, and it *moves the tab you're actively reading*, which is the original complaint aimed at a different tab.
- **#68 (move between windows)** means moving a tab you may be typing in, plus reworking group lookup, minimum-tab counting and sorting, all of which are per-window today.

Worth noting for the reply: the existing "Open new tabs next to current tab" setting does **not** help their case — [TabGroupService.ts:971](services/TabGroupService.ts:971) bails unless the opener is already in the same group, and their opener is a Google tab.

## Test plan

- [x] `bunx vitest run` — 870 pass, including 8 new tests covering each condition that gates the deferral and each one that bypasses it
- [x] `bunx playwright test --fail-on-flaky-tests` — 78 pass (was 72), no retries, including the reporter's scenario end to end: a background tab opened from another tab stays ungrouped, then groups the moment it is activated
- [x] `bun run code:check` clean
- [x] Chrome + Firefox packages build at 3.12.0

One thing the tests surfaced: the service keeps its new-tab flags in memory for the life of the process, so the unit tests use a fresh tab id each rather than leaking state between cases.

Version 3.12.0, changelog and `docs/FEATURES.md` updated, 2 new keys across all 8 locales.

I'd hold the reply to #68/#88 until this is merged, then answer both threads together with what actually shipped.