### PR TITLE
feat: move a tab to the window where its group lives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ for those.
 
 ## [Unreleased]
 
+## [3.13.0]
+
+### Added
+
+- "Move tab to its group's window", from the right-click menu or an (unassigned)
+  keyboard shortcut. Sends a tab to the window where its group already lives,
+  for people who keep windows roughly by topic. Grouping still never moves tabs
+  between windows on its own ([#90], closes [#68]).
+
 ## [3.12.0]
 
 ### Added
@@ -120,7 +129,8 @@ for those.
 - Tab groups for internationalized domains showed punycode — `Xn--mnchen-3ya`
   instead of `München` ([#75], closes [#74]).
 
-[unreleased]: https://github.com/nitzanpap/auto-tab-groups/compare/v3.12.0...HEAD
+[unreleased]: https://github.com/nitzanpap/auto-tab-groups/compare/v3.13.0...HEAD
+[3.13.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.13.0
 [3.12.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.12.0
 [3.11.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.11.0
 [3.10.0]: https://github.com/nitzanpap/auto-tab-groups/releases/tag/v3.10.0
@@ -152,3 +162,4 @@ for those.
 [#86]: https://github.com/nitzanpap/auto-tab-groups/pull/86
 [#87]: https://github.com/nitzanpap/auto-tab-groups/pull/87
 [#89]: https://github.com/nitzanpap/auto-tab-groups/pull/89
+[#90]: https://github.com/nitzanpap/auto-tab-groups/pull/90

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -46,6 +46,20 @@ Titles are matched with any sort-index prefix stripped, so the "Number groups"
 setting doesn't break exclusions. Renaming an excluded group ends its
 exclusion — title is identity here, as everywhere else in the extension.
 
+## Moving a Tab to Its Group's Window
+
+Right-click a tab and choose "Move tab to its group's window" to send it to the
+window where that group already lives. There's a keyboard command for it too,
+unassigned like the others.
+
+Nothing happens automatically — grouping never moves tabs between windows on its
+own. This is for when you keep windows roughly by topic and a tab lands in the
+wrong one.
+
+If several windows hold a group of that name, the largest one wins, which is
+usually the main window for that topic. If no other window has it, nothing
+happens.
+
 ## Waiting Until a Tab Is Viewed
 
 Off by default. When on, a tab opened **in the background from another tab**

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -326,6 +326,10 @@ export default defineBackground(() => {
             result = { enabled: tabGroupState.deferGroupingUntilSeen }
             break
 
+          case "moveTabToGroupWindow":
+            result = await tabGroupService.moveTabToItsGroupWindow(msg.tabId)
+            break
+
           case "getProtectedGroups":
             result = { titles: tabGroupState.protectedGroupTitles }
             break

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-tab-groups",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "type": "module",
   "description": "Cross-browser extension that automatically groups tabs by domain",
   "author": "Nitzan Papini",

--- a/public/_locales/ar/messages.json
+++ b/public/_locales/ar/messages.json
@@ -141,6 +141,14 @@
     "message": "علامات التبويب التي تُفتح في الخلفية تبقى بجوار علامة التبويب التي فُتحت منها حتى تنتقل إليها",
     "description": "Help text for the wait-until-viewed toggle."
   },
+  "contextMenuMoveToGroupWindow": {
+    "message": "نقل علامة التبويب إلى نافذة مجموعتها",
+    "description": "Right-click menu: send this tab to the window where its group already is."
+  },
+  "commandMoveToGroupWindow": {
+    "message": "نقل علامة التبويب إلى نافذة مجموعتها",
+    "description": "Keyboard command description: send the current tab to its group's window."
+  },
   "settingMinimumTabsForGroup": {
     "message": "الحد الأدنى لعلامات التبويب لتكوين مجموعة",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -141,6 +141,14 @@
     "message": "Im Hintergrund geöffnete Tabs bleiben neben dem Ursprungstab, bis du zu ihnen wechselst",
     "description": "Help text for the wait-until-viewed toggle."
   },
+  "contextMenuMoveToGroupWindow": {
+    "message": "Tab in das Fenster seiner Gruppe verschieben",
+    "description": "Right-click menu: send this tab to the window where its group already is."
+  },
+  "commandMoveToGroupWindow": {
+    "message": "Tab in das Fenster seiner Gruppe verschieben",
+    "description": "Keyboard command description: send the current tab to its group's window."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Mindestanzahl an Tabs für eine Gruppe",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -141,6 +141,14 @@
     "message": "Tabs opened in the background stay next to the tab they came from until you switch to them",
     "description": "Help text for the wait-until-viewed toggle."
   },
+  "contextMenuMoveToGroupWindow": {
+    "message": "Move tab to its group's window",
+    "description": "Right-click menu: send this tab to the window where its group already is."
+  },
+  "commandMoveToGroupWindow": {
+    "message": "Move tab to its group's window",
+    "description": "Keyboard command description: send the current tab to its group's window."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Minimum tabs to form a group",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -141,6 +141,14 @@
     "message": "Las pestañas abiertas en segundo plano permanecen junto a la pestaña de origen hasta que cambies a ellas",
     "description": "Help text for the wait-until-viewed toggle."
   },
+  "contextMenuMoveToGroupWindow": {
+    "message": "Mover la pestaña a la ventana de su grupo",
+    "description": "Right-click menu: send this tab to the window where its group already is."
+  },
+  "commandMoveToGroupWindow": {
+    "message": "Mover la pestaña a la ventana de su grupo",
+    "description": "Keyboard command description: send the current tab to its group's window."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Mínimo de pestañas para formar un grupo",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/he/messages.json
+++ b/public/_locales/he/messages.json
@@ -141,6 +141,14 @@
     "message": "לשוניות שנפתחות ברקע נשארות ליד הלשונית שממנה נפתחו עד שתעברו אליהן",
     "description": "Help text for the wait-until-viewed toggle."
   },
+  "contextMenuMoveToGroupWindow": {
+    "message": "העבר את הלשונית לחלון של הקבוצה שלה",
+    "description": "Right-click menu: send this tab to the window where its group already is."
+  },
+  "commandMoveToGroupWindow": {
+    "message": "העבר את הלשונית לחלון של הקבוצה שלה",
+    "description": "Keyboard command description: send the current tab to its group's window."
+  },
   "settingMinimumTabsForGroup": {
     "message": "מינימום לשוניות ליצירת קבוצה",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -141,6 +141,14 @@
     "message": "पृष्ठभूमि में खुले टैब्स उसी टैब के पास रहते हैं जहाँ से खुले थे, जब तक आप उन पर नहीं जाते",
     "description": "Help text for the wait-until-viewed toggle."
   },
+  "contextMenuMoveToGroupWindow": {
+    "message": "टैब को उसके समूह की विंडो में ले जाएँ",
+    "description": "Right-click menu: send this tab to the window where its group already is."
+  },
+  "commandMoveToGroupWindow": {
+    "message": "टैब को उसके समूह की विंडो में ले जाएँ",
+    "description": "Keyboard command description: send the current tab to its group's window."
+  },
   "settingMinimumTabsForGroup": {
     "message": "समूह बनाने के लिए न्यूनतम टैब्स",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -141,6 +141,14 @@
     "message": "Вкладки, открытые в фоне, остаются рядом с исходной, пока вы на них не перейдёте",
     "description": "Help text for the wait-until-viewed toggle."
   },
+  "contextMenuMoveToGroupWindow": {
+    "message": "Переместить вкладку в окно её группы",
+    "description": "Right-click menu: send this tab to the window where its group already is."
+  },
+  "commandMoveToGroupWindow": {
+    "message": "Переместить вкладку в окно её группы",
+    "description": "Keyboard command description: send the current tab to its group's window."
+  },
   "settingMinimumTabsForGroup": {
     "message": "Минимальное число вкладок для создания группы",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/public/_locales/zh/messages.json
+++ b/public/_locales/zh/messages.json
@@ -141,6 +141,14 @@
     "message": "在后台打开的标签页会留在来源标签页旁边,直到你切换过去",
     "description": "Help text for the wait-until-viewed toggle."
   },
+  "contextMenuMoveToGroupWindow": {
+    "message": "将标签页移到其分组所在的窗口",
+    "description": "Right-click menu: send this tab to the window where its group already is."
+  },
+  "commandMoveToGroupWindow": {
+    "message": "将标签页移到其分组所在的窗口",
+    "description": "Keyboard command description: send the current tab to its group's window."
+  },
   "settingMinimumTabsForGroup": {
     "message": "形成分组所需的最少标签页数",
     "description": "Label for the numeric input that sets the minimum tab count required to create a group."

--- a/services/CommandService.ts
+++ b/services/CommandService.ts
@@ -16,7 +16,8 @@ export const COMMANDS = {
   TOGGLE_AUTO_GROUPING: "toggle-auto-grouping",
   GROUP_ALL_TABS: "group-all-tabs",
   UNGROUP_ALL_TABS: "ungroup-all-tabs",
-  TOGGLE_COLLAPSE: "toggle-collapse"
+  TOGGLE_COLLAPSE: "toggle-collapse",
+  MOVE_TO_GROUP_WINDOW: "move-tab-to-group-window"
 } as const
 
 export type CommandId = (typeof COMMANDS)[keyof typeof COMMANDS]
@@ -54,6 +55,14 @@ export async function handleCommand(command: string): Promise<boolean> {
     case COMMANDS.TOGGLE_COLLAPSE:
       await tabGroupService.toggleAllGroupsCollapse()
       return true
+
+    case COMMANDS.MOVE_TO_GROUP_WINDOW: {
+      const [active] = await browser.tabs.query({ active: true, currentWindow: true })
+      if (active?.id) {
+        await tabGroupService.moveTabToItsGroupWindow(active.id)
+      }
+      return true
+    }
 
     default:
       // _execute_action and anything the browser adds later are handled by the

--- a/services/ContextMenuService.ts
+++ b/services/ContextMenuService.ts
@@ -51,6 +51,7 @@ class ContextMenuService {
   private readonly MENU_ID_ADD_TO_RULE_PARENT = "add-tab-to-rule"
   private readonly MENU_ID_ADD_TO_BLACKLIST = "add-to-blacklist"
   private readonly MENU_ID_PROTECT_GROUP = "protect-group"
+  private readonly MENU_ID_MOVE_TO_GROUP_WINDOW = "move-to-group-window"
   private readonly MENU_ID_NO_RULES = "add-to-rule-none"
   private initialized = false
   private menusCreated = false
@@ -123,6 +124,12 @@ class ContextMenuService {
     await browser.contextMenus.create({
       id: this.MENU_ID_PROTECT_GROUP,
       title: t("contextMenuProtectGroup", "Exclude group from auto-grouping"),
+      contexts
+    })
+
+    await browser.contextMenus.create({
+      id: this.MENU_ID_MOVE_TO_GROUP_WINDOW,
+      title: t("contextMenuMoveToGroupWindow", "Move tab to its group's window"),
       contexts
     })
 
@@ -249,6 +256,11 @@ class ContextMenuService {
 
     if (menuId === this.MENU_ID_ADD_TO_BLACKLIST) {
       await this.handleAddToBlacklist(tab)
+      return
+    }
+
+    if (menuId === this.MENU_ID_MOVE_TO_GROUP_WINDOW) {
+      if (tab?.id) await tabGroupService.moveTabToItsGroupWindow(tab.id)
       return
     }
 

--- a/services/TabGroupService.ts
+++ b/services/TabGroupService.ts
@@ -180,18 +180,13 @@ class TabGroupServiceSimplified {
       }
 
       // Domain/subdomain mode
-      const includeSubDomain = tabGroupState.groupByMode === "subdomain"
-      const domain = extractDomain(tab.url || "", includeSubDomain)
-      if (!domain) {
+      const expectedTitle = await this.getExpectedGroupTitle(tab)
+      if (!expectedTitle) {
         console.log(`[TabGroupService] No domain extracted, skipping`)
         return false
       }
 
-      // Check for custom rules first
       const customRule = await rulesService.findMatchingRule(tab.url || "")
-      const expectedTitle = customRule
-        ? customRule.effectiveGroupName || customRule.name
-        : getDomainDisplayName(domain)
 
       console.log(`[TabGroupService] Expected group title: "${expectedTitle}"`)
 
@@ -240,6 +235,87 @@ class TabGroupServiceSimplified {
 
     const groups = await browser.tabGroups.query({ windowId: browser.windows.WINDOW_ID_CURRENT })
     return new Set(groups.filter(g => this.isProtectedTitle(g.title)).map(g => g.id))
+  }
+
+  /**
+   * The group title this tab would be filed under, or null if it wouldn't be.
+   *
+   * Shared with the "move to its group's window" command so a manual move and
+   * automatic grouping can never disagree about where a tab belongs.
+   */
+  async getExpectedGroupTitle(tab: Browser.tabs.Tab): Promise<string | null> {
+    const url = tab.url || ""
+
+    if (tabGroupState.groupByMode === "rules-only") {
+      const customRule = await rulesService.findMatchingRule(url)
+
+      if (!customRule && extractDomain(url, false) === "system") {
+        return tabGroupState.systemGroupEnabled ? "System" : null
+      }
+
+      const effectiveRule = customRule ?? (await rulesService.findCatchAllRule(url))
+      if (!effectiveRule) return null
+
+      return effectiveRule.effectiveGroupName || effectiveRule.name
+    }
+
+    const domain = extractDomain(url, tabGroupState.groupByMode === "subdomain")
+    if (!domain) return null
+
+    const customRule = await rulesService.findMatchingRule(url)
+    return customRule
+      ? customRule.effectiveGroupName || customRule.name
+      : getDomainDisplayName(domain)
+  }
+
+  /**
+   * Sends a tab to the window where its group already lives.
+   *
+   * Requested in #68: when you keep windows roughly by topic, a tab opened in
+   * the wrong one is easier to deal with by sending it home than by hunting for
+   * it later. Nothing automatic — the user asks for this per tab.
+   *
+   * When several windows hold a group of that name, the largest wins, which is
+   * almost always the "main" one for that topic.
+   */
+  async moveTabToItsGroupWindow(
+    tabId: number
+  ): Promise<{ moved: boolean; reason?: "pinned" | "no-title" | "no-group" }> {
+    try {
+      if (!browser.tabGroups) return { moved: false, reason: "no-group" }
+
+      const tab = await browser.tabs.get(tabId)
+      if (tab.pinned) return { moved: false, reason: "pinned" }
+
+      const title = await this.getExpectedGroupTitle(tab)
+      if (!title) return { moved: false, reason: "no-title" }
+
+      const groups = await browser.tabGroups.query({})
+      const candidates = groups.filter(
+        group => group.windowId !== tab.windowId && stripIndexPrefix(group.title || "") === title
+      )
+      if (candidates.length === 0) return { moved: false, reason: "no-group" }
+
+      const withCounts = await Promise.all(
+        candidates.map(async group => ({
+          group,
+          count: (await browser.tabs.query({ groupId: group.id })).length
+        }))
+      )
+      withCounts.sort((a, b) => b.count - a.count || a.group.id - b.group.id)
+      const target = withCounts[0].group
+
+      await withTabEditRetry(() =>
+        browser.tabs.move(tabId, { windowId: target.windowId, index: -1 })
+      )
+      await withTabEditRetry(() => browser.tabs.group({ tabIds: [tabId], groupId: target.id }))
+
+      console.log(`[TabGroupService] Moved tab ${tabId} to "${title}" in window ${target.windowId}`)
+      return { moved: true }
+    } catch (error) {
+      console.error(`[TabGroupService] Error moving tab ${tabId} to its group's window:`, error)
+      return { moved: false, reason: "no-group" }
+    }
   }
 
   /**

--- a/tests/MoveToGroupWindow.test.ts
+++ b/tests/MoveToGroupWindow.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { tabGroupState } from "../services/TabGroupState"
+import { DEFAULT_STATE } from "../types/storage"
+import { mockBrowser } from "./setup"
+
+vi.mock("../utils/storage", () => ({
+  saveAllStorage: vi.fn().mockResolvedValue(undefined),
+  getGroupColor: vi.fn().mockResolvedValue(null),
+  updateGroupColor: vi.fn().mockResolvedValue(undefined),
+  groupColorMapping: { getValue: vi.fn().mockResolvedValue({}) }
+}))
+
+import { tabGroupService } from "../services/TabGroupService"
+
+/**
+ * "Move tab to its group's window" — the manual counterpart to automatic
+ * grouping, for people who keep windows roughly by topic.
+ */
+describe("moveTabToItsGroupWindow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    tabGroupState.updateFromStorage(DEFAULT_STATE)
+    mockBrowser.tabs.get.mockResolvedValue({
+      id: 1,
+      url: "https://example.com",
+      pinned: false,
+      windowId: 1,
+      groupId: -1
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  function groupsInOtherWindows(...groups: { id: number; title: string; windowId: number }[]) {
+    mockBrowser.tabGroups.query.mockResolvedValue(groups)
+  }
+
+  it("should move the tab into the matching group in another window", async () => {
+    groupsInOtherWindows({ id: 50, title: "Example", windowId: 2 })
+    mockBrowser.tabs.query.mockResolvedValue([{ id: 7 }])
+
+    const result = await tabGroupService.moveTabToItsGroupWindow(1)
+
+    expect(result.moved).toBe(true)
+    expect(mockBrowser.tabs.move).toHaveBeenCalledWith(1, { windowId: 2, index: -1 })
+    expect(mockBrowser.tabs.group).toHaveBeenCalledWith({ tabIds: [1], groupId: 50 })
+  })
+
+  it("should prefer the largest group when several windows have one", async () => {
+    // The biggest is almost always the "main" window for that topic
+    groupsInOtherWindows(
+      { id: 50, title: "Example", windowId: 2 },
+      { id: 51, title: "Example", windowId: 3 }
+    )
+    mockBrowser.tabs.query.mockImplementation(({ groupId }: { groupId: number }) =>
+      Promise.resolve(groupId === 51 ? [{ id: 7 }, { id: 8 }, { id: 9 }] : [{ id: 7 }])
+    )
+
+    await tabGroupService.moveTabToItsGroupWindow(1)
+
+    expect(mockBrowser.tabs.move).toHaveBeenCalledWith(1, { windowId: 3, index: -1 })
+  })
+
+  it("should ignore a matching group in the tab's own window", async () => {
+    groupsInOtherWindows({ id: 50, title: "Example", windowId: 1 })
+
+    const result = await tabGroupService.moveTabToItsGroupWindow(1)
+
+    expect(result).toEqual({ moved: false, reason: "no-group" })
+    expect(mockBrowser.tabs.move).not.toHaveBeenCalled()
+  })
+
+  it("should match a group carrying a sort-index prefix", async () => {
+    groupsInOtherWindows({ id: 50, title: "3. Example", windowId: 2 })
+    mockBrowser.tabs.query.mockResolvedValue([{ id: 7 }])
+
+    expect((await tabGroupService.moveTabToItsGroupWindow(1)).moved).toBe(true)
+  })
+
+  it("should do nothing when no other window has that group", async () => {
+    groupsInOtherWindows({ id: 50, title: "Something Else", windowId: 2 })
+
+    const result = await tabGroupService.moveTabToItsGroupWindow(1)
+
+    expect(result).toEqual({ moved: false, reason: "no-group" })
+    expect(mockBrowser.tabs.move).not.toHaveBeenCalled()
+  })
+
+  it("should leave pinned tabs alone", async () => {
+    mockBrowser.tabs.get.mockResolvedValue({
+      id: 1,
+      url: "https://example.com",
+      pinned: true,
+      windowId: 1
+    })
+    groupsInOtherWindows({ id: 50, title: "Example", windowId: 2 })
+
+    const result = await tabGroupService.moveTabToItsGroupWindow(1)
+
+    expect(result).toEqual({ moved: false, reason: "pinned" })
+    expect(mockBrowser.tabs.move).not.toHaveBeenCalled()
+  })
+
+  it("should use the rule's group name rather than the domain", async () => {
+    tabGroupState.updateFromStorage({
+      ...DEFAULT_STATE,
+      customRules: {
+        "rule-1": {
+          id: "rule-1",
+          name: "Reading",
+          domains: ["example.com"],
+          color: "blue",
+          enabled: true,
+          priority: 1,
+          createdAt: "2026-01-01T00:00:00.000Z"
+        }
+      }
+    })
+    groupsInOtherWindows(
+      { id: 50, title: "Example", windowId: 2 },
+      { id: 51, title: "Reading", windowId: 3 }
+    )
+    mockBrowser.tabs.query.mockResolvedValue([{ id: 7 }])
+
+    await tabGroupService.moveTabToItsGroupWindow(1)
+
+    expect(mockBrowser.tabs.move).toHaveBeenCalledWith(1, { windowId: 3, index: -1 })
+  })
+
+  it("should do nothing for a tab that has no group title at all", async () => {
+    tabGroupState.groupByMode = "rules-only"
+    mockBrowser.tabs.get.mockResolvedValue({
+      id: 1,
+      url: "https://unmatched.com",
+      pinned: false,
+      windowId: 1
+    })
+    groupsInOtherWindows({ id: 50, title: "Example", windowId: 2 })
+
+    const result = await tabGroupService.moveTabToItsGroupWindow(1)
+
+    expect(result).toEqual({ moved: false, reason: "no-title" })
+  })
+})

--- a/tests/e2e/move-to-group-window.e2e.ts
+++ b/tests/e2e/move-to-group-window.e2e.ts
@@ -1,0 +1,147 @@
+/**
+ * E2E Tests: Move Tab To Its Group's Window
+ *
+ * From #68: when you keep windows roughly by topic, a tab that lands in the
+ * wrong one is easier to deal with by sending it home than by hunting for it.
+ * Uses two real browser windows.
+ */
+
+import { type BrowserContext, expect, type Page, test } from "@playwright/test"
+import {
+  closeTestTabs,
+  createTab,
+  disableAutoGroup,
+  enableAutoGroup,
+  getExtensionId,
+  launchExtensionContext,
+  openPopup,
+  sendMessage,
+  setGroupByMode,
+  setMinimumTabs,
+  TEST_URLS,
+  ungroupAllTabs,
+  waitForGroup
+} from "./helpers/extension-helpers"
+
+let context: BrowserContext
+let extensionId: string
+let popupPage: Page
+
+/** Opens a second window holding a group with the given title */
+async function makeGroupInNewWindow(title: string, url: string): Promise<number> {
+  return await popupPage.evaluate(
+    async ({ groupTitle, tabUrl }) => {
+      const win = await chrome.windows.create({ url: tabUrl, focused: false })
+      const tabId = win.tabs?.[0]?.id as number
+      // Without createProperties, tabs.group makes the group in the *caller's*
+      // window and drags the tab back out of the new one
+      const groupId = await chrome.tabs.group({
+        tabIds: [tabId],
+        createProperties: { windowId: win.id }
+      })
+      await chrome.tabGroups.update(groupId, { title: groupTitle, color: "purple" })
+      return win.id as number
+    },
+    { groupTitle: title, tabUrl: url }
+  )
+}
+
+async function tabState(tabId: number) {
+  return await popupPage.evaluate(async id => {
+    const tab = await chrome.tabs.get(id)
+    const group = tab.groupId && tab.groupId !== -1 ? await chrome.tabGroups.get(tab.groupId) : null
+    return { windowId: tab.windowId, groupTitle: group?.title ?? null }
+  }, tabId)
+}
+
+async function tabIdFor(urlPart: string): Promise<number> {
+  return await popupPage.evaluate(async part => {
+    const tabs = await chrome.tabs.query({})
+    return tabs.find(tab => tab.url?.includes(part))?.id as number
+  }, urlPart)
+}
+
+async function closeExtraWindows(): Promise<void> {
+  await popupPage.evaluate(async () => {
+    const current = await chrome.windows.getCurrent()
+    for (const win of await chrome.windows.getAll()) {
+      if (win.id && win.id !== current.id) await chrome.windows.remove(win.id)
+    }
+  })
+}
+
+test.beforeAll(async () => {
+  context = await launchExtensionContext()
+  extensionId = await getExtensionId(context)
+})
+
+test.afterAll(async () => {
+  await context.close()
+})
+
+test.beforeEach(async () => {
+  await closeTestTabs(context)
+  popupPage = await openPopup(context, extensionId)
+  await disableAutoGroup(popupPage)
+  await ungroupAllTabs(popupPage)
+  await setMinimumTabs(popupPage, 1)
+  await setGroupByMode(popupPage, "domain")
+})
+
+test.afterEach(async () => {
+  if (popupPage && !popupPage.isClosed()) {
+    await closeExtraWindows()
+    await disableAutoGroup(popupPage)
+    await ungroupAllTabs(popupPage)
+    await popupPage.close()
+  }
+  await closeTestTabs(context)
+})
+
+test.describe("Move tab to its group's window", () => {
+  test("sends the tab to the window holding its group", async () => {
+    const otherWindowId = await makeGroupInNewWindow("Example", TEST_URLS.domain1)
+
+    await createTab(context, TEST_URLS.domain1Page2)
+    const tabId = await tabIdFor("example.com/page2")
+    const before = await tabState(tabId)
+    expect(before.windowId).not.toBe(otherWindowId)
+
+    await sendMessage(popupPage, "moveTabToGroupWindow", { tabId })
+
+    await expect(async () => {
+      const after = await tabState(tabId)
+      expect(after.windowId).toBe(otherWindowId)
+      expect(after.groupTitle).toBe("Example")
+    }).toPass()
+  })
+
+  test("does nothing when no other window has that group", async () => {
+    await createTab(context, TEST_URLS.domain1)
+    const tabId = await tabIdFor("example.com")
+    const before = await tabState(tabId)
+
+    const result = (await sendMessage(popupPage, "moveTabToGroupWindow", { tabId })) as {
+      moved: boolean
+    }
+
+    expect(result.moved).toBe(false)
+    expect((await tabState(tabId)).windowId).toBe(before.windowId)
+  })
+
+  test("works for a tab already grouped in its own window", async () => {
+    const otherWindowId = await makeGroupInNewWindow("Example", TEST_URLS.domain1)
+
+    await createTab(context, TEST_URLS.domain1Page2)
+    await enableAutoGroup(popupPage)
+    await waitForGroup(popupPage, "Example")
+    await disableAutoGroup(popupPage)
+
+    const tabId = await tabIdFor("example.com/page2")
+    await sendMessage(popupPage, "moveTabToGroupWindow", { tabId })
+
+    await expect(async () => {
+      expect((await tabState(tabId)).windowId).toBe(otherWindowId)
+    }).toPass()
+  })
+})

--- a/types/messages.ts
+++ b/types/messages.ts
@@ -43,6 +43,7 @@ export type MessageAction =
   | "toggleHideContextMenu"
   | "getUserLocale"
   | "setUserLocale"
+  | "moveTabToGroupWindow"
   | "getProtectedGroups"
   | "addProtectedGroup"
   | "removeProtectedGroup"
@@ -125,6 +126,14 @@ export interface ToggleGroupNewTabsMessage extends BaseMessage {
 export interface ToggleSystemGroupMessage extends BaseMessage {
   action: "toggleSystemGroup"
   enabled: boolean
+}
+
+/**
+ * Send a tab to the window where its group already lives
+ */
+export interface MoveTabToGroupWindowMessage extends BaseMessage {
+  action: "moveTabToGroupWindow"
+  tabId: number
 }
 
 /**

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -58,6 +58,9 @@ export default defineConfig({
         },
         "toggle-collapse": {
           description: "__MSG_commandToggleCollapse__"
+        },
+        "move-tab-to-group-window": {
+          description: "__MSG_commandMoveToGroupWindow__"
         }
       },
       icons: {


### PR DESCRIPTION
Closes #68

@robertmaxton42 confirmed the manual version is still wanted even with the waiting setting from #89:

> Much easier to manage a selection of windows organized roughly by topic [...] than one where 'long tail' one-offs that I really can just close are mixed in evenly with large projects.

## What it does

Right-click a tab → **"Move tab to its group's window"**, or bind the keyboard command (unassigned by default, like the rest). The tab is sent to the window that already holds its group and joins it.

- **Nothing automatic.** Grouping still never moves tabs between windows on its own — that was the part worth refusing: a tab you might be typing in vanishing to another window, plus group lookup, minimum group size and sorting all being per-window today.
- **When several windows hold a group of that name, the largest wins**, which is almost always the main window for that topic — matching how they described their setup.
- Pinned tabs are skipped; if no other window has the group, nothing happens.

## One refactor worth flagging

The "which group does this tab belong to" logic was inline in the auto-grouping path. It's now a shared `getExpectedGroupTitle()` used by both that and the manual move, so the two can't drift apart about where a tab belongs. Existing behaviour is unchanged — the full suite covers it.

## Test plan

- [x] `bunx vitest run` — 878 pass, including 8 new tests: the move itself, preferring the largest group, ignoring a match in the tab's own window, index-prefixed titles, pinned tabs, rule names beating domain names, and the no-match cases
- [x] `bunx playwright test --fail-on-flaky-tests` — 81 pass (was 78), no retries, including three across **two real browser windows**
- [x] `bun run code:check` clean
- [x] Chrome + Firefox packages build at 3.13.0

Worth recording from writing those E2E tests: `chrome.tabs.group({tabIds})` without `createProperties` creates the group in the *caller's* window and drags the tab out of the one you just made it in. That cost me a debugging round, and it's a trap for anyone writing multi-window tests later.

Version 3.13.0, changelog and `docs/FEATURES.md` updated, 2 new keys across all 8 locales.